### PR TITLE
Add media query helper function

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -310,6 +310,7 @@ export const Theme = props => {
 
 export type SpacingUnit = keyof typeof themeProps["space"]
 export type Color = keyof typeof themeProps["colors"]
+export type Breakpoint = keyof typeof breakpoints
 
 export type TypeSizes = typeof themeProps.typeSizes
 export type SansSize = keyof TypeSizes["sans"]

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,6 @@
-import { themeProps, Color, SpacingUnit } from "./Theme"
+import { themeProps, Color, SpacingUnit, Breakpoint } from "./Theme"
+
+type MediaType = "all" | "print" | "screen" | "speech"
 
 /**
  * A helper to easily access colors when not in a styled-components or styled-systems context
@@ -9,3 +11,11 @@ export const color = (colorKey: Color) => themeProps.colors[colorKey]
  * A helper to easily access space values when not in a styled-components or styled-systems context
  */
 export const space = (spaceKey: SpacingUnit) => themeProps.space[spaceKey]
+
+/**
+ * A helper to construct media query strings for responsive style targeting
+ */
+export const media = (
+  breakpointKey: Breakpoint,
+  mediaType: MediaType = "screen"
+) => `@media ${mediaType} and ${themeProps.mediaQueries[breakpointKey]}`


### PR DESCRIPTION
This adds an easy way to build media query strings with palette.

```javascript
styled.div`
  ${media('xl')} {
    display: none;
  }
`
```