### PR TITLE
Redirect palette traffic to the about page

### DIFF
--- a/www/content/docs/index.mdx
+++ b/www/content/docs/index.mdx
@@ -4,14 +4,3 @@ order: 1
 type: page
 hideInNav: true
 ---
-
-# Start Here.
-
-TKTKTK We're in the process of formalizing the creation of a design system. As
-such, we need a centralized place where documentation and code (i.e. ui
-components) can live to be shared by our digital product platforms. I propose
-that Palette become the repository that we adopt for this purpose.
-
-This would mean that any component that's deemed to be an official part of the
-design system would need to be migrated to Palette. Furthermore, I propose that
-Palette become the official name of Artsy's design system.

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -43,6 +43,13 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
  * since query data resolved below cannot be injected in at build time.
  */
 exports.createPages = ({ graphql, actions }) => {
+  actions.createRedirect({
+    fromPath: "/",
+    isPermanent: true,
+    redirectInBrowser: true,
+    toPath: "/home/about",
+  })
+
   return new Promise((resolve, reject) => {
     resolve(
       graphql(`


### PR DESCRIPTION
We want people to see the about page by default. 