### PR TITLE
[Renovate] Ignore docs2 folder

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
     "zephraph",
     "damassi",
     "l2succes"
+  ],
+  "ignorePaths": [
+    "docs2"
   ]
 }


### PR DESCRIPTION
Ignore the `docs2` gatsby folder for now. 

@zephraph - **very** impressed with how configurable Renovate is!