### PR TITLE
Build out icon page and wrap icons in <Icon>

### DIFF
--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { CloseIcon } from "../../svgs"
 import { Box } from "../Box"
+import { Flex } from "../Flex"
 import { Sans } from "../Typography"
 
 const Target = styled.div`
@@ -18,9 +19,11 @@ const Wrapper = styled(Box)`
   display: flex;
 `
 
-const TextWrapper = styled(Box)`
+const TextWrapper = styled(Flex)`
   width: 100%;
   text-align: center;
+  align-items: center;
+  justify-content: center;
 `
 
 const CloseButton = ({ onClick }) => {
@@ -35,6 +38,7 @@ export interface BannerProps {
   dismissable: boolean
   message: string
   backgroundColor: string
+  textColor: string
 }
 
 /**
@@ -44,6 +48,7 @@ export class Banner extends React.Component<BannerProps> {
   static defaultProps = {
     dismissable: false,
     backgroundColor: "red100",
+    textColor: "white100",
   }
 
   state = {
@@ -59,9 +64,13 @@ export class Banner extends React.Component<BannerProps> {
     const showCloseButton = this.props.dismissable
 
     return (
-      <Wrapper bg={this.props.backgroundColor} color="white100" p={1}>
+      <Wrapper
+        bg={this.props.backgroundColor}
+        color={this.props.textColor}
+        p={1}
+      >
         <TextWrapper>
-          <Sans size="2">{this.props.message}</Sans>
+          <Sans size="2">{this.props.children || this.props.message}</Sans>
         </TextWrapper>
         {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
       </Wrapper>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,3 +2,7 @@ export * from "./elements"
 export * from "./helpers"
 export * from "./svgs"
 export * from "./Theme"
+
+// Helpers
+import * as _AllIcons from "./svgs"
+export const AllIcons = _AllIcons

--- a/src/svgs/AuctionIcon.tsx
+++ b/src/svgs/AuctionIcon.tsx
@@ -1,12 +1,13 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const AuctionIcon: React.SFC = () => {
+export const AuctionIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g stroke="#000" fill="none" fillRule="evenodd">
         <path d="M10.977 6.698l4.547 2.625-4.41 7.64-4.547-2.626zM13.385 13.243l4.546 2.625-.5.866-4.546-2.625z" />
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/BellIcon.tsx
+++ b/src/svgs/BellIcon.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { color } from "../helpers"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: string
@@ -10,14 +11,16 @@ interface IconProps {
 export const BellIcon: React.SFC<IconProps> = ({
   fill = "#000",
   selected = false,
+  ...props
 }) => {
   if (selected) {
     return (
-      <svg
+      <Icon
         width="18"
         height="18"
         viewBox="0 0 18 18"
         xmlns="http://www.w3.org/2000/svg"
+        {...props}
       >
         <title>Save</title>
         <g id="Bell-/-Select" fill="none" fillRule="evenodd">
@@ -33,15 +36,16 @@ export const BellIcon: React.SFC<IconProps> = ({
             />
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   } else {
     return (
-      <svg
+      <Icon
         width="18"
         height="18"
         viewBox="0 0 18 18"
         xmlns="http://www.w3.org/2000/svg"
+        {...props}
       >
         <g id="Bell-/-Default" fill="none" fillRule="evenodd">
           <g
@@ -56,7 +60,7 @@ export const BellIcon: React.SFC<IconProps> = ({
             />
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   }
 }

--- a/src/svgs/BlueChipIcon.tsx
+++ b/src/svgs/BlueChipIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const BlueChipIcon: React.SFC = () => {
+export const BlueChipIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g transform="translate(6.25 6.25)" stroke="#000">
@@ -11,6 +12,6 @@ export const BlueChipIcon: React.SFC = () => {
           <path d="M6.604 3.671a.5.5 0 0 0-.708 0L3.671 5.896a.5.5 0 0 0 0 .708l2.225 2.225a.5.5 0 0 0 .708 0l2.225-2.225a.5.5 0 0 0 0-.708L6.604 3.671z" />
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/BookIcon.tsx
+++ b/src/svgs/BookIcon.tsx
@@ -1,15 +1,16 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const BookIcon: React.SFC = () => {
+export const BookIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g stroke="#000">
           <path d="M17.5 8.616v7.73L12.808 17.5H12.5V9.667l5-1.05zM7.5 8.616v7.73l4.692 1.154h.308V9.667l-5-1.05z" />
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/CheckIcon.tsx
+++ b/src/svgs/CheckIcon.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { color } from "../helpers"
 import { Color } from "../Theme"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: Color
@@ -18,13 +19,15 @@ export const CheckIcon: React.SFC<IconProps> = ({
   onClick = (_e: any) => {
     /* */
   },
