### PR TITLE
#minor fix to docs

### DIFF
--- a/docs/Tooltip.mdx
+++ b/docs/Tooltip.mdx
@@ -11,7 +11,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="left" mt={100}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -23,7 +23,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="center" mt={100}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -35,7 +35,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="right" mt={100}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -47,7 +47,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box mt={20}>
-    <Sans>
+    <Sans size="2">
       <Tooltip size="sm" content="Missing: title, price and 8 more">
         <span>10 requirements left to publish.</span>
       </Tooltip>
@@ -59,7 +59,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box mt={20}>
-    <Sans>
+    <Sans size="2">
       <Tooltip size="sm" content="Missing: title, price and 8 more" width="175">
         <span>10 requirements left to publish.</span>
       </Tooltip>
@@ -71,7 +71,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="center" mt={200}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -83,7 +83,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="center" mt={200}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed." width="500">
         <span>Artsy Collector</span>
       </Tooltip>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12753,7 +12753,7 @@ state-toggle@^1.0.0:
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
   integrity sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==
 
-static-extend@^0.1.2:
+static-extend@^0.1.1, static-extend@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=


### PR DESCRIPTION
Just wanted to see what we currently have as a tooltip and wanted it to load:)


But the real question I have is - wondering how to do this more permanent closable popup like the one that is defined here: https://app.zeplin.io/project/5b113f413ede4bb10dbfdc42/screen/5b354b3f925ef06d24e323f0

Want to have the wrapper style and positioning logic from tooltip essentially but add close button and support for more elaborate content.

I think for now I would just copy needed things but we should probably have a more generic style for positioning and bordering that can be included wherever. 