### PR TITLE
[PATCH dep] Add missing static-extend dep?

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-test-renderer": "^16.4.1",
     "regenerator-runtime": "^0.11.1",
     "semantic-release": "^15.5.0",
+    "static-extend": "^0.1.2",
     "styled-components": "^3.4.5",
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12710,7 +12710,7 @@ state-toggle@^1.0.0:
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
   integrity sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==
 
-static-extend@^0.1.1:
+static-extend@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=


### PR DESCRIPTION
Add missing `static-extend` dep. Seen this in a few node repos lately, not sure whats up. 