+  ...props
 }) => (
-  <svg
+  <Icon
     onClick={e => onClick(e)}
     style={style}
     width="20"
     height="20"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <path
       fill="none"
@@ -32,5 +35,5 @@ export const CheckIcon: React.SFC<IconProps> = ({
       strokeWidth="2"
       d="M4 9.7L8.2 14 16 6"
     />
-  </svg>
+  </Icon>
 )

--- a/src/svgs/CircleBlackCheckIcon.tsx
+++ b/src/svgs/CircleBlackCheckIcon.tsx
@@ -1,18 +1,19 @@
 import React, { Component } from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export class CircleBlackCheckIcon extends Component<
-  React.HTMLProps<HTMLElement>,
-  null
-> {
+export class CircleBlackCheckIcon extends Component<any> {
   render() {
+    const { width, height, ...rest } = this.props
+
     return (
-      <svg
+      <Icon
         width={this.props.width}
         height={this.props.height}
         viewBox="0 0 26 26"
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
+        {...rest}
       >
         <g id="QA" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
           <g id="Group-Copy">
@@ -28,7 +29,7 @@ export class CircleBlackCheckIcon extends Component<
             />
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   }
 }

--- a/src/svgs/CircleWhiteCheckIcon.tsx
+++ b/src/svgs/CircleWhiteCheckIcon.tsx
@@ -1,18 +1,19 @@
 import React, { Component } from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export class CircleWhiteCheckIcon extends Component<
-  React.HTMLProps<HTMLElement>,
-  null
-> {
+export class CircleWhiteCheckIcon extends Component<any> {
   render() {
+    const { width, height, ...rest } = this.props
+
     return (
-      <svg
+      <Icon
         width={this.props.width}
         height={this.props.height}
         viewBox="0 0 26 27"
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
+        {...rest}
       >
         <g id="QA" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
           <g id="following-" stroke="#000000">
@@ -29,7 +30,7 @@ export class CircleWhiteCheckIcon extends Component<
             </g>
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   }
 }

--- a/src/svgs/CloseIcon.tsx
+++ b/src/svgs/CloseIcon.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { color } from "../helpers"
 import { Color } from "../Theme"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill: Color
@@ -9,14 +10,15 @@ interface IconProps {
 /**
  * A CloseIcon
  */
-export const CloseIcon: React.SFC<IconProps> = ({ fill }) => (
-  <svg width="12" height="12" xmlns="http://www.w3.org/2000/svg">
+export const CloseIcon: React.SFC<IconProps> = ({ fill, ...props }) => (
+  <Icon width="12" height="12" xmlns="http://www.w3.org/2000/svg">
     <path
       fill={color(fill)}
       fillRule="nonzero"
       d="M5.03 5.904L.189.986 1.159 0 6 4.919 10.841 0l.97.986L6.97 5.904l5.03 5.11-.97.986L6 6.89.97 12 0 11.014l5.03-5.11z"
+      {...props}
     />
-  </svg>
+  </Icon>
 )
 
 CloseIcon.defaultProps = {

--- a/src/svgs/ClosedEyeIcon.tsx
+++ b/src/svgs/ClosedEyeIcon.tsx
@@ -1,14 +1,16 @@
 import React from "react"
 import styled from "styled-components"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const ClosedEyeIcon = props => (
+export const ClosedEyeIcon = ({ width, height, className, ...props }) => (
   <StyledClosedEye
-    width={props.width || 20}
-    height={props.height || 20}
+    width={width || 20}
+    height={height || 20}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 12 12"
-    className={props.className}
+    className={className}
+    {...props}
   >
     <path
       fill="#c2c2c2"
@@ -25,6 +27,6 @@ export const ClosedEyeIcon = props => (
   </StyledClosedEye>
 )
 
-const StyledClosedEye = styled.svg`
+const StyledClosedEye = styled(Icon)`
   vertical-align: middle;
 `

--- a/src/svgs/CreditCardIcon.tsx
+++ b/src/svgs/CreditCardIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** https://stripe.com/docs/api#card_object-brand */
 export type CreditCardType =
@@ -30,8 +31,8 @@ export const CreditCardIcon = ({
   }
 }
 
-const AmexIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
+const AmexIcon = props => (
+  <Icon
     xmlnsXlink="http://www.w3.org/1999/xlink"
     width={30}
     height={20}
@@ -48,11 +49,11 @@ const AmexIcon = (props: React.SVGProps<SVGSVGElement>) => (
         <path d="M9.999 11A.999.999 0 0 0 9 12.01v1.98A1 1 0 0 0 9.999 15H30v-4H9.999zM0 6v4h20.001A.999.999 0 0 0 21 8.99V7.01A.999.999 0 0 0 20.001 6H0z" />
       </g>
     </g>
-  </svg>
+  </Icon>
 )
 
-const DiscoverIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
+const DiscoverIcon = props => (
+  <Icon
     xmlnsXlink="http://www.w3.org/1999/xlink"
     width={30}
     height={20}
@@ -71,11 +72,11 @@ const DiscoverIcon = (props: React.SVGProps<SVGSVGElement>) => (
       />
       <rect width={20} height={3} x={5} y={5} fill="#D4D4D4" rx={1.5} />
     </g>
-  </svg>
+  </Icon>
 )
 
-const FallbackIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
+const FallbackIcon = props => (
+  <Icon
     xmlnsXlink="http://www.w3.org/1999/xlink"
     width={30}
     height={20}
@@ -91,11 +92,11 @@ const FallbackIcon = (props: React.SVGProps<SVGSVGElement>) => (
       <rect width={20} height={3} x={5} y={5} fill="#D4D4D4" rx={1.5} />
       <rect width={7} height={3} x={5} y={10} fill="#D4D4D4" rx={1.5} />
     </g>
-  </svg>
+  </Icon>
 )
 
-const MastercardIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
+const MastercardIcon = props => (
+  <Icon
     xmlnsXlink="http://www.w3.org/1999/xlink"
     width={30}
     height={20}
@@ -121,10 +122,10 @@ const MastercardIcon = (props: React.SVGProps<SVGSVGElement>) => (
         />
       </g>
     </g>
-  </svg>
+  </Icon>
 )
-const VisaIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
+const VisaIcon = props => (
+  <Icon
     xmlnsXlink="http://www.w3.org/1999/xlink"
     width={30}
     height={20}
@@ -146,5 +147,5 @@ const VisaIcon = (props: React.SVGProps<SVGSVGElement>) => (
         d="M1.992 0C.892 0 0 .898 0 1.998V6h30V1.998A1.999 1.999 0 0 0 28.008 0H1.992z"
       />
     </g>
-  </svg>
+  </Icon>
 )

--- a/src/svgs/DownloadIcon.tsx
+++ b/src/svgs/DownloadIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: string
@@ -6,13 +7,17 @@ interface IconProps {
 }
 
 /** Icon */
-export const DownloadIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
+export const DownloadIcon: React.SFC<IconProps> = ({
+  fill = "#000",
+  ...props
+}) => {
   return (
-    <svg
+    <Icon
       width="18"
       height="18"
       viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>Download</title>
       <g id="icon_download" fill="none" fillRule="evenodd">
@@ -32,7 +37,7 @@ export const DownloadIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
           </g>
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }
 

--- a/src/svgs/EditIcon.tsx
+++ b/src/svgs/EditIcon.tsx
@@ -1,17 +1,19 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: string
 }
 
 /** Icon */
-export const EditIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
+export const EditIcon: React.SFC<IconProps> = ({ fill = "#000", ...props }) => {
   return (
-    <svg
+    <Icon
       width="18"
       height="18"
       viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>Edit</title>
       <g id="icon_edit" fill="none" fillRule="evenodd">
@@ -30,7 +32,7 @@ export const EditIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
           </g>
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }
 

--- a/src/svgs/FairIcon.tsx
+++ b/src/svgs/FairIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const FairIcon: React.SFC = () => {
+export const FairIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <path d="M5.526 17.5h14.04" stroke="#000" strokeLinecap="square" />
@@ -12,6 +13,6 @@ export const FairIcon: React.SFC = () => {
         <path stroke="#000" d="M12.5 4.5h1v4h-1z" />
         <path fill="#000" d="M12 3.353L16 5.5 12.902 7H12z" />
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/FilterIcon.tsx
+++ b/src/svgs/FilterIcon.tsx
@@ -1,13 +1,14 @@
 import React from "react"
 import { color } from "../helpers"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill: string
 }
 
 /** Icon */
-export const FilterIcon = ({ fill }: IconProps) => (
-  <svg width="17px" height="14px" viewBox="0 0 17 14" version="1.1">
+export const FilterIcon = ({ fill, ...props }: IconProps) => (
+  <Icon width="17px" height="14px" viewBox="0 0 17 14" version="1.1" {...props}>
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g
         transform="translate(-43.000000, -785.000000)"
@@ -49,5 +50,5 @@ export const FilterIcon = ({ fill }: IconProps) => (
         </g>
       </g>
     </g>
-  </svg>
+  </Icon>
 )

--- a/src/svgs/GenomeIcon.tsx
+++ b/src/svgs/GenomeIcon.tsx
@@ -1,17 +1,22 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: string
 }
 
 /** Icon */
-export const GenomeIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
+export const GenomeIcon: React.SFC<IconProps> = ({
+  fill = "#000",
+  ...props
+}) => {
   return (
-    <svg
+    <Icon
       width="18"
       height="18"
       viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>Genome</title>
       <g id="icon_genome" fill="none" fillRule="evenodd">
@@ -29,7 +34,7 @@ export const GenomeIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
           </g>
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }
 

--- a/src/svgs/GroupIcon.tsx
+++ b/src/svgs/GroupIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const GroupIcon: React.SFC = () => {
+export const GroupIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g transform="translate(3.294 5.941)" stroke="#000">
@@ -12,6 +13,6 @@ export const GroupIcon: React.SFC = () => {
           <circle cx="14.747" cy="2.508" r="1.633" />
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/HeartIcon.tsx
+++ b/src/svgs/HeartIcon.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { color } from "../helpers"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: string
@@ -10,14 +11,16 @@ interface IconProps {
 export const HeartIcon: React.SFC<IconProps> = ({
   fill = "#000",
   selected = false,
+  ...props
 }) => {
   if (selected) {
     return (
-      <svg
+      <Icon
         width="18"
         height="18"
         viewBox="0 0 18 18"
         xmlns="http://www.w3.org/2000/svg"
+        {...props}
       >
         <title>Save</title>
         <g id="Save-/-Select" fill="none" fillRule="evenodd">
@@ -33,19 +36,20 @@ export const HeartIcon: React.SFC<IconProps> = ({
             />
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   } else {
     return (
-      <svg
+      <Icon
         xmlns="http://www.w3.org/2000/svg"
         width="18"
         height="18"
         viewBox="0 0 18 18"
         fill={fill}
+        {...props}
       >
         <path d="M12 3a4 4 0 0 0-2.83 1.17L9 4.34l-.17-.17a4.002 4.002 0 0 0-5.66 5.66l5.48 5.47a.48.48 0 0 0 .7 0l5.48-5.47A4 4 0 0 0 12 3zm2.12 6.12L9 14.24 3.88 9.12a3 3 0 1 1 4.24-4.24l.53.52.35.36.35-.36.53-.52a3 3 0 0 1 4.24 4.24z" />
-      </svg>
+      </Icon>
     )
   }
 }

--- a/src/svgs/HelpIcon.tsx
+++ b/src/svgs/HelpIcon.tsx
@@ -1,15 +1,17 @@
 import React, { Component } from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
 export class HelpIcon extends Component {
   render() {
     return (
-      <svg
+      <Icon
         className="icon__help"
         height="17px"
         width="17px"
         viewBox="0 0 17 17"
         xmlns="http://www.w3.org/2000/svg"
+        {...this.props}
       >
         <g
           stroke="none"
@@ -26,7 +28,7 @@ export class HelpIcon extends Component {
             />
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   }
 }

--- a/src/svgs/Icon.tsx
+++ b/src/svgs/Icon.tsx
@@ -3,6 +3,8 @@ import React from "react"
 import styled from "styled-components"
 import { space, SpaceProps } from "styled-system"
 
+// : React.SVGProps<SVGSVGElement>
+
 // tslint:disable-next-line:no-empty-interface
 interface IconProps extends SpaceProps {}
 

--- a/src/svgs/LocationIcon.tsx
+++ b/src/svgs/LocationIcon.tsx
@@ -1,13 +1,15 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const LocationIcon = () => (
-  <svg
+export const LocationIcon = props => (
+  <Icon
     className="icon__location"
     height="21px"
     width="16px"
     viewBox="0 0 16 21"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <g
       id="location"
@@ -36,5 +38,5 @@ export const LocationIcon = () => (
         </g>
       </g>
     </g>
-  </svg>
+  </Icon>
 )

--- a/src/svgs/LockIcon.tsx
+++ b/src/svgs/LockIcon.tsx
@@ -1,13 +1,14 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const LockIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg viewBox="0 0 9 12" width={9} height={12} fill="none" {...props}>
+export const LockIcon = props => (
+  <Icon viewBox="0 0 9 12" width={9} height={12} fill="none" {...props}>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M2 4H1a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H7V2.5a2.5 2.5 0 0 0-5 0V4zm1 0h3V2.5a1.5 1.5 0 1 0-3 0V4z"
       fill="#C2C2C2"
     />
-  </svg>
+  </Icon>
 )

--- a/src/svgs/LosingBidIcon.tsx
+++ b/src/svgs/LosingBidIcon.tsx
@@ -1,8 +1,9 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const LosingBidIcon = () => (
-  <svg width="17" height="17" viewBox="0 0 17 17">
+export const LosingBidIcon = props => (
+  <Icon width="17" height="17" viewBox="0 0 17 17" {...props}>
     <g
       fill="none"
       fillRule="evenodd"
@@ -13,5 +14,5 @@ export const LosingBidIcon = () => (
       <circle cx="7.5" cy="7.5" r="7.5" fill="#FFF" />
       <path d="M5.25 9.794L9.794 5.25M10 9.794L5.456 5.25" />
     </g>
-  </svg>
+  </Icon>
 )

--- a/src/svgs/MoreIcon.tsx
+++ b/src/svgs/MoreIcon.tsx
@@ -1,18 +1,23 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 interface MoreIconProps {
   fill?: string
 }
 
 /** Icon */
-export const MoreIcon: React.SFC<MoreIconProps> = ({ fill }: MoreIconProps) => {
+export const MoreIcon: React.SFC<MoreIconProps> = ({
+  fill,
+  ...props
+}: MoreIconProps) => {
   return (
-    <svg
+    <Icon
       width="18px"
       height="18px"
       viewBox="0 0 18 18"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>More</title>
       <g
@@ -45,7 +50,7 @@ export const MoreIcon: React.SFC<MoreIconProps> = ({ fill }: MoreIconProps) => {
           </g>
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }
 

--- a/src/svgs/MuseumIcon.tsx
+++ b/src/svgs/MuseumIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const MuseumIcon: React.SFC = () => {
+export const MuseumIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <path d="M6.526 17.5h11.94" stroke="#000" strokeLinecap="square" />
@@ -13,6 +14,6 @@ export const MuseumIcon: React.SFC = () => {
         />
         <path d="M12.37 5.7L7.78 8.5h9.376L12.37 5.7z" stroke="#000" />
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/OpenEyeIcon.tsx
+++ b/src/svgs/OpenEyeIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 interface OpenEyeIconProps {
   fill?: string
@@ -11,14 +12,16 @@ export const OpenEyeIcon: React.SFC<OpenEyeIconProps> = ({
   onClick = (_e: any) => {
     /* */
   },
+  ...props
 }) => {
   return (
-    <svg
+    <Icon
       width="18"
       onClick={e => onClick(e)}
       height="18"
       viewBox="0 0 18 18"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>Action/View/Md</title>
       <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
@@ -31,7 +34,7 @@ export const OpenEyeIcon: React.SFC<OpenEyeIconProps> = ({
           <path d="M8,8.57142857 C6.42204357,8.57142857 5.14285714,7.29224214 5.14285714,5.71428571 C5.14285714,4.13632929 6.42204357,2.85714286 8,2.85714286 C9.57795643,2.85714286 10.8571429,4.13632929 10.8571429,5.71428571 C10.8571429,7.29224214 9.57795643,8.57142857 8,8.57142857 Z M8,7.42857143 C8.94677386,7.42857143 9.71428571,6.66105957 9.71428571,5.71428571 C9.71428571,4.76751186 8.94677386,4 8,4 C7.05322614,4 6.28571429,4.76751186 6.28571429,5.71428571 C6.28571429,6.66105957 7.05322614,7.42857143 8,7.42857143 Z" />
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }
 

--- a/src/svgs/PlusIcon.tsx
+++ b/src/svgs/PlusIcon.tsx
@@ -1,15 +1,18 @@
 import React, { Component } from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export class PlusIcon extends Component<React.HTMLProps<HTMLElement>, null> {
+export class PlusIcon extends Component<any> {
   render() {
+    const { width, height, ...rest } = this.props
     return (
-      <svg
-        width={this.props.width}
-        height={this.props.height}
+      <Icon
+        width={width}
+        height={height}
         viewBox="0 0 26 27"
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
+        {...rest}
       >
         <g id="QA" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
           <g id="follow-symbol">
@@ -33,7 +36,7 @@ export class PlusIcon extends Component<React.HTMLProps<HTMLElement>, null> {
             </g>
           </g>
         </g>
-      </svg>
+      </Icon>
     )
   }
 }

--- a/src/svgs/ShareIcon.tsx
+++ b/src/svgs/ShareIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 interface IconProps {
   fill?: string
@@ -7,7 +8,7 @@ interface IconProps {
 /** Icon */
 export const ShareIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
   return (
-    <svg
+    <Icon
       xmlns="http://www.w3.org/2000/svg"
       width="18"
       height="18"
@@ -19,7 +20,7 @@ export const ShareIcon: React.SFC<IconProps> = ({ fill = "#000" }) => {
         fillRule="evenodd"
         d="M8.547 3.817L5.704 6.203a.25.25 0 0 1-.361-.042l-.3-.401a.25.25 0 0 1 .036-.338l3.579-3.123a.5.5 0 0 1 .672.013l.005.005.017.014 3.6 3.175a.25.25 0 0 1 .035.337l-.3.402a.25.25 0 0 1-.361.042L9.534 3.945V8H13.5a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-6a.5.5 0 0 1 .5-.5h4.047V3.817zm0 5.183H5v5h8V9H9.534v2.75a.25.25 0 0 1-.25.25h-.487a.25.25 0 0 1-.25-.25V9z"
       />
-    </svg>
+    </Icon>
   )
 }
 

--- a/src/svgs/SoloIcon.tsx
+++ b/src/svgs/SoloIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const SoloIcon: React.SFC = () => {
+export const SoloIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <g transform="translate(7.294 4.941)" stroke="#000">
@@ -11,6 +12,6 @@ export const SoloIcon: React.SFC = () => {
           <circle cx="5.053" cy="2.807" r="2.807" />
         </g>
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/TimerIcon.tsx
+++ b/src/svgs/TimerIcon.tsx
@@ -1,14 +1,10 @@
 import React from "react"
 import { color } from "../helpers"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const TimerIcon = ({
-  fill = "black100",
-  ...others
-}: React.SVGProps<SVGSVGElement> & {
-  fill: Parameters<typeof color>[0]
-}) => (
-  <svg
+export const TimerIcon = ({ fill = "black100", ...others }) => (
+  <Icon
     className="timer"
     viewBox="0 0 10 12"
     height="12"
@@ -16,9 +12,9 @@ export const TimerIcon = ({
     xmlns="http://www.w3.org/2000/svg"
     {...others}
   >
-    <g fill={color(fill)} fillRule="nonzero">
+    <g fill={color(fill as any)} fillRule="nonzero">
       <path d="M5.043 11.891C2.41 11.895.234 9.814.087 7.153-.06 4.49 1.873 2.177 4.489 1.883V1.13h-.524V.109h2.058v1.02H5.5v.744c1.082.1 2.1.558 2.9 1.303l.847-.858.713.723-.894.901a5.069 5.069 0 0 1 .39 5.221 4.946 4.946 0 0 1-4.412 2.728zm0-9.019c-2.18.002-3.947 1.791-3.95 3.999a4 4 0 0 0 2.437 3.696A3.914 3.914 0 0 0 7.835 9.7a4.037 4.037 0 0 0 .857-4.358 3.95 3.95 0 0 0-3.65-2.47z" />
       <path d="M4.489 3.83h1.009v3.701H4.489z" />
     </g>
-  </svg>
+  </Icon>
 )

--- a/src/svgs/TopEmergingIcon.tsx
+++ b/src/svgs/TopEmergingIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const TopEmergingIcon: React.SFC = () => {
+export const TopEmergingIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <path d="M0 0h25v25H0z" />
         <circle
@@ -19,6 +20,6 @@ export const TopEmergingIcon: React.SFC = () => {
           fill="#000"
         />
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/TopEstablishedIcon.tsx
+++ b/src/svgs/TopEstablishedIcon.tsx
@@ -1,9 +1,10 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const TopEstablishedIcon: React.SFC = () => {
+export const TopEstablishedIcon: React.SFC = props => {
   return (
-    <svg width="25" height="25" xmlns="http://www.w3.org/2000/svg">
+    <Icon width="25" height="25" xmlns="http://www.w3.org/2000/svg" {...props}>
       <g fill="none" fillRule="evenodd">
         <circle stroke="#000" cx="12.5" cy="12.5" r="6.25" />
         <path
@@ -11,6 +12,6 @@ export const TopEstablishedIcon: React.SFC = () => {
           fill="#000"
         />
       </g>
-    </svg>
+    </Icon>
   )
 }

--- a/src/svgs/WinningBidIcon.tsx
+++ b/src/svgs/WinningBidIcon.tsx
@@ -1,8 +1,9 @@
 import React from "react"
+import { Icon } from "./Icon"
 
 /** Icon */
-export const WinningBidIcon = () => (
-  <svg width="17" height="17" viewBox="0 0 17 17">
+export const WinningBidIcon = props => (
+  <Icon width="17" height="17" viewBox="0 0 17 17" {...props}>
     <g
       fill="none"
       fillRule="evenodd"
@@ -13,5 +14,5 @@ export const WinningBidIcon = () => (
       <circle cx="7.5" cy="7.5" r="7.5" fill="#FFF" />
       <path d="M4.5 7.5l2.377 2.294 4.544-4.544" />
     </g>
-  </svg>
+  </Icon>
 )

--- a/www/content/docs/components/EntityHeader.mdx
+++ b/www/content/docs/components/EntityHeader.mdx
@@ -3,7 +3,7 @@ name: EntityHeader
 wip: false
 ---
 
-<Playground title="Default, all properties present">
+<Playground showEditor={true}>
   <EntityHeader
     imageUrl="https://picsum.photos/110/110/?random"
     initials="FD"
@@ -18,7 +18,9 @@ wip: false
   />
 </Playground>
 
-<Playground title="No imageURL, initials are displayed">
+When no `imageURL` is provided it will defer to the `initials` prop:
+
+<Playground>
   <EntityHeader
     initials="FD"
     name="Francesca DiMattio"
@@ -32,38 +34,13 @@ wip: false
   />
 </Playground>
 
-<Playground title="No imageURL, initials overflow avatar">
-  <EntityHeader
-    initials="FDMATIO"
-    name="Francesca DiMattio"
-    meta="American, b. 1979"
-    FollowButton={
-      <Sans size="2" weight="medium" color="black">
-        Follow
-      </Sans>
-    }
-  />
-</Playground>
-
-<Playground title="No meta with follow button">
-  <EntityHeader
-    imageUrl="https://picsum.photos/110/110/?random"
-    name="Francesca DiMattio"
-    FollowButton={
-      <Sans size="2" weight="medium" color="black">
-        Follow
-      </Sans>
-    }
-  />
-</Playground>
-
-<Playground title="Only image with name">
+<Playground>
   <EntityHeader
     imageUrl="https://picsum.photos/110/110/?random"
     name="Francesca DiMattio"
   />
 </Playground>
 
-<Playground title="No optional properties present">
+<Playground>
   <EntityHeader name="Francesca DiMattio" />
 </Playground>

--- a/www/content/docs/components/PriceRange.mdx
+++ b/www/content/docs/components/PriceRange.mdx
@@ -2,9 +2,10 @@
 name: PriceRange
 ---
 
-All `PriceRange` props are passed to the underlying [Slider](#/docs-slider) component.
+All `PriceRange` props are passed to the underlying [Slider](#/docs-slider)
+component.
 
-<Playground title="Default slider">
+<Playground>
   <PriceRange
     min={1}
     max={100}
@@ -14,13 +15,17 @@ All `PriceRange` props are passed to the underlying [Slider](#/docs-slider) comp
   />
 </Playground>
 
-<Playground title="With non-default currency code">
+### With non-default currency code
+
+Defaults to USD.
+
+<Playground>
   <PriceRange
     min={10}
     max={100}
     step={10}
     defaultValue={[10, 100]}
     disabled={false}
-    currency="EUR" // defaults to USD
+    currency="EUR"
   />
 </Playground>

--- a/www/content/docs/components/StaticCountdownTimer.mdx
+++ b/www/content/docs/components/StaticCountdownTimer.mdx
@@ -12,7 +12,7 @@ name: StaticCountdownTimer
   />
 </Playground>
 
-<Playground title="Out of time">
+<Playground>
   <StaticCountdownTimer
     action="You forgot to do the thing 😵"
     note="And now it's too late."

--- a/www/content/docs/components/TimeRemaining.mdx
+++ b/www/content/docs/components/TimeRemaining.mdx
@@ -2,8 +2,6 @@
 name: TimeRemaining
 ---
 
-import { TimeRemaining } from "@artsy/palette"
-
 <Playground>
   <TimeRemaining
     countdownEnd="2019-01-03T20:15:00.000-04:00"

--- a/www/content/docs/elements/buttons/Link.mdx
+++ b/www/content/docs/elements/buttons/Link.mdx
@@ -2,21 +2,21 @@
 name: Link
 ---
 
-<Playground title="Default link">
+<Playground>
   <Box>
     <Link href="#">This is a default link</Link>
   </Box>
 </Playground>
 
-<Playground title="No underlines">
+<Playground>
   <Box>
     <Link href="#" noUnderline>
-      This is a non-underlined link
+      <Sans size="3">This is a non-underlined link</Sans>
     </Link>
   </Box>
 </Playground>
 
-<Playground title="Non-standard color link">
+<Playground>
   <Box>
     <Link href="#" color="purple100">
       This is a non-standard color link

--- a/www/content/docs/elements/dialogs/Banner.mdx
+++ b/www/content/docs/elements/dialogs/Banner.mdx
@@ -2,44 +2,63 @@
 name: Banner
 ---
 
-<Tabs>
-  <Tab name="Code">
+## General usage
 
-### Usage
+Banners are used to convey time bound messages, statuses and specfic actions to
+our users. Depending on the timespan and importance of the message, they can
+either be a permanent part of the page, or can be dismissable.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+<Banner backgroundColor="black10" textColor="black100">
+  Placeholder message text.
+</Banner>
 
-<Playground title="Status">
-  <Banner message="Something went wrong" />
+## Colors
+
+We primarily use banners that are either dark gray on light gray, or white on
+black.
+
+<Banner backgroundColor="black10" textColor="black100">
+  Example light banner.
+</Banner>
+
+<Spacer my={2} />
+
+<Banner backgroundColor="black100">Example dark banner.</Banner>
+
+When communicating a status, we use colored icons in along with text.
+
+<Banner backgroundColor="black10" textColor="black100">
+  <LockIcon /> Registration pending
+</Banner>
+
+### Status with custom background color
+
+<Playground>
+  <Banner backgroundColor="purple100">Something went wrong</Banner>
 </Playground>
 
-<Playground title="Status with custom background color">
-  <Banner backgroundColor="purple100" message="Something went wrong" />
+### Dismissable
+
+<Playground>
+  <Banner dismissable>Something went wrong</Banner>
 </Playground>
 
-<Playground title="Dismissable">
-  <Banner dismissable message="Something went wrong" />
+<Playground title="Status With Wrapped text" showToggle={true} expanded={false}>
+  <Banner>
+    Error message here. If the message wraps. This is how error message here. If
+    the message wraps. If the message wraps. Error message here. If the message
+    wraps. This is how error message here. If the message wraps. If the message
+    wraps.
+  </Banner>
 </Playground>
 
-<Playground title="Status With Wrapped text">
-  <Banner message="Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps. Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps." />
-</Playground>
-
-<Playground title="Dismissable With Wrapped text">
+<Playground
+  title="Dismissable With Wrapped text"
+  showToggle={true}
+  expanded={false}
+>
   <Banner
     dismissable
     message="Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps. Error message here. If the message wraps. This is how error message here. If the message wraps. If the message wraps."
   />
 </Playground>
-
-  </Tab>
-  <Tab name="Guidelines">
-
-  </Tab>
-
-  <Tab name="Notes">
-
-  </Tab>
-</Tabs>

--- a/www/content/docs/elements/layout/Collapse.mdx
+++ b/www/content/docs/elements/layout/Collapse.mdx
@@ -2,22 +2,54 @@
 name: Collapse
 ---
 
-<Playground title="Open">
-  <Collapse open>
-    <BorderBox>A Collapse component ... Not really cool yet!</BorderBox>
-  </Collapse>
-</Playground>
-
 <Playground title="Toggle">
   <Toggler>
     {({ on, toggle }) => (
       <>
         <Button onClick={toggle}>{on ? "Close" : "Open"}</Button>
         <Collapse open={on}>
-          <BorderBox my={2}>
-            A Collapse component with toggle button ... Its pretty cool!
-          </BorderBox>
+          <BorderBox my={2}>A Collapse component with toggle button</BorderBox>
         </Collapse>
+      </>
+    )}
+  </Toggler>
+</Playground>
+
+## Animating "auto"
+
+When animating height="auto" (or width="auto") sometimes React Spring needs a
+bit more information to determine where to move things. In the below example,
+adding `position="relative"` to the container returns the proper height for the
+multi-line string.
+
+See https://react-spring.surge.sh/gotchas#animating-auto for more info.
+
+<Playground>
+  <Toggler>
+    {({ on, toggle }) => (
+      <>
+        <Spacer mb={4} />
+        <Flex flexDirection="column" alignItems="center">
+          <Button onClick={toggle} width="300px">
+            Toggle
+          </Button>
+          <Spacer mb={4} />
+          <Flex alignItems="flex-start">
+            <BorderBox width="300px" flexDirection="column" position="relative">
+              <Collapse open={on}>
+                <Box>Hello I am some multiline content inside collapse</Box>
+              </Collapse>
+            </BorderBox>
+          </Flex>
+          <Spacer mb={4} />
+          <Flex alignItems="flex-start">
+            <BorderBox width="300px" flexDirection="column" position="relative">
+              <Collapse open={!on}>
+                <Box>Hello I am some multiline content inside collapse</Box>
+              </Collapse>
+            </BorderBox>
+          </Flex>
+        </Flex>
       </>
     )}
   </Toggler>

--- a/www/content/docs/tokens/Icons.mdx
+++ b/www/content/docs/tokens/Icons.mdx
@@ -1,23 +1,29 @@
 ---
 name: Icons
-hideInNav: true
+wip: true
 ---
 
-<Playground>
-  <CheckIcon />
-</Playground>
+import { AllIcons } from "@artsy/palette"
+import _ from "lodash"
 
-<Playground>
-  <CloseIcon />
-</Playground>
-
-<Playground>
-  <Join separator={<Separator m={1} />}>
-    <ChevronIcon direction="left" />
-    <ChevronIcon direction="right" />
-    <ChevronIcon direction="up" />
-    <ChevronIcon direction="down" />
-    <ChevronIcon direction="rotate(0)" />
-    <ChevronIcon direction="rotate(90)" />
-  </Join>
-</Playground>
+<Flex flexWrap="wrap">
+  {Object.entries(AllIcons).map(([iconName, IconComponent], index) => {
+    const blacklist = ["Icon"]
+    if (
+      !_.isFunction(IconComponent) ||
+      blacklist.some(icon => icon === iconName)
+    ) {
+      return null
+    }
+    const size = "10px"
+    return (
+      <Box pr={4} pb={2} mb={4} key={index}>
+        <Sans size="3" width={size} height={size} weight="medium">
+          {iconName}
+        </Sans>
+        <Spacer my={1} />
+        <IconComponent />
+      </Box>
+    )
+  })}
+</Flex>

--- a/www/content/docs/tokens/Icons.mdx
+++ b/www/content/docs/tokens/Icons.mdx
@@ -6,6 +6,11 @@ wip: true
 import { AllIcons } from "@artsy/palette"
 import _ from "lodash"
 
+See [Notion](https://www.notion.so/artsy/Icons-c49c292a40e243baacd7842a4de983d4)
+for complete list.
+
+<Spacer my={4} />
+
 <Flex flexWrap="wrap">
   {Object.entries(AllIcons).map(([iconName, IconComponent], index) => {
     const blacklist = ["Icon"]
@@ -15,14 +20,14 @@ import _ from "lodash"
     ) {
       return null
     }
-    const size = "10px"
+    const size = "40px"
     return (
       <Box pr={4} pb={2} mb={4} key={index}>
-        <Sans size="3" width={size} height={size} weight="medium">
+        <IconComponent width={size} height={size} />
+        <Separator my={1} />
+        <Sans size="3" weight="medium">
           {iconName}
         </Sans>
-        <Spacer my={1} />
-        <IconComponent />
       </Box>
     )
   })}

--- a/www/content/docs/tokens/Spacing.mdx
+++ b/www/content/docs/tokens/Spacing.mdx
@@ -47,7 +47,7 @@ This means that in practice one should rarely use concrete pixel values:
   </Box>
 </Flex>
 
-### Bad
+### Avoid this
 
 <Playground layout="horizontal">
   <BorderBox mt="10px" p="20px">

--- a/www/src/components/GlobalComponents.jsx
+++ b/www/src/components/GlobalComponents.jsx
@@ -8,7 +8,6 @@ import {
   Box,
   Sans,
   Serif,
-  Spacer,
   injectGlobalStyles,
   color,
   space,

--- a/www/src/components/GlobalComponents.jsx
+++ b/www/src/components/GlobalComponents.jsx
@@ -5,6 +5,7 @@ import * as Palette from "@artsy/palette"
 import { CodeEditor } from "../components/Playground"
 
 import {
+  Box,
   Sans,
   Serif,
   Spacer,
@@ -40,6 +41,7 @@ export const globalCSS = `
 
   div {
     &.contentDiv {
+      margin-top: ${space(2)}px;
       margin-bottom: ${space(2)}px;
     }
   }
@@ -66,36 +68,32 @@ export const { GlobalStyles } = injectGlobalStyles(`
  */
 export const MarkdownComponents = {
   h1: props => (
-    <>
+    <Box mb={5}>
       <Serif size="8" color="black100">
         {props.children}
       </Serif>
-      <Spacer mb={5} />
-    </>
+    </Box>
   ),
   h2: props => (
-    <>
+    <Box my={2}>
       <Sans size="5" weight="medium" color="black100">
         {props.children}
       </Sans>
-      <Spacer mb={1} />
-    </>
+    </Box>
   ),
   h3: props => (
-    <>
+    <Box my={2}>
       <Sans size="4" weight="medium" color="black100">
         {props.children}
       </Sans>
-      <Spacer mb={1} />
-    </>
+    </Box>
   ),
   h4: props => (
-    <>
+    <Box my={2}>
       <Serif size="4" color="black100">
         {props.children}
       </Serif>
-      <Spacer mb={1} />
-    </>
+    </Box>
   ),
   div: props => {
     return <div className="contentDiv">{props.children}</div>

--- a/www/src/components/Playground.jsx
+++ b/www/src/components/Playground.jsx
@@ -28,6 +28,7 @@ export const CodeEditor = withMDXScope(
     language = "html",
     layout = "vertical",
     scope,
+    showEditor = true,
     showPreview = true,
     showToggle = false,
     title,
@@ -62,11 +63,13 @@ export const CodeEditor = withMDXScope(
                 </>
               )}
 
-              <EditorContainer px={2}>
-                <ArtsyCodeTheme editable={editable}>
-                  <LiveEditor {...{ language }} />
-                </ArtsyCodeTheme>
-              </EditorContainer>
+              {showEditor && (
+                <EditorContainer px={2}>
+                  <ArtsyCodeTheme editable={editable}>
+                    <LiveEditor {...{ language }} />
+                  </ArtsyCodeTheme>
+                </EditorContainer>
+              )}
             </Box>
           )
         }
@@ -84,11 +87,13 @@ export const CodeEditor = withMDXScope(
                 </PreviewContainer>
               )}
 
-              <EditorContainer width="50%" pl={2}>
-                <ArtsyCodeTheme editable={editable}>
-                  <LiveEditor {...{ language }} />
-                </ArtsyCodeTheme>
-              </EditorContainer>
+              {showEditor && (
+                <EditorContainer width="50%" pl={2}>
+                  <ArtsyCodeTheme editable={editable}>
+                    <LiveEditor {...{ language }} />
+                  </ArtsyCodeTheme>
+                </EditorContainer>
+              )}
             </Flex>
           )
         }


### PR DESCRIPTION
Makes icons (mostly) consistent by wrapping them in a base component. 

<img width="818" alt="screen shot 2019-02-03 at 9 17 20 pm" src="https://user-images.githubusercontent.com/236943/52191419-58b35b00-27f9-11e9-8737-986a6e1b0dd6.png">
