### PR TITLE
Export typesizes from the index

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,12 @@
-export { Theme, themeProps, Color, SpacingUnit } from "./Theme"
+export {
+  Theme,
+  themeProps,
+  Color,
+  SpacingUnit,
+  TypeSizes,
+  SansSizes,
+  DisplaySizes,
+  SerifSizes,
+} from "./Theme"
 export { Display, Sans, Serif } from "./elements/Typography"
 export { color, space } from "./helpers"


### PR DESCRIPTION
Another update to expose some of the types so that they don't have to be manually imported from a sub-module. 