### PR TITLE
Add platform specific fonts

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import reset from "styled-reset"
 import { GridThemeProvider, injectLayoutBaseCSS } from "styled-bootstrap-grid"
 import { ThemeProvider } from "styled-components"
+import { fontFamily } from "./platform/fonts"
 
 // Notion: https://www.notion.so/artsy/Design-92030f16ed7c4c72bb3eb832b4243d04
 // API: https://jxnblk.com/styled-system/api
@@ -63,22 +64,7 @@ export const themeProps = {
     white100: "#FFF",
   },
 
-  fontFamily: {
-    sans: {
-      regular: "Unica77LL-Regular",
-      italic: "Unica77LL-Italic",
-      medium: "Unica77LLWeb-Medium",
-      mediumItalic: "Unica77LLWeb-MediumItalic",
-    },
-    serif: {
-      regular: "AGaramondPro-Regular",
-      italic: "AGaramondPro-Italic",
-      semibold: "AGaramondPro-Semibold",
-    },
-    display: {
-      regular: "AvantGardeGothicITC",
-    },
-  },
+  fontFamily,
 
   // prettier-ignore
   /** Media queries to work with in web  */

--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { styled as primitives } from "../platform/primitives"
 import { themeProps } from "../Theme"
+import { FontValue } from "../platform/fonts"
 
 // @ts-ignore
 import { StyledComponentClass } from "styled-components"
@@ -38,6 +39,21 @@ const verticalAlign = style({
   prop: "verticalAlign",
 })
 
+const fontFamilyHelper = ({ fontFamily }: { fontFamily: FontValue }) => {
+  if (typeof fontFamily === "string") {
+    return `font-family: ${fontFamily}`
+  } else {
+    return [`font-family: ${fontFamily.fontFamily};`]
+      .concat(
+        fontFamily.fontStyle ? `font-style: ${fontFamily.fontStyle};` : []
+      )
+      .concat(
+        fontFamily.fontWeight ? `font-weight: ${fontFamily.fontWeight};` : []
+      )
+      .join("\n")
+  }
+}
+
 export interface TextProps
   extends ColorProps,
     MaxWidthProps,
@@ -51,6 +67,7 @@ export interface TextProps
 }
 
 export const Text = primitives.Text.attrs<TextProps>({})`
+  ${fontFamilyHelper}
   font-family: ${({ fontFamily }) => fontFamily || "inherit"};
   font-size: ${({ fontSize }) => fontSize}px;
   line-height: ${({ lineHeight }) => lineHeight}px;

--- a/src/platform/fonts/fontFamily.ios.ts
+++ b/src/platform/fonts/fontFamily.ios.ts
@@ -1,0 +1,18 @@
+import { FontFamily } from "./index"
+
+export const fontFamily: FontFamily = {
+  sans: {
+    regular: "Unica77LL-Regular",
+    italic: "Unica77LL-Italic",
+    medium: "Unica77LLWeb-Medium",
+    mediumItalic: "Unica77LLWeb-MediumItalic",
+  },
+  serif: {
+    regular: "AGaramondPro-Regular",
+    italic: "AGaramondPro-Italic",
+    semibold: "AGaramondPro-Semibold",
+  },
+  display: {
+    regular: "AvantGardeGothicITC",
+  },
+}

--- a/src/platform/fonts/fontFamily.ts
+++ b/src/platform/fonts/fontFamily.ts
@@ -1,0 +1,28 @@
+import { FontFamily } from "./index"
+
+export const fontFamily: FontFamily = {
+  sans: {
+    regular: "Unica77LLWebRegular",
+    italic: "Unica77LLWebItalic",
+    medium: "Unica77LLWebMedium",
+    mediumItalic: "Unica77LLWebMediumItalic",
+  },
+  serif: {
+    regular:
+      "'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif",
+    italic: {
+      fontFamily:
+        "'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif",
+      fontStyle: "italic",
+    },
+    semibold: {
+      fontFamily:
+        "'Adobe Garamond W08', 'adobe-garamond-pro', 'AGaramondPro-Regular', 'Times New Roman', Times, serif",
+      fontWeight: 600,
+    },
+  },
+  display: {
+    regular:
+      "'ITC Avant Garde Gothic W04','AvantGardeGothicITCW01D 731075', AvantGardeGothicITCW01Dm, Helvetica, sans-serif",
+  },
+}

--- a/src/platform/fonts/index.ts
+++ b/src/platform/fonts/index.ts
@@ -1,0 +1,26 @@
+export { fontFamily } from "./fontFamily"
+
+export interface FontDefinition {
+  fontFamily: string
+  fontWeight?: string | number
+  fontStyle?: string
+}
+
+export type FontValue = string | FontDefinition
+
+export interface FontFamily {
+  sans: {
+    regular: FontValue
+    italic: FontValue
+    medium: FontValue
+    mediumItalic: FontValue
+  }
+  serif: {
+    regular: FontValue
+    italic: FontValue
+    semibold: FontValue
+  }
+  display: {
+    regular: FontValue
+  }
+}


### PR DESCRIPTION
This adds support for platform specific font declarations. The font families implement the same interface across platforms. 

Also adds a helper to allow expressing more complex font-family configurations (like when we have to define weight, style). 

Adds fallbacks for web. Might want to double check  those and update any that are missing. 