### PR TITLE
Add banner

### DIFF
--- a/docs/Banner.mdx
+++ b/docs/Banner.mdx
@@ -1,0 +1,14 @@
+---
+name: Banner
+---
+
+import { Playground } from 'docz'
+import { Banner } from '../src'
+
+# Banner
+
+## Status
+
+<Playground>
+  <Banner message="Something went wrong" />
+</Playground>

--- a/docs/Banner.mdx
+++ b/docs/Banner.mdx
@@ -12,3 +12,9 @@ import { Banner } from '../src'
 <Playground>
   <Banner message="Something went wrong" />
 </Playground>
+
+## Dismissable
+
+<Playground>
+  <Banner dismissable message="Something went wrong" />
+</Playground>

--- a/docs/Banner.mdx
+++ b/docs/Banner.mdx
@@ -18,3 +18,15 @@ import { Banner } from '../src'
 <Playground>
   <Banner dismissable message="Something went wrong" />
 </Playground>
+
+## Status With Wrapped text
+
+<Playground>
+  <Banner message="Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps. Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps." />
+</Playground>
+
+## Dismissable With Wrapped text
+
+<Playground>
+  <Banner dismissable message="Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps. Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps." />
+</Playground>

--- a/docs/Icons.mdx
+++ b/docs/Icons.mdx
@@ -1,0 +1,20 @@
+---
+name: Icons
+---
+
+import { Playground } from 'docz'
+import { Check, CloseIcon } from '../src/svgs'
+
+# Icons
+
+## Check
+
+<Playground>
+  <Check />
+</Playground>
+
+## CloseIcon
+
+<Playground>
+  <CloseIcon />
+</Playground>

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -5,20 +5,31 @@ import { space } from "../../helpers"
 import { Box } from "../Box"
 import { Sans } from "../Typography"
 
