### PR TITLE
[FEATURE ios] Add Collapse implementation

### DIFF
--- a/src/elements/Collapse/Collapse.ios.tsx
+++ b/src/elements/Collapse/Collapse.ios.tsx
@@ -1,0 +1,145 @@
+import React from "react"
+import { View } from "react-native"
+import { animated, Spring } from "react-spring/dist/native.cjs.js"
+
+const AnimatedView = animated(View)
+
+export interface CollapseProps {
+  /** Determines whether content is expanded or collapsed */
+  open: boolean
+  /**
+   * If we're rendering within a statically-sized component (e.g. FlatList), we need
+   * to propagate a sentinel value in order to trigger re-render or re-measure.
+   */
+  onAnimationFrame: (animateValue: { height: number }) => void
+}
+
+interface State {
+  isMounted: boolean
+  hasMeasured: boolean
+  isMeasuring: boolean
+  isAnimating: boolean
+  measuredHeight?: number
+}
+
+/** Collapses content with animation when open is not true */
+export class Collapse extends React.Component<CollapseProps, State> {
+  measureRef: View
+
+  state: State = {
+    isMounted: false,
+    isMeasuring: false,
+    isAnimating: false,
+    hasMeasured: false,
+  }
+
+  componentDidMount() {
+    this.setState({ isMounted: true })
+  }
+
+  handleMeasureRef = ref => {
+    this.measureRef = ref
+  }
+
+  measureChildren = () => {
+    this.setState({ isMeasuring: true }, () => {
+      requestAnimationFrame(() => {
+        if (!this.measureRef) {
+          this.setState({
+            isMeasuring: false,
+          })
+          return
+        }
+
+        // @ts-ignore
+        this.measureRef.measure((x, y, width, height) => {
+          this.setState({
+            isMeasuring: false,
+            hasMeasured: true,
+            measuredHeight: height,
+          })
+        })
+      })
+    })
+  }
+
+  handleLayout = ev => {
+    const { open } = this.props
+    const { hasMeasured, isMeasuring, measuredHeight, isAnimating } = this.state
+    const height = ev.nativeEvent.layout.height
+    if (
+      !hasMeasured ||
+      !open ||
+      isMeasuring ||
+      measuredHeight === height ||
+      isAnimating
+    ) {
+      return
+    }
+    this.setState({
+      measuredHeight: height,
+    })
+  }
+
+  handleFrame = animatedValue => {
+    if (this.props.onAnimationFrame) {
+      this.props.onAnimationFrame(animatedValue)
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const willExpand = nextProps.open && !this.props.open
+    if (nextProps.open !== this.props.open) {
+      this.setState({ isAnimating: true }, () => {
+        if (willExpand && !this.measureRef && this.state.hasMeasured) {
+          // We've previously measured children and can animate without further work.
+          return
+        } else if (!this.state.hasMeasured) {
+          // Children are ready to measure, measureRef might be mounted already.
+          this.measureChildren()
+        }
+      })
+    }
+  }
+
+  measureView = () => (
+    <View
+      ref={this.handleMeasureRef}
+      style={{ opacity: 0, position: "absolute" }}
+    >
+      {this.props.children}
+    </View>
+  )
+
+  render() {
+    const { isMeasuring, isMounted, measuredHeight } = this.state
+    const { open, children } = this.props
+
+    // We must render children once in order to measure and derive a static height for animation.
+    if (isMeasuring) {
+      return this.measureView()
+    }
+
+    return (
+      <Spring
+        native
+        immediate={!isMounted}
+        from={{ height: 0 }}
+        to={{ height: open && measuredHeight ? measuredHeight : 0 }}
+        onRest={() => {
+          this.setState({ isAnimating: false })
+        }}
+        onFrame={this.handleFrame}
+      >
+        {props => (
+          <AnimatedView
+            style={{ ...props, overflow: "hidden" }}
+            onLayout={this.handleLayout}
+          >
+            {children}
+          </AnimatedView>
+        )}
+      </Spring>
+    )
+  }
+}


### PR DESCRIPTION
As part of ongoing Local Discovery work, we needed an animated `Collapse` implementation and wanted to extend the existing implementation in Palette. We ran into a couple issues while building this out:

- `react-spring` has a `peerDependency` [on `react` at `>=16.4.0`](https://github.com/drcmda/react-spring/blob/v5.9.2/package.json#L111). It looks like it depends on [`React.forwardRef`](https://reactjs.org/docs/forwarding-refs.html), a feature added in React 16.3. Emission is on `16.3.0-alpha.1` and appears to not have this feature, causing `react-spring` to throw an error. I'm opting to pin `react-spring` via `resolutions` in emission at 5.5 (the latest working version) rather than downgrade the version used in palette as we are in the process of upgrading React Native and could upgrade seamlessly in the future and there are some fixes to the `height: auto` animation used in the web implementation that we'd lose if we downgraded.
- `react-spring`'s `height: auto` animation target support doesn't work on RN, so we have to manually measure the view to derive a static height prior to animating. I cribbed much of this logic from [`react-collapsible`](https://github.com/oblador/react-native-collapsible/blob/master/Collapsible.js). It looks like we could upstream this to `react-spring` based on the same logic used for web support: https://github.com/drcmda/react-spring/blob/master/src/targets/web/fix-auto.js 

<img src="https://user-images.githubusercontent.com/5216744/49174629-c97b5a00-f314-11e8-8950-061102cfce18.gif" width=200>
