### PR TITLE
Correct font name issue on ios

### DIFF
--- a/src/platform/fonts/fontFamily.ios.ts
+++ b/src/platform/fonts/fontFamily.ios.ts
@@ -4,8 +4,8 @@ export const fontFamily: FontFamily = {
   sans: {
     regular: "Unica77LL-Regular",
     italic: "Unica77LL-Italic",
-    medium: "Unica77LLWeb-Medium",
-    mediumItalic: "Unica77LLWeb-MediumItalic",
+    medium: "Unica77LL-Medium",
+    mediumItalic: "Unica77LL-MediumItalic",
   },
   serif: {
     regular: "AGaramondPro-Regular",


### PR DESCRIPTION
Some of the font names were messed up for ios. This should fix them. 