### PR TITLE
adds purple5 #minor

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -49,8 +49,10 @@ export const themeProps = {
     black5: "#F8F8F8",
     /** Full purple, secondary brand color. Should only used in time/transitions (on hover, active state), for highlighting vital text, and links.   */
     purple100: "#6E1EFF",
-    /** 30 black (light purple), avoid usage  */
+    /** 30 purple (light purple), avoid usage  */
     purple30: "#D3BBFF",
+    /* 5 purple, highlight, accent */
+    purple5: "#F8F3FF",
     /** Full green, success */
     green100: "#0EDA83",
     /** Full red, error */


### PR DESCRIPTION
adds [purple5](https://www.notion.so/artsy/purple-47f26e30e0604d79accdb791c2ba2aaa) to `colors` + corrects `purple30` comment.

<img width="743" alt="screen shot 2018-07-17 at 4 16 53 pm" src="https://user-images.githubusercontent.com/687513/42843015-e3d55244-89dc-11e8-93b6-dfe44c85f0c5.png">
