### PR TITLE
[Tooling] Add jest-styled-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,10 @@
     "docz-theme-default": "^0.12.4",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
+    "enzyme-to-json": "^3.3.5",
     "husky": "^0.14.3",
     "jest": "^23.5.0",
+    "jest-styled-components": "^6.3.1",
     "lint-staged": "^7.2.0",
     "prettier": "^1.12.1",
     "react-dom": "^16.5.0",
@@ -90,8 +92,8 @@
   "dependencies": {
     "rc-slider": "^8.6.2",
     "react": "^16.5.0",
-    "styled-system": "^3.1.11",
-    "react-spring": "^5.7.2"
+    "react-spring": "^5.7.2",
+    "styled-system": "^3.1.11"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [
@@ -149,6 +151,9 @@
     ],
     "setupFiles": [
       "<rootDir>/jest.config.ts"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
     ],
     "transform": {
       ".(ts|tsx)": "babel-jest"

--- a/src/elements/Banner/Banner.test.tsx
+++ b/src/elements/Banner/Banner.test.tsx
@@ -1,8 +1,15 @@
 import { mount } from "enzyme"
+import "jest-styled-components"
 import React from "react"
 import { Banner } from "../Banner"
 
 describe("Button", () => {
+  it("has default red background", () => {
+    const message = "There was an error."
+    const wrapper = mount(<Banner message={message} />)
+    expect(wrapper).toHaveStyleRule("background-color", "red100")
+  })
+
   it("displays the message", () => {
     const message = "There was an error."
     const wrapper = mount(<Banner message={message} />)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3517,11 +3517,6 @@ class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  dependencies:
-    arr-union "^3.1.0"
-    define-property "^0.2.5"
-    isobject "^3.0.0"
-    static-extend "^0.1.1"
 
 classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
@@ -4305,6 +4300,16 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
   integrity sha1-lGfQMsOM+u+58teVASUwYvh/ob0=
+
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
 
 csso@^3.5.0:
   version "3.5.1"
@@ -5098,6 +5103,13 @@ enzyme-adapter-utils@^1.8.0:
     function.prototype.name "^1.1.0"
     object.assign "^4.1.0"
     prop-types "^15.6.2"
+
+enzyme-to-json@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
+  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
+  dependencies:
+    lodash "^4.17.4"
 
 enzyme@^3.6.0:
   version "3.6.0"
@@ -7636,6 +7648,13 @@ jest-snapshot@^23.5.0:
     natural-compare "^1.4.0"
     pretty-format "^23.5.0"
     semver "^5.5.0"
+
+jest-styled-components@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.3.1.tgz#fa21a89bfe8c20081c7c083cbaed2200854b60e3"
+  integrity sha512-zie3ajvJbwlbHCAq8/Bv5jdbcYCz0ZMRNNX6adL7wSRpkCVPQtiJigv1140JN1ZOJIODPn8VKrjeFCN+jlPa7w==
+  dependencies:
+    css "^2.2.4"
 
 jest-util@^23.4.0:
   version "23.4.0"
@@ -12554,7 +12573,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
   integrity sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==


### PR DESCRIPTION
Adds [`jest-styled-components`](https://github.com/styled-components/jest-styled-components#tohavestylerule) for testing against style rules. 

Example: 
```js
  it("has default red background", () => {
    const message = "There was an error."
    const wrapper = mount(<Banner message={message} />)
    expect(wrapper).toHaveStyleRule("background-color", "red100")
  })
```