### PR TITLE
Expand first level nav items on load

### DIFF
--- a/www/content/docs/components/index.mdx
+++ b/www/content/docs/components/index.mdx
@@ -1,4 +1,5 @@
 ---
 name: Components
 order: 4
+expandSubNav: true
 ---

--- a/www/content/docs/elements/index.mdx
+++ b/www/content/docs/elements/index.mdx
@@ -1,6 +1,7 @@
 ---
 name: Elements
 order: 3
+expandSubNav: true
 navSpacer:
   mt: 0
 ---

--- a/www/content/docs/tokens/index.mdx
+++ b/www/content/docs/tokens/index.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tokens
 order: 2
-expandSubNav: false
+expandSubNav: true
 ---
 
 All about tokens

--- a/www/content/docs/utilities/index.mdx
+++ b/www/content/docs/utilities/index.mdx
@@ -2,6 +2,7 @@
 name: Utilities
 order: 4
 wip: true
+expandSubNav: true
 navSpacer:
   mt: 1
 ---

--- a/www/src/components/Sidebar/NavTree.tsx
+++ b/www/src/components/Sidebar/NavTree.tsx
@@ -91,6 +91,7 @@ function renderNavTree(tree: TreeNode[], treeDepth: number = 0) {
                       */}
                       <NavLink
                         disableNavigation
+                        expandSubNav={expandSubNav}
                         to={path}
                         onClick={() => {
                           navState.toggleNavItem(path)
@@ -203,8 +204,13 @@ const NavLinkWrapper = ({
   }
 }
 
-const NavLink = styled(NavLinkWrapper)`
-  cursor: pointer;
+const NavLink = styled(NavLinkWrapper)<{ expandSubNav?: boolean }>`
+  ${({ expandSubNav }) => {
+    const cursor = expandSubNav ? "initial" : "pointer"
+    return `
+      cursor: ${cursor};
+    `
+  }}
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
Make discovery a bit easier. 

<img width="710" alt="screen shot 2019-02-04 at 10 04 21 am" src="https://user-images.githubusercontent.com/236943/52227409-49b5c280-2864-11e9-9e00-c0ca2ffcd513.png">

