### PR TITLE
Add some helpers to make it easy to access theme values

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,13 @@
+import { themeProps } from "./Theme"
+
+/**
+ * A helper to easily access colors when not in a styled-components or styled-systems context
+ */
+export const color = (colorKey: keyof typeof themeProps["colors"]) =>
+  themeProps.colors[colorKey]
+
+/**
+ * A helper to easily access space values when not in a styled-components or styled-systems context
+ */
+export const space = (spaceKey: keyof typeof themeProps["space"]) =>
+  themeProps.space[spaceKey]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export { Theme, themeProps } from "./Theme"
 export { Display, Sans, Serif } from "./elements/Typography"
+export { color, space } from "./helpers"


### PR DESCRIPTION
I've got some cases in my current work that I need to access values of the theme outside of the context of styled-components or styled-system. I.E. passing a color to an svg prop and using space for a width. 