### PR TITLE
Update grid gutter to match designs

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -70,7 +70,7 @@ export const themeProps = {
       padding: 15,
     },
     col: {
-      padding: 15,
+      padding: 10,
     },
   },
 


### PR DESCRIPTION
Currently the designs have the cutter at 20px. This updates the col padding to reflect that. 

![image](https://user-images.githubusercontent.com/3087225/41313018-c6f13c5c-6e56-11e8-8d6d-96f249b0faf0.png)
