### PR TITLE
Use editorial workflow when deployed

### DIFF
--- a/www/static/admin/config.js
+++ b/www/static/admin/config.js
@@ -117,4 +117,6 @@ const collections = [
 
 export const config = {
   collections,
+  publish_mode:
+    process.env.NODE_ENV === "development" ? undefined : "editorial_workflow",
 }


### PR DESCRIPTION
I've only got it enabled for prod because it only works with the github backend. 