### PR TITLE
Fixes broken references to neflity cms paths on github

### DIFF
--- a/www/static/admin/config.js
+++ b/www/static/admin/config.js
@@ -105,10 +105,15 @@ const collections = [
     description: "Utilities",
     folder: "content/docs/utilities",
   },
-].map(field => ({
-  ...defaultFields,
-  ...field,
-}))
+]
+  .map(field => ({
+    ...defaultFields,
+    ...field,
+  }))
+  .map(({ folder, ...collection }) => ({
+    ...collection,
+    folder: process.env.NODE_ENV === "development" ? folder : `www/${folder}`,
+  }))
 
 export const config = {
   collections,


### PR DESCRIPTION
The references from netlify-cms to githubs content was broken do to it referencing content files from the root of the repository instead of using the `www` base root configured in gatsby. This change will leave the content path as is for development, but update the path for live deployments. 