### PR TITLE
Adds the ability to set the number of lines for a text element in React Native

### DIFF
--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -69,6 +69,11 @@ export interface TextProps
   fontSize: number
   lineHeight: number
   style?: CSSProperties
+  /**
+   * React Native specific, allows you to tell the native renderers whether
+   * this field could be multi-line or not.
+   */
+  numberOfLines?: number
 }
 
 export const Text = primitives.Text.attrs<TextProps>({})`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "target": "es2015",
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "dist",
     "plugins": [
       {


### PR DESCRIPTION
Adds a property that only exists in the React Native `Text` primitive. Had a good debate with @zephraph about whether this the the best abstraction, but given that it's one property when porting a complex set of screens it's probably alright for now. 

It's likely we'll need something more complex later for bigger design system elements.