### PR TITLE
Fix yarn linking with docs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,19 +6,21 @@
       "@babel/env",
       {
         "targets": {
-          "browsers": [
-            "last 2 versions"
-          ]
+          "browsers": ["last 2 versions"]
         }
       }
     ]
   ],
   "plugins": [
     "babel-plugin-add-react-displayname",
+    "babel-plugin-styled-components",
     "@babel/plugin-proposal-class-properties",
-    ["module-resolver", {
-      "extensions": [".ts", ".tsx"],
-      "root": ["./src"]
-    }]
+    [
+      "module-resolver",
+      {
+        "extensions": [".ts", ".tsx"],
+        "root": ["./src"]
+      }
+    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "typescript-styled-plugin": "^0.10.0"
   },
   "dependencies": {
+    "babel-plugin-styled-components": "^1.10.0",
     "moment": "^2.23.0",
     "moment-timezone": "^0.5.23",
     "rc-slider": "^8.6.2",

--- a/src/elements/BorderBox/BorderBox.tsx
+++ b/src/elements/BorderBox/BorderBox.tsx
@@ -16,3 +16,5 @@ export const BorderBox = styledWrapper(BorderBoxBase)<BorderBoxProps>`
       }
     `};
 `
+
+BorderBox.displayName = "BorderBox"

--- a/src/elements/Box/Box.tsx
+++ b/src/elements/Box/Box.tsx
@@ -72,3 +72,5 @@ export const Box = primitives.View<BoxProps>`
   ${width};
   ${zIndex};
 `
+
+Box.displayName = "Box"

--- a/src/elements/Flex/Flex.tsx
+++ b/src/elements/Flex/Flex.tsx
@@ -78,3 +78,5 @@ export const Flex = primitives.View<FlexProps>`
   ${bottom};
   ${zIndex};
 `
+
+Flex.displayName = "Flex"

--- a/src/elements/Grid/Grid.tsx
+++ b/src/elements/Grid/Grid.tsx
@@ -34,3 +34,7 @@ export const Col: any = styled(_Col)`
   ${textAlign};
   ${width};
 `
+
+Grid.displayName = "Grid"
+Row.displayName = "Row"
+Col.displayName = "Col"

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -65,3 +65,6 @@ ResponsiveImage.defaultProps = {
   width: "100%",
   ratio: 1,
 }
+
+Image.displayName = "Image"
+ResponsiveImage.displayName = "ResponsiveImage"

--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -27,3 +27,5 @@ export const Link = styled.a<LinkProps>`
   ${space};
   ${styledColor};
 `
+
+Link.displayName = "Link"

--- a/src/elements/Spacer/Spacer.tsx
+++ b/src/elements/Spacer/Spacer.tsx
@@ -10,3 +10,5 @@ export interface SpacerProps extends SpaceProps, WidthProps, HeightProps {}
 export const Spacer: React.SFC<SpacerProps & { id?: string }> = props => {
   return <Box {...props} />
 }
+
+Spacer.displayName = "Spacer"

--- a/src/elements/StackableBorderBox/StackableBorderBox.tsx
+++ b/src/elements/StackableBorderBox/StackableBorderBox.tsx
@@ -26,3 +26,5 @@ export const StackableBorderBox = styledWrapper(BorderBox)<BorderBoxProps>`
     border-bottom-right-radius: 0;
   }
 `
+
+StackableBorderBox.displayName = "StackableBorderBox"

--- a/src/elements/Typography/Typography.tsx
+++ b/src/elements/Typography/Typography.tsx
@@ -274,3 +274,7 @@ export interface DisplayProps extends Partial<TextProps> {
  * <Display color="black10" size="3t">Hi</Display>
  */
 export const Display = createStyledText<DisplayProps>("display")
+
+Sans.displayName = "Sans"
+Serif.displayName = "Serif"
+Display.displayName = "Display"

--- a/src/helpers/__tests__/media.test.ts
+++ b/src/helpers/__tests__/media.test.ts
@@ -2,10 +2,10 @@ import { media } from "../media"
 
 describe("media", () => {
   it("returns the mediaQuery", () => {
-    expect(media.xs``.join("")).toContain("@media (max-width: 767px)")
-    expect(media.sm``.join("")).toContain("@media (max-width: 768px)")
-    expect(media.md``.join("")).toContain("@media (max-width: 900px)")
-    expect(media.lg``.join("")).toContain("@media (max-width: 1024px)")
-    expect(media.xl``.join("")).toContain("@media (max-width: 1192px)")
+    expect(media.xs``.join("")).toContain("@media (max-width:767px)")
+    expect(media.sm``.join("")).toContain("@media (max-width:768px)")
+    expect(media.md``.join("")).toContain("@media (max-width:900px)")
+    expect(media.lg``.join("")).toContain("@media (max-width:1024px)")
+    expect(media.xl``.join("")).toContain("@media (max-width:1192px)")
   })
 })

--- a/src/helpers/injectGlobalStyles.tsx
+++ b/src/helpers/injectGlobalStyles.tsx
@@ -11,30 +11,36 @@ export function injectGlobalStyles<P>(
 ) {
   const GlobalStyles = createGlobalStyle<P>`
     @import url("https://webfonts.artsy.net/all-webfonts.css");
