### PR TITLE
[FIX absPaths] Remove abs paths due to type emission

### DIFF
--- a/src/elements/Avatar/Avatar.tsx
+++ b/src/elements/Avatar/Avatar.tsx
@@ -1,10 +1,10 @@
-import { Flex } from "elements/Flex"
-import { Serif } from "elements/Typography"
-import { color } from "helpers/color"
-import { styled as primitives, styledWrapper } from "platform/primitives"
 import React, { ImgHTMLAttributes, SFC } from "react"
 import { space, SpaceProps } from "styled-system"
-import { SerifSize } from "Theme"
+import { color } from "../../helpers/color"
+import { styled as primitives, styledWrapper } from "../../platform/primitives"
+import { SerifSize } from "../../Theme"
+import { Flex } from "../Flex"
+import { Serif } from "../Typography"
 
 /**
  * Spec: TODO
@@ -93,7 +93,7 @@ export const AvatarImage = primitives.Image<AvatarProps>`
   ${space};
 `
 
-const InitialsHolder = styledWrapper(Flex)`
+const InitialsHolder = styledWrapper(Flex)<AvatarProps>`
   background-color: ${color("black10")};
   border-radius: ${props => sizeValue(props).diameter};
   text-align: center;

--- a/src/elements/BorderBox/BorderBox.tsx
+++ b/src/elements/BorderBox/BorderBox.tsx
@@ -1,6 +1,6 @@
-import { color } from "helpers"
-import { styledWrapper } from "platform/primitives"
 import { css } from "styled-components"
+import { color } from "../../helpers"
+import { styledWrapper } from "../../platform/primitives"
 import { BorderBoxBase, BorderBoxProps } from "./BorderBoxBase"
 
 /**

--- a/src/elements/BorderBox/BorderBoxBase.tsx
+++ b/src/elements/BorderBox/BorderBoxBase.tsx
@@ -1,5 +1,10 @@
 // @ts-ignore
 import React from "react"
+
+import { color, space } from "../../helpers"
+import { styledWrapper } from "../../platform/primitives"
+import { Flex, FlexProps } from "../Flex"
+
 import {
   background,
   BackgroundProps,
@@ -12,10 +17,6 @@ import {
   width,
   WidthProps,
 } from "styled-system"
-
-import { Flex, FlexProps } from "elements/Flex"
-import { color, space } from "helpers"
-import { styledWrapper } from "platform/primitives"
 
 export interface BorderBoxProps
   extends BackgroundProps,

--- a/src/elements/Box/Box.tsx
+++ b/src/elements/Box/Box.tsx
@@ -1,6 +1,6 @@
-import { styled as primitives } from "platform/primitives"
 // @ts-ignore
 import React from "react"
+import { styled as primitives } from "../../platform/primitives"
 
 import {
   background,

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -1,8 +1,8 @@
-import { Spinner } from "elements/Spinner"
-import { Sans, SansProps } from "elements/Typography"
 import React, { Component, ReactNode } from "react"
 import styled, { css } from "styled-components"
-import { themeProps } from "Theme"
+import { themeProps } from "../../Theme"
+import { Spinner } from "../Spinner"
+import { Sans, SansProps } from "../Typography"
 
 import {
   BorderProps,

--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
-import { Flex, FlexProps } from "elements/Flex"
-import { color, space } from "helpers"
 import React from "react"
 import styled, { css } from "styled-components"
+import { color, space } from "../../helpers"
+import { Flex, FlexProps } from "../Flex"
 
 import {
   BorderProps,

--- a/src/elements/Colors/Colors.tsx
+++ b/src/elements/Colors/Colors.tsx
@@ -1,9 +1,9 @@
-import { Flex } from "elements/Flex"
-import { Display } from "elements/Typography"
 import React from "react"
 import styled from "styled-components"
 import { BackgroundProps, color, ColorProps } from "styled-system"
-import { themeProps } from "Theme"
+import { themeProps } from "../../Theme"
+import { Flex } from "../Flex"
+import { Display } from "../Typography"
 
 export interface ColorBlockProps extends ColorProps, BackgroundProps {}
 

--- a/src/elements/Flex/Flex.tsx
+++ b/src/elements/Flex/Flex.tsx
@@ -1,4 +1,4 @@
-import { styled as primitives } from "platform/primitives"
+import { styled as primitives } from "../../platform/primitives"
 
 import {
   alignContent,

--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -1,9 +1,9 @@
-import { Flex, FlexProps } from "elements/Flex"
-import { Sans } from "elements/Typography"
-import { color } from "helpers"
-import { styledWrapper } from "platform/primitives"
 import React, { SFC } from "react"
-import { SansSize } from "Theme"
+import { color } from "../../helpers"
+import { styledWrapper } from "../../platform/primitives"
+import { SansSize } from "../../Theme"
+import { Flex, FlexProps } from "../Flex"
+import { Sans } from "../Typography"
 
 /**
  * Spec: zpl.io/2Zg4Rdq

--- a/src/elements/Radio/Radio.tsx
+++ b/src/elements/Radio/Radio.tsx
@@ -1,7 +1,7 @@
-import { Flex, FlexProps } from "elements/Flex"
-import { color, space } from "helpers"
 import React from "react"
 import styled, { css } from "styled-components"
+import { Flex, FlexProps } from "../../elements/Flex"
+import { color, space } from "../../helpers"
 
 import {
   BorderProps,

--- a/src/elements/RadioGroup/RadioGroup.tsx
+++ b/src/elements/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,6 @@
-import { Flex, FlexProps } from "elements/Flex"
-import { RadioProps } from "elements/Radio"
 import React from "react"
+import { Flex, FlexProps } from "../Flex"
+import { RadioProps } from "../Radio"
 
 /**
  * Spec: zpl.io/bAvnwlB

--- a/src/elements/Select/Select.tsx
+++ b/src/elements/Select/Select.tsx
@@ -1,7 +1,7 @@
-import { Sans } from "elements/Typography"
-import { color, space } from "helpers"
 import React, { SFC } from "react"
 import styled, { css } from "styled-components"
+import { color, space } from "../../helpers"
+import { Sans } from "../Typography"
 
 import {
   PositionProps,

--- a/src/elements/Separator/Separator.tsx
+++ b/src/elements/Separator/Separator.tsx
@@ -1,9 +1,9 @@
 // @ts-ignore
 import React from "react"
 
-import { color } from "helpers"
-import { styled as primitives } from "platform/primitives"
 import { space, SpaceProps, width, WidthProps } from "styled-system"
+import { color } from "../../helpers"
+import { styled as primitives } from "../../platform/primitives"
 
 export interface SeparatorProps extends SpaceProps, WidthProps {}
 

--- a/src/elements/Slider/Slider.tsx
+++ b/src/elements/Slider/Slider.tsx
@@ -1,4 +1,3 @@
-import { color, space } from "helpers"
 import { Range } from "rc-slider"
 import React from "react"
 import styled from "styled-components"
@@ -9,6 +8,7 @@ import {
   space as styledSpace,
   SpaceProps,
 } from "styled-system"
+import { color, space } from "../../helpers"
 
 export interface SliderProps extends BorderProps, SpaceProps {
   /**

--- a/src/elements/Spacer/Spacer.tsx
+++ b/src/elements/Spacer/Spacer.tsx
@@ -1,6 +1,6 @@
-import { Box } from "elements/Box"
 import React from "react"
 import { HeightProps, SpaceProps, WidthProps } from "styled-system"
+import { Box } from "../../elements/Box"
 
 export interface SpacerProps extends SpaceProps, WidthProps, HeightProps {}
 

--- a/src/elements/StackableBorderBox/StackableBorderBox.tsx
+++ b/src/elements/StackableBorderBox/StackableBorderBox.tsx
@@ -1,8 +1,8 @@
-import { BorderBox } from "elements/BorderBox"
-import { BorderBoxProps } from "elements/BorderBox/BorderBoxBase"
-import { media, space } from "helpers"
-import { styledWrapper } from "platform/primitives"
 import { space as styledSpace } from "styled-system"
+import { media, space } from "../../helpers"
+import { styledWrapper } from "../../platform/primitives"
+import { BorderBox } from "../BorderBox"
+import { BorderBoxProps } from "../BorderBox/BorderBoxBase"
 
 /**
  * A stackable border box is a BorderBox that shares borders with its siblings.

--- a/src/elements/Tooltip/Tooltip.tsx
+++ b/src/elements/Tooltip/Tooltip.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import styled from "styled-components"
 
-import { BorderBox } from "elements/BorderBox"
-import { Sans } from "elements/Typography"
+import { BorderBox } from "../BorderBox"
+import { Sans } from "../Typography"
 
 const Wrapper = styled.div`
   position: relative;

--- a/src/elements/Typography/Typography.tsx
+++ b/src/elements/Typography/Typography.tsx
@@ -1,8 +1,15 @@
-import { FontValue } from "platform/fonts"
-import { styled as primitives } from "platform/primitives"
 import React, { CSSProperties } from "react"
 import styled from "styled-components"
-import { DisplaySize, SansSize, SerifSize, themeProps, TypeSizes } from "Theme"
+import { FontValue } from "../../platform/fonts"
+import { styled as primitives } from "../../platform/primitives"
+
+import {
+  DisplaySize,
+  SansSize,
+  SerifSize,
+  themeProps,
+  TypeSizes,
+} from "../../Theme"
 
 // @ts-ignore
 import { StyledComponentClass } from "styled-components"

--- a/src/elements/__tests__/Avatar.test.tsx
+++ b/src/elements/__tests__/Avatar.test.tsx
@@ -1,6 +1,6 @@
-import { Avatar } from "elements/Avatar"
 import { mount } from "enzyme"
 import React from "react"
+import { Avatar } from "../Avatar"
 
 describe("Avatar", () => {
   it("renders an AvatarImage if image url provided", () => {

--- a/src/elements/__tests__/Button.test.tsx
+++ b/src/elements/__tests__/Button.test.tsx
@@ -1,7 +1,7 @@
-import { Button } from "elements/Button"
 import { mount } from "enzyme"
 import React from "react"
-import { Theme } from "Theme"
+import { Theme } from "../../Theme"
+import { Button } from "../Button"
 
 describe("Button", () => {
   it("returns variants and sizes", () => {

--- a/src/elements/__tests__/Join.test.tsx
+++ b/src/elements/__tests__/Join.test.tsx
@@ -1,6 +1,6 @@
-import { Join } from "elements/Join"
 import { mount } from "enzyme"
 import React from "react"
+import { Join } from "../Join"
 
 describe("Join", () => {
   it("renders a separator", () => {

--- a/src/elements/__tests__/RadioGroup.test.tsx
+++ b/src/elements/__tests__/RadioGroup.test.tsx
@@ -1,7 +1,7 @@
-import { Radio } from "elements/Radio"
-import { RadioGroup } from "elements/RadioGroup"
 import { mount } from "enzyme"
 import React from "react"
+import { Radio } from "../Radio"
+import { RadioGroup } from "../RadioGroup"
 
 describe("RadioGroup", () => {
   it("renders a radio group", () => {

--- a/src/elements/__tests__/Typography.test.tsx
+++ b/src/elements/__tests__/Typography.test.tsx
@@ -1,7 +1,7 @@
-import { Display, Sans, Serif, Text } from "elements/Typography"
 import React from "react"
 import renderer from "react-test-renderer"
-import { themeProps } from "Theme"
+import { themeProps } from "../../Theme"
+import { Display, Sans, Serif, Text } from "../Typography"
 
 class Catcher extends React.Component<{ onError: (error: Error) => void }> {
   componentDidCatch(error, _info) {

--- a/src/helpers/__tests__/color.test.ts
+++ b/src/helpers/__tests__/color.test.ts
@@ -1,4 +1,4 @@
-import { color } from "helpers/color"
+import { color } from "../color"
 
 describe("color", () => {
   it("returns the correct color", () => {

--- a/src/helpers/__tests__/media.test.ts
+++ b/src/helpers/__tests__/media.test.ts
@@ -1,4 +1,4 @@
-import { media } from "helpers/media"
+import { media } from "../media"
 
 describe("media", () => {
   it("returns the mediaQuery", () => {

--- a/src/helpers/__tests__/space.test.ts
+++ b/src/helpers/__tests__/space.test.ts
@@ -1,4 +1,4 @@
-import { space } from "helpers/space"
+import { space } from "../space"
 
 describe("space", () => {
   it("returns the correct space", () => {

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -1,4 +1,4 @@
-import { Color, themeProps } from "Theme"
+import { Color, themeProps } from "../Theme"
 
 /**
  * A helper to easily access colors when not in a styled-components or

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -1,5 +1,5 @@
 import { css } from "styled-components"
-import { breakpoints } from "Theme"
+import { breakpoints } from "../Theme"
 
 type Media = { [S in keyof typeof breakpoints]: typeof css }
 

--- a/src/helpers/space.ts
+++ b/src/helpers/space.ts
@@ -1,4 +1,4 @@
-import { SpacingUnit, themeProps } from "Theme"
+import { SpacingUnit, themeProps } from "../Theme"
 
 /**
  * A helper to easily access space values when not in a styled-components or

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": "src",
     "experimentalDecorators": true,
     "jsx": "react",
     "lib": ["dom", "es2015", "es2016", "es2017"],


### PR DESCRIPTION
Remove absolute path imports. 

See https://github.com/Microsoft/TypeScript/issues/15479#issuecomment-300240856 for more info. 