### PR TITLE
Add ability to pass styles to injectGlobal

### DIFF
--- a/src/helpers/injectGlobalStyles.tsx
+++ b/src/helpers/injectGlobalStyles.tsx
@@ -3,7 +3,7 @@ import { Display, Sans, Serif } from "../elements/Typography"
 import { color } from "./color"
 
 /** Serves as the default reset for apps importing Palette */
-export function injectGlobalStyles() {
+export function injectGlobalStyles(additionalStyles?: string) {
   injectGlobal`
     @import url("https://webfonts.artsy.net/all-webfonts.css");
 
@@ -41,6 +41,8 @@ export function injectGlobalStyles() {
       -webkit-font-smoothing: antialiased;
       text-rendering: optimizeLegibility;
     }
+
+    ${additionalStyles};
   `
 
   // Mixins


### PR DESCRIPTION
When creating a `<GlobalStyles>` helper, can now pass additional rules: 

```js
const { GlobalStyles } = injectGlobalStyles(`
  a {
    text-decoration: none;
  }
`)

const MyComponent = props => <GlobalStyles>{props.children}</GlobalStyles>
```