### PR TITLE
Add placeholder to TextArea component

### DIFF
--- a/docs/TextArea.mdx
+++ b/docs/TextArea.mdx
@@ -9,7 +9,7 @@ import { Toggle } from "react-powerplug"
 ## Basic
 
 <Playground>
-  <TextArea defaultValue="This is some text" onChange={console.log} />
+  <TextArea placeholder="Start typing..." onChange={console.log} />
 </Playground>
 
 ## With error

--- a/src/elements/TextArea/TextArea.tsx
+++ b/src/elements/TextArea/TextArea.tsx
@@ -37,6 +37,7 @@ export interface TextAreaProps {
   defaultValue?: string
   innerRef?: React.RefObject<HTMLTextAreaElement>
   className?: string
+  placeholder?: string
 }
 
 interface TextAreaState {


### PR DESCRIPTION
This existed in the Reaction version, putting it back for the Palette refactor.