### PR TITLE
Move grid provider from reaction

### DIFF
--- a/src/Theme.tsx
+++ b/src/Theme.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { GridThemeProvider } from "styled-bootstrap-grid"
 import { ThemeProvider } from "styled-components"
 import { fontFamily } from "./platform/fonts"
 
@@ -324,7 +325,13 @@ export const themeProps = {
  * A wrapper component for passing down the Artsy theme context
  */
 export const Theme = props => {
-  return <ThemeProvider theme={themeProps}>{props.children}</ThemeProvider>
+  return (
+    <ThemeProvider theme={themeProps}>
+      <GridThemeProvider gridTheme={themeProps.grid}>
+        {props.children}
+      </GridThemeProvider>
+    </ThemeProvider>
+  )
 }
 
 /** All available px spacing maps */


### PR DESCRIPTION
Removes the grid theme provider from Reaction since the grid now exists in palette