### PR TITLE
Typography responsive sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/react": "^16.4.13",
     "@types/react-test-renderer": "^16.0.1",
     "@types/styled-components": "^3.0.0",
-    "@types/styled-system": "^3.0.3",
+    "@types/styled-system": "^3.0.7",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.0.1",
     "babel-plugin-module-resolver": "^3.1.1",
@@ -87,7 +87,7 @@
   "dependencies": {
     "rc-slider": "^8.6.2",
     "react": "^16.5.0",
-    "styled-system": "^3.0.3"
+    "styled-system": "^3.1.11"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [

--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -337,8 +337,10 @@ export type Breakpoint = keyof typeof breakpoints
 /** All available type sizes */
 export type TypeSizes = typeof themeProps.typeSizes
 /** All available sizes for our sans font */
-export type SansSize = keyof TypeSizes["sans"]
+export type SansSize = keyof TypeSizes["sans"] | Array<keyof TypeSizes["sans"]>
 /** All available sizes for our serif font */
-export type SerifSize = keyof TypeSizes["serif"]
+export type SerifSize =
+  | keyof TypeSizes["serif"]
+  | Array<keyof TypeSizes["serif"]>
 /** All available sizes for our display font */
 export type DisplaySize = keyof TypeSizes["display"]

--- a/src/elements/Typography/Typography.test.tsx
+++ b/src/elements/Typography/Typography.test.tsx
@@ -65,6 +65,33 @@ describe("Typography", () => {
         )
       })
     })
+
+    describe("concerning font-size & line-height", () => {
+      it("supports a single size", () => {
+        const sans = renderer.create(<Sans size="3">Hello world</Sans>).root
+        const text = sans.findByType(Text as React.ComponentClass<any>)
+        expect(text.props.fontSize).toEqual(
+          `${themeProps.typeSizes.sans["3"].fontSize}px`
+        )
+        expect(text.props.lineHeight).toEqual(
+          `${themeProps.typeSizes.sans["3"].lineHeight}px`
+        )
+      })
+
+      it("supports multiple responsive sizes", () => {
+        const sans = renderer.create(<Sans size={["2", "4"]}>Hello world</Sans>)
+          .root
+        const text = sans.findByType(Text as React.ComponentClass<any>)
+        expect(text.props.fontSize).toEqual([
+          `${themeProps.typeSizes.sans["2"].fontSize}px`,
+          `${themeProps.typeSizes.sans["4"].fontSize}px`,
+        ])
+        expect(text.props.lineHeight).toEqual([
+          `${themeProps.typeSizes.sans["2"].lineHeight}px`,
+          `${themeProps.typeSizes.sans["4"].lineHeight}px`,
+        ])
+      })
+    })
   })
 
   describe("Serif", () => {
@@ -140,6 +167,34 @@ describe("Typography", () => {
             </Catcher>
           )
         })
+      })
+    })
+
+    describe("concerning font-size & line-height", () => {
+      it("supports a single size", () => {
+        const serif = renderer.create(<Serif size="3">Hello world</Serif>).root
+        const text = serif.findByType(Text as React.ComponentClass<any>)
+        expect(text.props.fontSize).toEqual(
+          `${themeProps.typeSizes.serif["3"].fontSize}px`
+        )
+        expect(text.props.lineHeight).toEqual(
+          `${themeProps.typeSizes.serif["3"].lineHeight}px`
+        )
+      })
+
+      it("supports multiple responsive sizes", () => {
+        const serif = renderer.create(
+          <Serif size={["2", "4"]}>Hello world</Serif>
+        ).root
+        const text = serif.findByType(Text as React.ComponentClass<any>)
+        expect(text.props.fontSize).toEqual([
+          `${themeProps.typeSizes.serif["2"].fontSize}px`,
+          `${themeProps.typeSizes.serif["4"].fontSize}px`,
+        ])
+        expect(text.props.lineHeight).toEqual([
+          `${themeProps.typeSizes.serif["2"].lineHeight}px`,
+          `${themeProps.typeSizes.serif["4"].lineHeight}px`,
+        ])
       })
     })
 

