### PR TITLE
Adds a tslint config requesting JSDoc for exporting components, and does some of the easier comments

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -312,15 +312,25 @@ export const themeProps = {
   },
 }
 
+/**
+ * A wrapper component for passing down the Artsy theme context
+ */
 export const Theme = props => {
   return <ThemeProvider theme={themeProps}>{props.children}</ThemeProvider>
 }
 
+/** All available px spacing maps */
 export type SpacingUnit = keyof typeof themeProps["space"]
+/** All available color keys */
 export type Color = keyof typeof themeProps["colors"]
+/** All available width breakpoint */
 export type Breakpoint = keyof typeof breakpoints
 
+/** All available type sizes */
 export type TypeSizes = typeof themeProps.typeSizes
+/** All available sizes for our sans font */
 export type SansSize = keyof TypeSizes["sans"]
+/** All available sizes for our serif font */
 export type SerifSize = keyof TypeSizes["serif"]
+/** All available sizes for our display font */
 export type DisplaySize = keyof TypeSizes["display"]

--- a/src/elements/Box.tsx
+++ b/src/elements/Box.tsx
@@ -45,6 +45,10 @@ export interface BorderBoxProps
   hover?: boolean
 }
 
+/**
+ * A `View` or `div` (depending on the platform) that has a common border
+ * and padding set by default
+ */
 export const BorderBox = styledWrapper(Flex).attrs<BorderBoxProps>({})`
   border: 1px solid ${color("black10")};
   border-radius: 2px;
@@ -92,6 +96,10 @@ export interface BoxProps
     WidthProps,
     ZIndexProps {}
 
+/**
+ * Box is just a `View` or `div` (depending on the platform) with common styled-systems
+ * hooks.
+ */
 export const Box = primitives.View.attrs<BoxProps>({})`
   ${background};
   ${bottom};

--- a/src/elements/Flex.tsx
+++ b/src/elements/Flex.tsx
@@ -57,6 +57,9 @@ export interface FlexProps
   flexGrow?: number | string
 }
 
+/**
+ * A utility component that encapsulates flexbox behavior
+ */
 export const Flex = primitives.View.attrs<FlexProps>({})`
   display: flex;
   ${alignContent};

--- a/src/elements/Join.tsx
+++ b/src/elements/Join.tsx
@@ -4,6 +4,26 @@ interface JoinProps {
   separator: React.ReactElement<any>
 }
 
+/**
+ * `Join` is a higher order component that renders a separator component
+ * between each of `Join`'s direct children.
+ *
+ * @example
+ *
+ *  <Join separator={<SomeComponent/>}>
+ *    <child1/>
+ *    <child2/>
+ *    <child3/>
+ *  </Join>
+ *
+ * which renders
+ *
+ * <child1/>
+ * <SomeComponent/>
+ * <child2/>
+ * <SomeComponent/>
+ * <child3/>
+ */
 export const Join: SFC<JoinProps> = ({ separator, children }) => {
   const childArray = React.Children.toArray(children) as any
 

--- a/src/elements/Separator.tsx
+++ b/src/elements/Separator.tsx
@@ -7,6 +7,9 @@ import { space, SpaceProps, width, WidthProps } from "styled-system"
 
 interface SeparatorProps extends SpaceProps, WidthProps {}
 
+/**
+ * A horizontal divider whose width and spacing can be adjusted
+ */
 export const Separator = primitives.View.attrs<SeparatorProps>({})`
   border: 1px solid ${color("black10")};
   border-bottom-width: 0;

--- a/src/elements/Spacer.tsx
+++ b/src/elements/Spacer.tsx
@@ -3,6 +3,10 @@ import { HeightProps, SpaceProps, WidthProps } from "styled-system"
 import { Box } from "./Box"
 
 export interface SpacerProps extends SpaceProps, WidthProps, HeightProps {}
+
+/**
+ * A component used to inject space where it's needed
+ */
 export const Spacer: React.SFC<SpacerProps & { id?: string }> = props => {
   return <Box {...props} />
 }

--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -106,10 +106,13 @@ export interface TypeSizeKeys {
 }
 
 /**
- *
+ * Any valid font family
  */
 export type FontFamily = typeof themeProps["fontFamily"]
 
+/**
+ * Any valid font weight
+ */
 export type FontWeights =
   | keyof FontFamily["sans"]
   | keyof FontFamily["serif"]

--- a/src/elements/Typography.tsx
+++ b/src/elements/Typography.tsx
@@ -75,14 +75,14 @@ export interface TextProps
    */
   numberOfLines?: number
   /**
-   * React Native specific. When `numberOfLines` is set, this prop defines how 
-   * text will be truncated. `numberOfLines` must be set in conjunction with 
+   * React Native specific. When `numberOfLines` is set, this prop defines how
+   * text will be truncated. `numberOfLines` must be set in conjunction with
    * this prop.
    */
   ellipsizeMode?: string
 }
 
-export const Text = primitives.Text.attrs<TextProps>({})`
+const Text = primitives.Text.attrs<TextProps>({})`
   ${fontFamilyHelper};
   font-size: ${({ fontSize }) => fontSize}px;
   line-height: ${({ lineHeight }) => lineHeight}px;