+
     *:focus {
       outline: none;
     }
+
     html {
       -webkit-box-sizing: border-box;
               box-sizing: border-box;
       -ms-overflow-style: scrollbar;
     }
+
     *,
     *::before,
     *::after {
       -webkit-box-sizing: inherit;
               box-sizing: inherit;
     }
+
     html,
     body,
     #root {
       -webkit-tap-highlight-color: transparent;
       height: 100%;
     }
+
     body {
       margin: 0;
       padding: 0;
     }
+
     html, body {
       font-family: 'AGaramondPro-Regular';
       font-size: 16px;
@@ -42,28 +48,36 @@ export function injectGlobalStyles<P>(
       -webkit-font-smoothing: antialiased;
       text-rendering: optimizeLegibility;
     }
+
     /* Default links */
+
     a {
       cursor: pointer;
       color: inherit;
       transition: color 0.25s;
+
       &:hover {
         color: ${color("black100")};
       }
+
       &:active {
         color: ${color("black100")};
       }
+
       /* ts-styled-plugin erroniously parses this; see: */
       /* https://github.com/Microsoft/typescript-styled-plugin/issues/54 */
       &.noUnderline {
         ${noUnderline};
       }
+
       &.colorLink {
         ${noUnderline};
         ${colorLink};
       }
     }
+
     /* <Sans /> links */
+
     ${Sans} {
       a {
         color: inherit;
@@ -82,7 +96,9 @@ export function injectGlobalStyles<P>(
         }
       }
     }
+
     /* <Serif /> links */
+
     ${Serif} {
       a {
         color: inherit;
@@ -101,17 +117,19 @@ export function injectGlobalStyles<P>(
         }
       }
     }
+
     /* <Display /> links */
+
     ${Display} {
       a {
         color: ${color("black100")};
         text-decoration: none;
-        text-transform: uppercase;
         &:hover {
           text-decoration: underline;
         }
       }
     }
+
     ${additionalStyles};
   `
 

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -107,6 +107,9 @@ exports.onCreateWebpackConfig = ({ actions }) => {
     ],
     resolve: {
       modules: [path.resolve(__dirname, "src"), "node_modules"],
+      alias: {
+        "styled-components": require.resolve("styled-components"),
+      },
     },
   })
 }

--- a/www/package.json
+++ b/www/package.json
@@ -66,7 +66,7 @@
     "webpack-shell-plugin": "^0.5.0"
   },
   "dependencies": {
-    "@artsy/palette": "^3.0.0",
+    "@artsy/palette": "^3.0.2",
     "@babel/core": "^7.2.2",
     "@mdx-js/mdx": "^0.16.6",
     "@mdx-js/tag": "^0.16.6",

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@artsy/palette@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-3.0.0.tgz#9b1a3778f39611c298ca57f57a5bbc71731e7c87"
-  integrity sha512-dM1vO9zy7sCpewXKqHrBk9gY6Lbtj664yaoATrlOZwHCJD9FNQs1rrEp/oRDE8s973hhX32VUhMErwa+duLAfg==
+"@artsy/palette@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-3.0.2.tgz#b534ef4a669bf55a798f9676ec946cbdddb5065e"
+  integrity sha512-1nKT6sHNsyfkA6SzhEBtm+jqNlnCfr0UVcKVVloX2Fp0RCEmrf8blcsATOnzXjnX26JJldcOxol7gH4tU/S3OA==
   dependencies:
     moment "^2.23.0"
     moment-timezone "^0.5.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,7 +1581,7 @@ babel-plugin-react-transform@^3.0.0:
   dependencies:
     lodash "^4.6.1"
 
-"babel-plugin-styled-components@>= 1":
+"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
   integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==


### PR DESCRIPTION
Fixes `yarn link` when working in docs by enforcing styled-components resolution to `www/node_modules/styled-components`. 

Also add babel-plugin-styled-components so we can see styled components' displayNames when looking at the dom. 