### PR TITLE
Fix Tooltip component docs

### DIFF
--- a/docs/Tooltip.mdx
+++ b/docs/Tooltip.mdx
@@ -11,7 +11,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="left" mt={100}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -23,7 +23,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="center" mt={100}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -35,7 +35,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="right" mt={100}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -47,7 +47,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box mt={20}>
-    <Sans>
+    <Sans size="2">
       <Tooltip size="sm" content="Missing: title, price and 8 more">
         <span>10 requirements left to publish.</span>
       </Tooltip>
@@ -59,7 +59,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box mt={20}>
-    <Sans>
+    <Sans size="2">
       <Tooltip size="sm" content="Missing: title, price and 8 more" width="175">
         <span>10 requirements left to publish.</span>
       </Tooltip>
@@ -71,7 +71,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="center" mt={200}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed.">
         <span>Artsy Collector</span>
       </Tooltip>
@@ -83,7 +83,7 @@ import { Box, Sans, Tooltip } from '../src'
 
 <Playground>
   <Box textAlign="center" mt={200}>
-    <Sans>
+    <Sans size="2">
       <Tooltip content="We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed. We have verified that this collector has an Artsy account. Collector’s name will be revealed when the order is confirmed." width="500">
         <span>Artsy Collector</span>
       </Tooltip>


### PR DESCRIPTION
Provide the required `size` attribute to `<Sans>` components in the `<Tooltip>` component docs.