### PR TITLE
Updates types to not be plural

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -310,6 +310,6 @@ export type SpacingUnit = keyof typeof themeProps["space"]
 export type Color = keyof typeof themeProps["colors"]
 
 export type TypeSizes = typeof themeProps.typeSizes
-export type SansSizes = keyof TypeSizes["sans"]
-export type SerifSizes = keyof TypeSizes["serif"]
-export type DisplaySizes = keyof TypeSizes["display"]
+export type SansSize = keyof TypeSizes["sans"]
+export type SerifSize = keyof TypeSizes["serif"]
+export type DisplaySize = keyof TypeSizes["display"]

--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -4,9 +4,9 @@ import { styled as primitives } from "../platform/primitives"
 import {
   themeProps,
   TypeSizes,
-  SansSizes,
-  SerifSizes,
-  DisplaySizes,
+  SansSize,
+  SerifSize,
+  DisplaySize,
 } from "../Theme"
 import { FontValue } from "../platform/fonts"
 
@@ -84,9 +84,9 @@ export const Text = primitives.Text.attrs<TextProps>({})`
 
 export type FontTypes = keyof TypeSizes
 export interface TypeSizeKeys {
-  sans: SansSizes
-  serif: SerifSizes
-  display: DisplaySizes
+  sans: SansSize
+  serif: SerifSize
+  display: DisplaySize
 }
 
 export type FontFamily = typeof themeProps["fontFamily"]
@@ -163,7 +163,7 @@ function createStyledText<P extends StyledTextProps>(
 export interface SansProps extends Partial<TextProps> {
   italic?: boolean
 
-  size: SansSizes
+  size: SansSize
 
   /**
    * Explicitly specify `null` to inherit weight from parent, otherwise default
@@ -185,7 +185,7 @@ export const Sans = createStyledText<SansProps>("sans", (weight, italic) => {
 export interface SerifProps extends Partial<TextProps> {
   italic?: boolean
 
-  size: SerifSizes
+  size: SerifSize
 
   /**
    * Explicitly specify `null` to inherit weight from parent, otherwise default
@@ -208,7 +208,7 @@ export const Serif = createStyledText<SerifProps>("serif", (weight, italic) => {
  */
 
 export interface DisplayProps extends Partial<TextProps> {
-  size: DisplaySizes
+  size: DisplaySize
 
   /**
    * Explicitly specify `null` to inherit weight from parent, otherwise default

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,9 +4,9 @@ export {
   Color,
   SpacingUnit,
   TypeSizes,
-  SansSizes,
-  DisplaySizes,
-  SerifSizes,
+  SansSize,
+  DisplaySize,
+  SerifSize,
 } from "./Theme"
 export { Display, Sans, Serif } from "./elements/Typography"
 export { color, space } from "./helpers"


### PR DESCRIPTION
After using this in reaction it didn't really feel right to use `size: SansSizes`. I think `SansSize` feels better as a type being as its not a list of types. 