@@ -94,14 +94,22 @@ export const Text = primitives.Text.attrs<TextProps>({})`
   ${verticalAlign};
 `
 
+/**
+ * The supported typefaces
+ */
 export type FontTypes = keyof TypeSizes
+
 export interface TypeSizeKeys {
   sans: SansSize
   serif: SerifSize
   display: DisplaySize
 }
 
+/**
+ *
+ */
 export type FontFamily = typeof themeProps["fontFamily"]
+
 export type FontWeights =
   | keyof FontFamily["sans"]
   | keyof FontFamily["serif"]
@@ -184,6 +192,14 @@ export interface SansProps extends Partial<TextProps> {
   weight?: null | "regular" | "medium"
 }
 
+/**
+ * The Sans typeface is used for presenting objective dense information
+ * (such as tables) and intervening communications (such as error feedback).
+ *
+ * @example
+ *
+ * <Sans color="black10" size="3t" weight="medium" italic>Hi</Sans>
+ */
 export const Sans = createStyledText<SansProps>("sans", (weight, italic) => {
   return italic && weight === "medium"
     ? "mediumItalic"
@@ -206,6 +222,14 @@ export interface SerifProps extends Partial<TextProps> {
   weight?: null | "regular" | "semibold"
 }
 
+/**
+ * The Serif typeface is used as the primary Artsy voice, guiding users through
+ * flows, instruction, and communications.
+ *
+ * @example
+ *
+ * <Serif color="black10" size="3t" weight="semibold">Hi</Serif>
+ */
 export const Serif = createStyledText<SerifProps>("serif", (weight, italic) => {
   if (italic && weight && weight !== "regular") {
     throw new Error(
@@ -214,10 +238,6 @@ export const Serif = createStyledText<SerifProps>("serif", (weight, italic) => {
   }
   return _selectFontFamilyType(weight, italic)
 })
-
-/**
- * Display
- */
 
 export interface DisplayProps extends Partial<TextProps> {
   size: DisplaySize
@@ -229,4 +249,13 @@ export interface DisplayProps extends Partial<TextProps> {
   weight?: null | "regular"
 }
 
+/**
+ * The Display typeface has limited utility and is in the process of being
+ * phased out in most places. Ask your friendly neighborhood design team member
+ * if you're unsure if it should be used.
+ *
+ * @example
+ *
+ * <Display color="black10" size="3t">Hi</Display>
+ */
 export const Display = createStyledText<DisplayProps>("display")

--- a/src/platform/fonts/fontFamily.ios.ts
+++ b/src/platform/fonts/fontFamily.ios.ts
@@ -1,5 +1,8 @@
 import { FontFamily } from "./index"
 
+/**
+ * A map of the font families and their settings
+ */
 export const fontFamily: FontFamily = {
   sans: {
     regular: "Unica77LL-Regular",

--- a/src/platform/fonts/fontFamily.ts
+++ b/src/platform/fonts/fontFamily.ts
@@ -2,6 +2,9 @@ import { FontFamily } from "./index"
 
 const sansFallback = "'Helvetica Neue', Helvetica, Arial, sans-serif"
 
+/**
+ * A map of the font families and their settings
+ */
 export const fontFamily: FontFamily = {
   sans: {
     regular: `Unica77LLWebRegular, ${sansFallback}`,

--- a/src/platform/fonts/index.ts
+++ b/src/platform/fonts/index.ts
@@ -1,13 +1,23 @@
 export { fontFamily } from "./fontFamily"
 
+/**
+ * Type definition for font objects
+ */
 export interface FontDefinition {
   fontFamily: string
   fontWeight?: string | number
   fontStyle?: string
 }
 
+/**
+ * Type definition for font value properties which can either
+ * be an object for complex definitions or a string for single entries.
+ */
 export type FontValue = string | FontDefinition
 
+/**
+ * Defines the shape of the font family
+ */
 export interface FontFamily {
   sans: {
     regular: FontValue

--- a/src/platform/primitives.ios.ts
+++ b/src/platform/primitives.ios.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:completed-docs */
+
 import styles from "styled-components/native"
 
 // @ts-ignore

--- a/src/platform/primitives.ts
+++ b/src/platform/primitives.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:completed-docs */
+
 import styles from "styled-components"
 
 // @ts-ignore

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,15 @@
     "ordered-imports": false,
     "no-namespace": [true, "allow-declarations"],
     "trailing-comma": false,
-    "variable-name": [true, "ban-keywords", "allow-leading-underscore"]
+    "variable-name": [true, "ban-keywords", "allow-leading-underscore"],
+    "completed-docs": [
+      true,
+      {
+        "functions": { "visibilities": ["exported"] },
+        "classes": { "visibilities": ["exported"] },
+        "types": { "visibilities": ["exported"] },
+        "variables": { "visibilities": ["exported"] }
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR needs additional work, @zephraph - any chance you could throw 15m at adding some of the additional fails? It's things like `Box`, `Flex` etc, which I don't really understand enough to feel like I should be writing the core docs.

I didn't add interfaces in here, I don't think that matters too much. In the most ideal state, we turn on properties so and people know what all the options in props are - but I'm not sure if that's overkill.

