### PR TITLE
[PATCH select] make arrow clickable

### DIFF
--- a/src/elements/Select.tsx
+++ b/src/elements/Select.tsx
@@ -92,10 +92,7 @@ const hideDefaultSkin = css`
   }
 `
 
-const caretArrow =
-  css <
-  SelectProps >
-  `
+const caretArrow = css<SelectProps>`
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 4px solid
@@ -155,8 +152,8 @@ const SmallSelectContainer = styled.div.attrs<SelectProps>({})`
     cursor: pointer;
     pointer-events: none;
     position: absolute;
-    top: 12px;
-    margin-left: 8px;
+    top: 10px;
+    margin-left: -8px;
     ${caretArrow};
   }
 


### PR DESCRIPTION
Simple fix to move the arrow into the target area and vertically aligning it with the label on the `Select` component. As of now it's a bit misleading as it's outside of the target area.

<img width="450" src="https://user-images.githubusercontent.com/296775/46375269-f25ad800-c660-11e8-8689-efea69f59581.gif" />