--- a/src/elements/Typography/Typography.tsx
+++ b/src/elements/Typography/Typography.tsx
@@ -19,6 +19,10 @@ import {
   ColorProps,
   display,
   DisplayProps as StyledSystemDisplayProps,
+  fontSize,
+  FontSizeProps,
+  lineHeight,
+  LineHeightProps,
   maxWidth,
   MaxWidthProps,
   space,
@@ -27,6 +31,8 @@ import {
   textAlign,
   TextAlignProps,
 } from "styled-system"
+
+import { determineFontSizes } from "./determineFontSizes"
 
 /**
  * Spec: https://www.notion.so/artsy/Typography-d1f9f6731f3d47c78003d6d016c30221
@@ -69,10 +75,10 @@ export interface TextProps
     SpaceProps,
     StyledSystemDisplayProps,
     TextAlignProps,
-    VerticalAlignProps {
+    VerticalAlignProps,
+    FontSizeProps,
+    LineHeightProps {
   fontFamily?: string
-  fontSize: number
-  lineHeight: number
   style?: CSSProperties
   /**
    * React Native specific. Allows you to tell the native renderers whether
@@ -90,8 +96,8 @@ export interface TextProps
 /** Base Text component for typography */
 export const Text = primitives.Text.attrs<TextProps>({})`
   ${fontFamilyHelper};
-  font-size: ${({ fontSize }) => fontSize}px;
-  line-height: ${({ lineHeight }) => lineHeight}px;
+  ${fontSize};
+  ${lineHeight};
   ${color};
   ${display};
   ${maxWidth};
@@ -143,7 +149,7 @@ function _selectFontFamilyType(weight?: null | FontWeights, italic?: boolean) {
 }
 
 interface StyledTextProps extends Partial<TextProps> {
-  size: string
+  size: string | string[]
   weight?: null | FontWeights
   italic?: boolean
 }
@@ -177,7 +183,7 @@ function createStyledText<P extends StyledTextProps>(
           fontFamily={
             fontFamilyType && themeProps.fontFamily[fontType][fontFamilyType]
           }
-          {...themeProps.typeSizes[fontType][size]}
+          {...determineFontSizes(fontType, size)}
           {...textProps}
         />
       )

--- a/src/elements/Typography/determineFontSizes.test.ts
+++ b/src/elements/Typography/determineFontSizes.test.ts
@@ -1,0 +1,29 @@
+import { determineFontSizes } from "./determineFontSizes"
+
+import { themeProps } from "../../Theme"
+
+describe("determineFontSizes", () => {
+  it("returns a single fontSize and lineHeight if string is passed in", () => {
+    const result = determineFontSizes("sans", "2")
+
+    expect(result).toEqual({
+      fontSize: `${themeProps.typeSizes.sans[2].fontSize}px`,
+      lineHeight: `${themeProps.typeSizes.sans[2].lineHeight}px`,
+    })
+  })
+
+  it("returns multiple fontSizes and lineHeights if array is passed in", () => {
+    const result = determineFontSizes("sans", ["2", "4"])
+
+    expect(result).toEqual({
+      fontSize: [
+        `${themeProps.typeSizes.sans[2].fontSize}px`,
+        `${themeProps.typeSizes.sans[4].fontSize}px`,
+      ],
+      lineHeight: [
+        `${themeProps.typeSizes.sans[2].lineHeight}px`,
+        `${themeProps.typeSizes.sans[4].lineHeight}px`,
+      ],
+    })
+  })
+})

--- a/src/elements/Typography/determineFontSizes.ts
+++ b/src/elements/Typography/determineFontSizes.ts
@@ -1,0 +1,28 @@
+import { themeProps } from "../../Theme"
+import { FontFamily } from "./Typography"
+
+/**
+ * Determines which font sizes/line heights to use for typography.
+ */
+export function determineFontSizes(
+  fontType: keyof FontFamily,
+  size: string | string[]
+) {
+  if (!Array.isArray(size)) {
+    const match = themeProps.typeSizes[fontType][size]
+    return {
+      fontSize: `${match.fontSize}px`,
+      lineHeight: `${match.lineHeight}px`,
+    }
+  }
+
+  return size.map(s => themeProps.typeSizes[fontType][s]).reduce(
+    (accumulator, current) => {
+      return {
+        fontSize: [...accumulator.fontSize, `${current.fontSize}px`],
+        lineHeight: [...accumulator.lineHeight, `${current.lineHeight}px`],
+      }
+    },
+    { fontSize: [], lineHeight: [] }
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,6 +961,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
+  integrity sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -1346,10 +1353,10 @@
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/styled-system@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-3.0.3.tgz#ce3c1c6975c9ec6fe2b518841d4258f0e8d46dfe"
-  integrity sha512-F2mwTxqA+zdioNV1jQmtV4KlJVtE0YpK/zhCC4hgflRG2M5UKLxKYFQKPqQyEcM0g+pNbc0JNiC80NTdMwracA==
+"@types/styled-system@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-3.0.7.tgz#1bb1b5161f2009f10aa37c4c627ecb78fa543cb3"
+  integrity sha512-5IVTchugOLqVdSQcF7C5b544k3zML1+EhA67pWnueMwz/wrr15GXHw8GvdOQqgm9mZ3HbgZSBMXDSH5Q0yZE8Q==
 
 "@webassemblyjs/ast@1.7.8":
   version "1.7.8"
@@ -3510,6 +3517,11 @@ class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
@@ -12710,7 +12722,7 @@ state-toggle@^1.0.0:
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
   integrity sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==
 
-static-extend@^0.1.2:
+static-extend@^0.1.1, static-extend@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
@@ -12946,11 +12958,12 @@ styled-components@^3.4.5:
     stylis-rule-sheet "^0.0.10"
     supports-color "^3.2.3"
 
-styled-system@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-3.0.3.tgz#8ca3938fa382564e059f181d37d563b753cc9f41"
-  integrity sha512-+tW500CMIJAGJInkzF5cgUPYaCnz8PcPxdV5okfyU8EQAH4JHkmZL0ycPNsMxAXNzYxAk4TQD8zr8RKk4Qwtfg==
+styled-system@^3.1.11:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-3.1.11.tgz#a91a38cf7a0f0e625b897a04fdd506a359a3629f"
+  integrity sha512-d0p32F7Y55uRWNDb1P0JcIiGVi13ZxiSCvn8zNS68exAKW9Q5jp+IGTXUIavQOD/J8r3tydtE3vRk8Ii2i39HA==
   dependencies:
+    "@babel/runtime" "^7.1.2"
     prop-types "^15.6.2"
 
 stylis-rule-sheet@^0.0.10:


### PR DESCRIPTION
This PR adds the ability to specify multiple sizes for typographical elements, to target different responsive breakpoints.

Previously, you could create a type element like this to specify one size:

`<Sans size="2">text here</Sans>`

With these changes, you're now able to create a type element like this to specify multiple sizes:

`<Sans size={[2, 3]}>text here</Sans>`

The array passed in is mapped to pixel sizes for `font-size` and `line-height` here in palette, which are then passed through to styled-system. 

Also included in this PR is an update to the styled-system dependency. This was required to make this feature work; the older version wasn't creating the required media queries.