### PR TITLE
Support vertical-align on text components

### DIFF
--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -1,5 +1,6 @@
 import React, { SFC } from "react"
 import styledWrapper from "styled-components"
+import { style } from "styled-system"
 import { TextProps, TypographyProps } from "../palette"
 import { styled } from "../platform/primitives"
 
@@ -11,6 +12,10 @@ import {
   textAlign,
   themeGet,
 } from "styled-system"
+
+const verticalAlign = style({
+  prop: "verticalAlign",
+})
 
 const dynamicTheme = callback => props =>
   themeGet.apply(null, [].concat(callback(props)))(props)
@@ -41,6 +46,7 @@ const Text = styled.Text.attrs<TextProps>({})`
   ${maxWidth};
   ${space};
   ${textAlign};
+  ${verticalAlign};
 `
 
 const _Sans: SFC<TypographyProps> = props => (

--- a/src/palette.d.ts
+++ b/src/palette.d.ts
@@ -1,4 +1,8 @@
-export interface TextProps {
+export interface VerticalAlignProps {
+  verticalAlign?: "baseline" | "text-top" | "text-bottom" | "sub" | "super"
+}
+
+export interface TextProps extends VerticalAlignProps {
   family: "unica" | "garamond" | "avantgarde"
   typeSize: string // TODO: Make this more granular
 }


### PR DESCRIPTION
This supports using the `verticalAlign` prop on `Sans`, `Serif`, and `Display` components. 

`verticalAlign` isn't supported by styled-system out of the box, so this is another one of those special cases where I had to create it... not sure about where the types go. We might want to create a package kinda dedicated to these special things... or make PRs for them to styled system. 