### PR TITLE
[Docs] Update router to use hash for deeplinking

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,4 +1,5 @@
 export default {
+  hashRouter: true,
   indexHtml: "docs/index.html",
   protocol: "http",
   typescript: true,


### PR DESCRIPTION
Updates routes to support a `/#/` so that deeplinking works. Can flip this off once we figure out how to support dynamic urls. 