+import { CloseIcon } from "../../svgs"
+
 const Target = styled.div`
   height: 30px;
+  padding: 9px;
   position: absolute;
-  right: 11px;
-  top: 11px;
+  right: 15px;
+  top: 15px;
   width: 30px;
 
   &:hover {
     cursor: pointer;
   }
+
+  svg {
+    display: block;
+  }
 `
 
 const CloseButton = ({ onClick }) => {
-  return <Target onClick={onClick}>X</Target>
+  return (
+    <Target onClick={onClick}>
+      <CloseIcon fill="white100" />
+    </Target>
+  )
 }
 
 export interface BannerProps {
@@ -50,11 +61,13 @@ export class Banner extends React.Component<BannerProps> {
       <Box
         bg="red100"
         color="white100"
-        p={space(2)}
+        height={space(6)}
         position="relative"
         textAlign="center"
       >
-        <Sans size="2">{this.props.message}</Sans>
+        <Sans size="2" style={{ lineHeight: "60px" }}>
+          {this.props.message}
+        </Sans>
         {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
       </Box>
     )

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import styled from "styled-components"
 
-import { space } from "../../helpers"
 import { Box } from "../Box"
 import { Sans } from "../Typography"
 
@@ -61,9 +60,9 @@ export class Banner extends React.Component<BannerProps> {
       <Box
         bg="red100"
         color="white100"
-        p={space(2)}
-        pr={space(6)}
+        p={2}
         position="relative"
+        pr={6}
         textAlign={showCloseButton ? "left" : "center"}
       >
         <Sans size="2">{this.props.message}</Sans>

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -1,10 +1,28 @@
 import React from "react"
+import styled from "styled-components"
 
 import { space } from "../../helpers"
 import { Box } from "../Box"
 import { Sans } from "../Typography"
 
+const Target = styled.div`
+  height: 30px;
+  position: absolute;
+  right: 11px;
+  top: 11px;
+  width: 30px;
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+const CloseButton = ({ onClick }) => {
+  return <Target onClick={onClick}>X</Target>
+}
+
 export interface BannerProps {
+  dismissable: boolean
   message: string
 }
 
@@ -12,10 +30,32 @@ export interface BannerProps {
  * A banner
  */
 export class Banner extends React.Component<BannerProps> {
+  static defaultProps = {
+    dismissable: false,
+  }
+
+  state = {
+    dismissed: false,
+  }
+
+  handleCloseClick = () => {
+    this.setState({ dismissed: true })
+  }
+
   render() {
+    if (this.state.dismissed) return null
+    const showCloseButton = this.props.dismissable
+
     return (
-      <Box bg="red100" color="white100" p={space(2)} textAlign="center">
+      <Box
+        bg="red100"
+        color="white100"
+        p={space(2)}
+        position="relative"
+        textAlign="center"
+      >
         <Sans size="2">{this.props.message}</Sans>
+        {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
       </Box>
     )
   }

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -55,6 +55,8 @@ export class Banner extends React.Component<BannerProps> {
   render() {
     if (this.state.dismissed) return null
     const showCloseButton = this.props.dismissable
+    const textAlignment = showCloseButton ? "left" : "center"
+    const paddingRight = showCloseButton ? 6 : 2
 
     return (
       <Box
@@ -62,8 +64,8 @@ export class Banner extends React.Component<BannerProps> {
         color="white100"
         p={2}
         position="relative"
-        pr={6}
-        textAlign={showCloseButton ? "left" : "center"}
+        pr={paddingRight}
+        textAlign={textAlignment}
       >
         <Sans size="2">{this.props.message}</Sans>
         {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+import { space } from "../../helpers"
+import { Box } from "../Box"
+import { Sans } from "../Typography"
+
+export interface BannerProps {
+  message: string
+}
+
+/**
+ * A banner
+ */
+export class Banner extends React.Component<BannerProps> {
+  render() {
+    return (
+      <Box bg="red100" color="white100" p={space(2)} textAlign="center">
+        <Sans size="2">{this.props.message}</Sans>
+      </Box>
+    )
+  }
+}

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -9,10 +9,8 @@ import { CloseIcon } from "../../svgs"
 
 const Target = styled.div`
   height: 30px;
+  margin: 0 auto ${space(1)}px;
   padding: 9px;
-  position: absolute;
-  right: 15px;
-  top: 15px;
   width: 30px;
 
   &:hover {
@@ -61,14 +59,12 @@ export class Banner extends React.Component<BannerProps> {
       <Box
         bg="red100"
         color="white100"
-        height={space(6)}
+        p={space(2)}
         position="relative"
         textAlign="center"
       >
-        <Sans size="2" style={{ lineHeight: "60px" }}>
-          {this.props.message}
-        </Sans>
         {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
+        <Sans size="2">{this.props.message}</Sans>
       </Box>
     )
   }

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -9,8 +9,10 @@ import { CloseIcon } from "../../svgs"
 
 const Target = styled.div`
   height: 30px;
-  margin: 0 auto ${space(1)}px;
   padding: 9px;
+  position: absolute;
+  top: 11px;
+  right: 11px;
   width: 30px;
 
   &:hover {
@@ -60,11 +62,12 @@ export class Banner extends React.Component<BannerProps> {
         bg="red100"
         color="white100"
         p={space(2)}
+        pr={space(6)}
         position="relative"
-        textAlign="center"
+        textAlign={showCloseButton ? "left" : "center"}
       >
-        {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
         <Sans size="2">{this.props.message}</Sans>
+        {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
       </Box>
     )
   }

--- a/src/elements/Banner/index.tsx
+++ b/src/elements/Banner/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Banner"

--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -3,6 +3,8 @@ import styled, { css } from "styled-components"
 import { color, space } from "../../helpers"
 import { Flex, FlexProps } from "../Flex"
 
+import { Check } from "../../svgs"
+
 import {
   BorderProps,
   borders,
@@ -49,12 +51,9 @@ export class Checkbox extends React.Component<CheckboxProps> {
 
   iconColor = () => {
     const { disabled, selected } = this.props
-    if (disabled && selected) {
-      return color("black30")
-    } else if (disabled) {
-      return color("black5")
-    }
-    return color("white100")
+    if (disabled && selected) return "black30"
+    if (disabled) return "black5"
+    return "white100"
   }
 
   render() {
@@ -79,35 +78,13 @@ export class Checkbox extends React.Component<CheckboxProps> {
           error={error}
           disabled={disabled}
         >
-          <Check color={this.iconColor()} />
+          <Check stroke={this.iconColor()} />
         </CheckboxButton>
         <Label style={this.labelColor()}>{children}</Label>
       </Container>
     )
   }
 }
-
-const StyledSvg = styled.svg`
-  position: relative;
-  top: -${BORDER_WIDTH}px;
-  left: -${BORDER_WIDTH}px;
-`
-
-const Check = ({ color: strokeColor }) => (
-  <StyledSvg
-    width={`${space(SIZE)}px`}
-    height={`${space(SIZE)}px`}
-    viewBox="0 0 20 20"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      fill="none"
-      stroke={strokeColor}
-      strokeWidth="2"
-      d="M4 9.7L8.2 14 16 6"
-    />
-  </StyledSvg>
-)
 
 const checkBorderColor = ({ disabled, selected, error }) => {
   if (disabled) return color("black10")
@@ -135,6 +112,12 @@ const CheckboxButton = styled.div.attrs<CheckboxToggleProps>({})`
   width: ${space(SIZE)}px;
   height: ${space(SIZE)}px;
   transition: background-color 0.25s, border-color 0.25s;
+
+  svg {
+    position: relative;
+    top: -${BORDER_WIDTH}px;
+    left: -${BORDER_WIDTH}px;
+  }
 `
 
 const Label = styled.div``

--- a/src/elements/__tests__/Banner.test.tsx
+++ b/src/elements/__tests__/Banner.test.tsx
@@ -1,0 +1,26 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Banner } from "../Banner"
+
+describe("Button", () => {
+  it("displays the message", () => {
+    const message = "There was an error."
+    const wrapper = mount(<Banner message={message} />)
+    expect(wrapper.text()).toEqual(message)
+    expect(wrapper.find("CloseButton")).toHaveLength(0)
+  })
+
+  it("is dismissable", () => {
+    const message = "There was an error."
+    const wrapper = mount(<Banner dismissable message={message} />)
+    expect(wrapper.find("CloseButton")).toHaveLength(1)
+  })
+
+  it("disappears when dismissed", () => {
+    const message = "There was an error."
+    const wrapper = mount(<Banner dismissable message={message} />)
+    expect(wrapper.find("CloseButton")).toHaveLength(1)
+    wrapper.find("CloseButton").simulate("click")
+    expect(wrapper.find("CloseButton")).toHaveLength(0)
+  })
+})

--- a/src/elements/index.tsx
+++ b/src/elements/index.tsx
@@ -1,4 +1,5 @@
 export * from "./Avatar"
+export * from "./Banner"
 export * from "./BorderBox"
 export * from "./Box"
 export * from "./Button"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export * from "./elements"
 export * from "./helpers"
+export * from "./svgs"
 export * from "./Theme"

--- a/src/svgs/Check/Check.tsx
+++ b/src/svgs/Check/Check.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { color } from "../../helpers"
+import { Color } from "../../Theme"
+
+interface IconProps {
+  stroke: Color
+}
+
+/**
+ * A Check
+ */
+export const Check: React.SFC<IconProps> = ({ stroke }) => (
+  <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fill="none"
+      stroke={color(stroke)}
+      strokeWidth="2"
+      d="M4 9.7L8.2 14 16 6"
+    />
+  </svg>
+)
+
+Check.defaultProps = {
+  stroke: "black100",
+}

--- a/src/svgs/Check/index.tsx
+++ b/src/svgs/Check/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Check"

--- a/src/svgs/CloseIcon/CloseIcon.tsx
+++ b/src/svgs/CloseIcon/CloseIcon.tsx
@@ -13,7 +13,7 @@ export const CloseIcon: React.SFC<IconProps> = ({ fill }) => (
   <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
     <path
       fill={color(fill)}
-      fill-rule="nonzero"
+      fillRule="nonzero"
       d="M5.03 5.904L.189.986 1.159 0 6 4.919 10.841 0l.97.986L6.97 5.904l5.03 5.11-.97.986L6 6.89.97 12 0 11.014l5.03-5.11z"
     />
   </svg>

--- a/src/svgs/CloseIcon/CloseIcon.tsx
+++ b/src/svgs/CloseIcon/CloseIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { color } from "../../helpers"
+import { Color } from "../../Theme"
+
+interface IconProps {
+  fill: Color
+}
+
+/**
+ * A CloseIcon
+ */
+export const CloseIcon: React.SFC<IconProps> = ({ fill }) => (
+  <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fill={color(fill)}
+      fill-rule="nonzero"
+      d="M5.03 5.904L.189.986 1.159 0 6 4.919 10.841 0l.97.986L6.97 5.904l5.03 5.11-.97.986L6 6.89.97 12 0 11.014l5.03-5.11z"
+    />
+  </svg>
+)
+
+CloseIcon.defaultProps = {
+  fill: "black100",
+}

--- a/src/svgs/CloseIcon/index.tsx
+++ b/src/svgs/CloseIcon/index.tsx
@@ -1,0 +1,1 @@
+export * from "./CloseIcon"

--- a/src/svgs/index.tsx
+++ b/src/svgs/index.tsx
@@ -1,0 +1,1 @@
+export * from "./CloseIcon"

--- a/src/svgs/index.tsx
+++ b/src/svgs/index.tsx
@@ -1,1 +1,2 @@
+export * from "./Check"
 export * from "./CloseIcon"


### PR DESCRIPTION
This PR is for #110 and represents some messing around with how we might do SVGs. Open to thoughts and ideas!! ❤️ 

Here's some shots of the component:

<img width="1038" alt="screen shot 2018-10-16 at 8 32 48 am" src="https://user-images.githubusercontent.com/79799/47020082-313b6400-d11e-11e8-8e50-db3ac00d5aca.png">

<img width="512" alt="screen shot 2018-10-16 at 8 33 04 am" src="https://user-images.githubusercontent.com/79799/47020090-36001800-d11e-11e8-977d-cbb2c93ebe19.png">

While working on this I explored an idea I had about getting SVG images into Palette. I made `src/svgs` and then created `CloseIcon` in there for the purposes of completing the Banner component. Then, I took a stab at pulling out the other SVG in the Checkbox element.

From there, I added a page for Icons that looks like this:

<img width="1340" alt="screen shot 2018-10-15 at 4 23 22 pm" src="https://user-images.githubusercontent.com/79799/46979331-f2160000-d096-11e8-8241-9e4558373323.png">

So this is one way we could do it. Would love feedback.