### PR TITLE
WIP => [Primitives] Add layout primitives

### DIFF
--- a/src/elements/Box.tsx
+++ b/src/elements/Box.tsx
@@ -1,0 +1,110 @@
+import { color, space } from "../helpers"
+// @ts-ignore
+import React from "react"
+// import { media } from "styled-bootstrap-grid"
+import { styled as primitives, styledWrapper } from "../platform/primitives"
+import {
+  background,
+  BackgroundProps,
+  bottom,
+  BottomProps,
+  color as styledColor,
+  ColorProps,
+  display,
+  DisplayProps,
+  height,
+  HeightProps,
+  left,
+  LeftProps,
+  maxWidth,
+  MaxWidthProps,
+  position,
+  PositionProps,
+  right,
+  RightProps,
+  space as styledSpace,
+  SpaceProps,
+  textAlign,
+  TextAlignProps,
+  top,
+  TopProps,
+  width,
+  WidthProps,
+  zIndex,
+  ZIndexProps,
+} from "styled-system"
+import { Flex, FlexProps } from "./Flex"
+
+export interface BorderBoxProps
+  extends BackgroundProps,
+    FlexProps,
+    HeightProps,
+    MaxWidthProps,
+    SpaceProps,
+    WidthProps {
+  hover?: boolean
+}
+
+export const BorderBox = styledWrapper(Flex).attrs<BorderBoxProps>({})`
+  border: 1px solid ${color("black10")};
+  border-radius: 2px;
+  padding: ${space(2)}px;
+  ${background};
+  ${height};
+  ${maxWidth};
+  ${styledSpace};
+  ${width};
+`
+
+// export const StackableBorderBox = styled(BorderBox)`
+//   :not(:first-child) {
+//     border-top-left-radius: 0;
+//     border-top-right-radius: 0;
+//   }
+//   :not(:last-child) {
+//     border-bottom: 0;
+//     border-bottom-left-radius: 0;
+//     border-bottom-right-radius: 0;
+//   }
+
+//   ${media.sm`
+//     padding: ${space(3)}px;
+//     ${styledSpace};
+//   `};
+// `
+
+export interface BoxProps
+  extends BackgroundProps,
+    BottomProps,
+    BottomProps,
+    ColorProps,
+    DisplayProps,
+    HeightProps,
+    LeftProps,
+    LeftProps,
+    MaxWidthProps,
+    PositionProps,
+    PositionProps,
+    RightProps,
+    SpaceProps,
+    TextAlignProps,
+    TopProps,
+    WidthProps,
+    ZIndexProps {}
+
+export const Box = primitives.View.attrs<BoxProps>({})`
+  ${background};
+  ${bottom};
+  ${display};
+  ${height};
+  ${left};
+  ${maxWidth};
+  ${position};
+  ${right};
+  ${styledColor};
+  ${styledSpace};
+  ${textAlign};
+  ${top};
+  ${width};
+  ${zIndex};
+`

--- a/src/elements/Flex.tsx
+++ b/src/elements/Flex.tsx
@@ -1,0 +1,77 @@
+import { styled as primitives } from "../platform/primitives"
+import {
+  alignContent,
+  AlignContentProps,
+  alignItems,
+  AlignItemsProps,
+  bottom,
+  BottomProps,
+  flexBasis,
+  FlexBasisProps,
+  flexDirection,
+  FlexDirectionProps,
+  flexWrap,
+  FlexWrapProps,
+  height,
+  HeightProps,
+  justifyContent,
+  JustifyContentProps,
+  maxHeight,
+  MaxHeightProps,
+  maxWidth,
+  MaxWidthProps,
+  position,
+  PositionProps,
+  space,
+  SpaceProps,
+  style,
+  width,
+  WidthProps,
+  zIndex,
+  ZIndexProps,
+} from "styled-system"
+
+// @ts-ignore
+import { ClassAttributes, HTMLAttributes } from "react"
+
+const flexGrow = style({
+  prop: "flexGrow",
+  // numberToPx: false,
+})
+
+export interface FlexProps
+  extends AlignItemsProps,
+    AlignContentProps,
+    FlexBasisProps,
+    FlexDirectionProps,
+    FlexWrapProps,
+    JustifyContentProps,
+    SpaceProps,
+    HeightProps,
+    WidthProps,
+    MaxHeightProps,
+    MaxWidthProps,
+    PositionProps,
+    BottomProps,
+    ZIndexProps {
+  flexGrow?: number | string
+}
+
+export const Flex = primitives.View.attrs<FlexProps>({})`
+  display: flex;
+  ${alignContent};
+  ${alignItems};
+  ${flexBasis};
+  ${flexDirection};
+  ${flexGrow};
+  ${flexWrap};
+  ${justifyContent};
+  ${space};
+  ${height};
+  ${maxHeight};
+  ${width};
+  ${maxWidth};
+  ${position};
+  ${bottom};
+  ${zIndex};
+`

--- a/src/elements/Join.tsx
+++ b/src/elements/Join.tsx
@@ -1,0 +1,28 @@
+import React, { SFC } from "react"
+
+interface JoinProps {
+  separator: React.ReactElement<any>
+}
+
+export const Join: SFC<JoinProps> = ({ separator, children }) => {
+  const childArray = React.Children.toArray(children) as any
+
+  return childArray.reduce((acc, curr, currentIndex) => {
+    acc.push(
+      React.cloneElement(curr as React.ReactElement<any>, {
+        key: `join-${currentIndex}`,
+      })
+    )
+
+    if (currentIndex !== childArray.length - 1) {
+      acc.push(
+        separator &&
+          React.cloneElement(separator, {
+            key: `join-sep-${currentIndex}`,
+          })
+      )
+    }
+
+    return acc
+  }, []) as any
+}

--- a/src/elements/Separator.tsx
+++ b/src/elements/Separator.tsx
@@ -1,0 +1,19 @@
+// @ts-ignore
+import React from "react"
+
+import { color } from "../helpers"
+import { styled as primitives } from "../platform/primitives"
+import { space, SpaceProps, width, WidthProps } from "styled-system"
+
+interface SeparatorProps extends SpaceProps, WidthProps {}
+
+export const Separator = primitives.View.attrs<SeparatorProps>({})`
+  border: 1px solid ${color("black10")};
+  border-bottom-width: 0;
+  ${space};
+  ${width};
+`
+
+Separator.defaultProps = {
+  width: "100%",
+}

--- a/src/elements/Spacer.tsx
+++ b/src/elements/Spacer.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+import { HeightProps, SpaceProps, WidthProps } from "styled-system"
+import { Box } from "./Box"
+
+export interface SpacerProps extends SpaceProps, WidthProps, HeightProps {}
+export const Spacer: React.SFC<SpacerProps & { id?: string }> = props => {
+  return <Box {...props} />
+}

--- a/src/platform/primitives.ios.ts
+++ b/src/platform/primitives.ios.ts
@@ -7,3 +7,5 @@ export const styled = {
   Text: styles.Text,
   View: styles.View,
 }
+
+export const styledWrapper = styles

--- a/src/platform/primitives.ts
+++ b/src/platform/primitives.ts
@@ -9,3 +9,5 @@ export const styled = {
   Text: styles.div,
   View: styles.div,
 }
+
+export const styledWrapper = styles


### PR DESCRIPTION
Adds base layout primitives, which were first tested out in Emission to see what would work: 

- `Box`
- `Flex`
- `Join`
- `Separator`
- `Spacer`

In `Box` we have some Web-specific values that will need to be updated but need to discuss approach.