### PR TITLE
[FEATURE makeTextaDiv] Make web Text primitive a div

### DIFF
--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -2,7 +2,15 @@ import React, { SFC } from "react"
 import styledWrapper from "styled-components"
 import { TextProps, TypographyProps } from "../palette"
 import { styled } from "../platform/primitives"
-import { color, maxWidth, space, textAlign, themeGet } from "styled-system"
+
+import {
+  color,
+  display,
+  maxWidth,
+  space,
+  textAlign,
+  themeGet,
+} from "styled-system"
 
 const dynamicTheme = callback => props =>
   themeGet.apply(null, [].concat(callback(props)))(props)
@@ -29,9 +37,10 @@ const Text = styled.Text.attrs<TextProps>({})`
   font-size: ${dynamicTheme(fontSize)}px;
   line-height: ${dynamicTheme(lineHeight)}px;
   ${color};
+  ${display};
+  ${maxWidth};
   ${space};
   ${textAlign};
-  ${maxWidth};
 `
 
 const _Sans: SFC<TypographyProps> = props => (

--- a/src/platform/primitives.ts
+++ b/src/platform/primitives.ts
@@ -1,6 +1,6 @@
 import styles from "styled-components"
 
 export const styled = {
-  Text: styles.span,
+  Text: styles.div,
   View: styles.div,
 }


### PR DESCRIPTION
Makes it so we can support an array of nested content (like from CMS) inside of our text declarations:

```javascript
<Sans>
  <p>...</p>
</Sans>
```

If such were a `span`, it would throw an HTML error. 