### PR TITLE
add styling to border

### DIFF
--- a/docs/Select.mdx
+++ b/docs/Select.mdx
@@ -89,3 +89,30 @@ import { Value } from 'react-powerplug'
     )}
   </Value>
 </Playground>
+
+## Error State
+
+<Playground>
+  <Value>
+    {({ value="bad", set }) => {
+      const error = value === "good" ? "" : "bad value"
+      return (
+        <LargeSelect
+          error={error}
+          options={[
+            {
+              text: "Good",
+              value: "good",
+            },
+            {
+              text: "Bad",
+              value: "bad",
+            },
+          ]}
+          selected={value}
+          onSelect={value => set(value)}
+        />
+      )
+    }}
+  </Value>
+</Playground>

--- a/docs/Select.mdx
+++ b/docs/Select.mdx
@@ -94,19 +94,19 @@ import { Value } from 'react-powerplug'
 
 <Playground>
   <Value>
-    {({ value="bad", set }) => {
-      const error = value === "good" ? "" : "bad value"
+    {({ value="badValue", set }) => {
+      const error = value === "goodValue" ? "" : "Error Message"
       return (
         <LargeSelect
           error={error}
           options={[
             {
               text: "Good",
-              value: "good",
+              value: "goodValue",
             },
             {
               text: "Bad",
-              value: "bad",
+              value: "badValue",
             },
           ]}
           selected={value}

--- a/src/elements/Select.tsx
+++ b/src/elements/Select.tsx
@@ -18,6 +18,7 @@ export interface SelectProps extends PositionProps, SpaceProps {
   options: Option[]
   selected?: string
   disabled?: boolean
+  error?: string
   onSelect?: (value) => void
 }
 
@@ -91,7 +92,10 @@ const hideDefaultSkin = css`
   }
 `
 
-const caretArrow = css<SelectProps>`
+const caretArrow =
+  css <
+  SelectProps >
+  `
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 4px solid
@@ -111,11 +115,17 @@ const LargeSelectContainer = styled.div.attrs<SelectProps>({})`
     line-height: ${themeGet("typeSizes.serif.3t.lineHeight")}px;
     height: 40px;
     ${hideDefaultSkin};
-    border: 1px solid ${color("black10")};
+    border: 1px solid
+      ${({ error }) => (error && color("red100")) || color("black10")};
     border-radius: 0;
+    transition: border-color 0.25s;
     padding-right: ${space(1)}px;
     cursor: ${props => (props.disabled ? "default" : "pointer")};
     ${styledSpace};
+    &:hover,
+    &:focus {
+      border-color: ${color("purple100")};
+    }
   }
 
   &::after {


### PR DESCRIPTION
This PR adds border styling to our `Select` html elements.
Spec: https://app.zeplin.io/project/5acd19ff49a1429169c3128b/screen/5ace8399553bdae0668efe69
Tracked in https://artsyproduct.atlassian.net/browse/PURCHASE-504
cc @damassi 

The gif below doesn't capture it well but the `border-transition` property is working identically to the other components (whose borders are controlled by reaction).

![_last](https://user-images.githubusercontent.com/9088720/46221709-30cc5c00-c31c-11e8-87cb-03d27853eb37.gif)

(from `yarn link`ed in reaction )storybook:
![address](https://user-images.githubusercontent.com/9088720/46173834-68cc9400-c275-11e8-9b5f-e46e7c631070.gif)
