### PR TITLE
Remove the purple border from <Link>

### DIFF
--- a/docs/Link.mdx
+++ b/docs/Link.mdx
@@ -9,13 +9,13 @@ import { Box, Link } from '../src'
 
 <Playground>
   <Box>
-    <Link>This is a default link</Link>
+    <Link href="#">This is a default link</Link>
   </Box>
   <Box>
-    <Link noUnderline>This is a non-underlined link</Link>
+    <Link href="#" noUnderline>This is a non-underlined link</Link>
   </Box>
   <Box>
-    <Link color="purple100">This is a non-standard color link</Link>
+    <Link href="#" color="purple100">This is a non-standard color link</Link>
   </Box>
 </Playground>
 

--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -13,9 +13,7 @@ export interface LinkProps extends SpaceProps {
  * Spec: https://zpl.io/2Gm6D3d
  */
 export const Link = styled.a<LinkProps>`
-  ${space};
-  ${styledColor};
-  cursor: pointer;
+  color: ${color("black100")};
   transition: color 0.25s;
   text-decoration: ${props =>
     props.noUnderline || props.color ? "none" : "underline"};
@@ -24,7 +22,8 @@ export const Link = styled.a<LinkProps>`
     color: ${color("black100")};
   }
   &:focus {
-    border: 1px solid ${color("purple100")};
     color: ${props => (props.color ? color(props.color) : color("black100"))};
   }
+  ${space};
+  ${styledColor};
 `


### PR DESCRIPTION
While the border is helpful when focusing on a link and using the tab key to move forward, it looks too disruptive for most of our default
links. Let's just remove it for now and re-visit when we think we really need it.

Also adding href to <Link> otherwise browsers do not apply default styles to link tags.