### PR TITLE
feat: add disabled prop to select

### DIFF
--- a/docs/Select.mdx
+++ b/docs/Select.mdx
@@ -35,6 +35,34 @@ import { Value } from 'react-powerplug'
   </Value>
 </Playground>
 
+## Disabled LargeSelect
+
+<Playground>
+  <Value>
+    {({ value, set }) => (
+      <LargeSelect
+        options={[
+          {
+            text: "Most Recent",
+            value: "mostRecent",
+          },
+          {
+            text: "Price",
+            value: "price",
+          },
+          {
+            text: "Estimate",
+            value: "estimate",
+          },
+        ]}
+        selected={value}
+        onSelect={value => set(value)}
+        disabled
+      />
+    )}
+  </Value>
+</Playground>
+
 ## SmallSelect
 
 <Playground>

--- a/src/elements/Select.tsx
+++ b/src/elements/Select.tsx
@@ -17,6 +17,7 @@ interface Option {
 export interface SelectProps extends PositionProps, SpaceProps {
   options: Option[]
   selected?: string
+  disabled?: boolean
   onSelect?: (value) => void
 }
 
@@ -28,6 +29,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
     <LargeSelectContainer {...props} p={1}>
       <select
         value={props.selected}
+        disabled={props.disabled}
         onChange={event => props.onSelect && props.onSelect(event.target.value)}
       >
         {props.options.map(({ value, text }) => (
@@ -89,10 +91,11 @@ const hideDefaultSkin = css`
   }
 `
 
-const caretArrow = css`
+const caretArrow = css<SelectProps>`
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-top: 4px solid black;
+  border-top: 4px solid
+    ${props => (props.disabled ? color("black10") : color("black100"))};
   width: 0;
   height: 0;
 `
@@ -111,12 +114,13 @@ const LargeSelectContainer = styled.div.attrs<SelectProps>({})`
     border: 1px solid ${color("black10")};
     border-radius: 0;
     padding-right: ${space(1)}px;
+    cursor: ${props => (props.disabled ? "default" : "pointer")};
     ${styledSpace};
   }
 
   &::after {
     content: "";
-    cursor: pointer;
+    cursor: ${props => (props.disabled ? "default" : "pointer")};
     pointer-events: none;
     position: absolute;
     top: 45%;


### PR DESCRIPTION
Adds a disabled prop and state to `LargeSelect`. I'm not aware of an official spec for this, but I followed the design seen [here](https://app.zeplin.io/project/5ab94282c124db8d58365b47/screen/5b7c5afcd2b23b7c8a0c3a2e) and followed the disabled state of `Radio` for how to handle the hovered disabled state - `default` cursor.