### PR TITLE
Add react-helmet

### DIFF
--- a/www/content/pages/CHANGELOG.mdx
+++ b/www/content/pages/CHANGELOG.mdx
@@ -7,6 +7,22 @@ navSpacer:
   mt: 1
 ---
 
+# v2.37.2 (Fri Feb 01 2019)
+
+#### 🐛  Bug Fix
+
+- Add netlifycms categories [#246](https://github.com/artsy/palette/pull/246) ([@damassi](https://github.com/damassi))
+
+---
+
+# v2.37.1 (Thu Jan 31 2019)
+
+#### 🐛  Bug Fix
+
+- Add placeholder to TextArea component [#245](https://github.com/artsy/palette/pull/245) ([@eessex](https://github.com/eessex))
+
+---
+
 # v2.37.0 (Thu Jan 31 2019)
 
 #### 🚀  Enhancement

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -70,6 +70,7 @@ module.exports = {
       },
     },
     "gatsby-plugin-catch-links",
+    "gatsby-plugin-react-helmet",
     "gatsby-plugin-styled-components",
     "gatsby-plugin-typescript",
   ],

--- a/www/package.json
+++ b/www/package.json
@@ -92,6 +92,7 @@
     "gatsby-plugin-manifest": "^2.0.9",
     "gatsby-plugin-netlify-cms": "^3.0.10",
     "gatsby-plugin-offline": "^2.0.16",
+    "gatsby-plugin-react-helmet": "^3.0.5",
     "gatsby-plugin-sharp": "^2.0.14",
     "gatsby-plugin-styled-components": "^3.0.4",
     "gatsby-source-filesystem": "^2.0.16",
@@ -105,7 +106,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.8.0-alpha.1",
     "react-dom": "^16.8.0-alpha.1",
-    "react-head": "^3.0.2",
+    "react-helmet": "^5.2.0",
     "react-powerplug": "^1.0.0",
     "styled-components": "^3.4.5",
     "unstated": "^2.1.1"

--- a/www/src/Boot.tsx
+++ b/www/src/Boot.tsx
@@ -1,7 +1,6 @@
 import { injectGlobalStyles, Theme } from "@artsy/palette"
 import { MDXProvider } from "@mdx-js/tag"
 import React from "react"
-import { HeadProvider } from "react-head"
 import { Provider as StateProvider } from "unstated"
 import { MarkdownComponents } from "./components/GlobalComponents"
 import { Playground } from "./components/Playground"
@@ -24,13 +23,11 @@ export const LayoutComponents = {
 export const Boot = ({ element }) => {
   return (
     <StateProvider>
-      <HeadProvider>
-        <MDXProvider components={LayoutComponents}>
-          <Theme>
-            <GlobalStyles>{element}</GlobalStyles>
-          </Theme>
-        </MDXProvider>
-      </HeadProvider>
+      <MDXProvider components={LayoutComponents}>
+        <Theme>
+          <GlobalStyles>{element}</GlobalStyles>
+        </Theme>
+      </MDXProvider>
     </StateProvider>
   )
 }

--- a/www/src/layouts/DefaultLayout.tsx
+++ b/www/src/layouts/DefaultLayout.tsx
@@ -4,6 +4,7 @@ import { StatusBadge } from "components/StatusBadge"
 import { graphql } from "gatsby"
 import MDXRenderer from "gatsby-mdx/mdx-renderer"
 import React from "react"
+import { Helmet } from "react-helmet"
 import styled from "styled-components"
 
 export default function DocsLayout(props) {
@@ -18,6 +19,9 @@ export default function DocsLayout(props) {
 
   return (
     <Flex>
+      <Helmet defaultTitle="Palette" titleTemplate="Palette | %s">
+        <title>{name}</title>
+      </Helmet>
       <Sidebar />
       <ContentArea>
         {type !== "page" && <ComponentName name={name} wip={wip} />}

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -5733,7 +5733,7 @@ executable@^4.1.0:
   dependencies:
     pify "^2.2.0"
 
-exenv@^1.2.0:
+exenv@^1.2.0, exenv@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
   integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
@@ -6525,6 +6525,13 @@ gatsby-plugin-page-creator@^2.0.5:
     micromatch "^3.1.10"
     parse-filepath "^1.0.1"
     slash "^1.0.0"
+
+gatsby-plugin-react-helmet@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.0.5.tgz#eaeca7c83c6c273d31454598949dd0d3b4ff5f31"
+  integrity sha512-Xn8d4EckfUkO3xB8qfjn1AcqeA2fYgd6Mbin3RHc/Zu6YRiOQqdJAVBXz+7PbFpTt+6GCluKklEpFUA4RS4oYw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
 
 gatsby-plugin-sharp@^2.0.14:
   version "2.0.17"
@@ -12392,13 +12399,15 @@ react-frame-component@^4.0.2:
   resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.0.2.tgz#408f137ab4ba14cd13a5844b86ac972903dda021"
   integrity sha512-846zt81ijEC0ul6sBWzxkI5EGIE39ft9EaNzQUcszV/WWWDnldFJ+tKU7Et2GhZ4OHT/cy1GHcjsLLsdiOXhBg==
 
-react-head@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-head/-/react-head-3.0.2.tgz#efe79b1e5805a18a5ffc58e6a810eeeb609d82bd"
-  integrity sha512-+wtK+pbxl17GfiBgqaSMrRob2rQZ0UJnRb1iEVzWQPUGC/TNMUTmpIzKx55xVKXbfsNTk8QAq0p3139YEnisUA==
+react-helmet@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
+  integrity sha1-qBgR3yExOm1VxfBYxK66XW89l6c=
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    tiny-invariant "^1.0.0"
+    deep-equal "^1.0.1"
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-side-effect "^1.1.0"
 
 react-hot-loader@^4.0.0, react-hot-loader@^4.6.2:
   version "4.6.3"
@@ -12567,6 +12576,14 @@ react-select@^2.1.1:
     raf "^3.4.0"
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
+
+react-side-effect@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
+  integrity sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react-sortable-hoc@^0.6.8:
   version "0.6.8"
@@ -14921,11 +14938,6 @@ tiny-emitter@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
   integrity sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==
-
-tiny-invariant@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.3.tgz#91efaaa0269ccb6271f0296aeedb05fc3e067b7a"
-  integrity sha512-ytQx8T4DL8PjlX53yYzcIC0WhIZbpR0p1qcYjw2pHu3w6UtgWwFJQ/02cnhOnBBhlFx/edUIfcagCaQSe3KMWg==
 
 tinycolor2@^1.1.2:
   version "1.4.1"


### PR DESCRIPTION
Removes react-head and adds react-helmet (since the newer version seems to be ideal API-wise)

Palette should deploy after this. 