### PR TITLE
[FIX tooltip] Darken the tooltip drop shadow

### DIFF
--- a/src/elements/Tooltip/Tooltip.tsx
+++ b/src/elements/Tooltip/Tooltip.tsx
@@ -24,7 +24,7 @@ const Tip = styled(BorderBox)`
   background: white;
   border: none;
   bottom: 100%;
-  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
   left: ${(p: TipProps) =>
     p.tipPosition.left === null ? "auto" : `${p.tipPosition.left}px`};
   right: ${(p: TipProps) =>


### PR DESCRIPTION
Some minor QA feedback from @nicoleyeo …

### Before

<img width="269" alt="screen shot 2018-10-09 at 2 16 23 pm" src="https://user-images.githubusercontent.com/140521/46689473-f1c8c100-cbcd-11e8-95f9-f93c06e7d6eb.png">

### After

<img width="276" alt="screen shot 2018-10-09 at 2 16 08 pm" src="https://user-images.githubusercontent.com/140521/46689472-f1302a80-cbcd-11e8-9222-74242e165017.png">

