### PR TITLE
[WIP] Update layout primitives

### DIFF
--- a/src/elements/Box.tsx
+++ b/src/elements/Box.tsx
@@ -1,7 +1,6 @@
 import { color, space } from "../helpers"
 // @ts-ignore
 import React from "react"
-// import { media } from "styled-bootstrap-grid"
 import { styled as primitives, styledWrapper } from "../platform/primitives"
 import {
   background,
@@ -55,23 +54,6 @@ export const BorderBox = styledWrapper(Flex).attrs<BorderBoxProps>({})`
   ${styledSpace};
   ${width};
 `
-
-// export const StackableBorderBox = styled(BorderBox)`
-//   :not(:first-child) {
-//     border-top-left-radius: 0;
-//     border-top-right-radius: 0;
-//   }
-//   :not(:last-child) {
-//     border-bottom: 0;
-//     border-bottom-left-radius: 0;
-//     border-bottom-right-radius: 0;
-//   }
-
-//   ${media.sm`
-//     padding: ${space(3)}px;
-//     ${styledSpace};
-//   `};
-// `
 
 export interface BoxProps
   extends BackgroundProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,4 +9,9 @@ export {
   SerifSize,
 } from "./Theme"
 export { Display, Sans, Serif } from "./elements/Typography"
+export { Box, BorderBox } from "./elements/Box"
+export { Flex } from "./elements/Flex"
+export { Join } from "./elements/Join"
+export { Spacer } from "./elements/Spacer"
+export { Separator } from "./elements/Separator"
 export { color, space, media } from "./helpers"


### PR DESCRIPTION
This is a continuation of #65 which I might've kinda accidentally merged. I'm just going to keep the work going in this PR. 

Original description below

---

Adds base layout primitives, which were first tested out in Emission to see what would work: 

- `Box`
- `Flex`
- `Join`
- `Separator`
- `Spacer`

In `Box` we have some Web-specific values that will need to be updated but need to discuss approach.