### PR TITLE
Preempt issues w/ yarn 1.11+ from removing integrity checks

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-unsafe-disable-integrity-migration "false"
+unsafe-disable-integrity-migration false

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+unsafe-disable-integrity-migration "false"


### PR DESCRIPTION
Brought up by @javamonn in [slack](https://artsy.slack.com/archives/C03J4L2KK/p1539016467000100). 

Yarn 1.11+ will have the auto checksum disabled behind a flag because it was technically a major difference released under a minor version update. See the [yarn issue](https://github.com/yarnpkg/yarn/pull/6465) for more. 

cc @alloy, @damassi 