### PR TITLE
Add `label` prop to Radio

### DIFF
--- a/src/elements/Radio/Radio.tsx
+++ b/src/elements/Radio/Radio.tsx
@@ -78,17 +78,17 @@ export const Radio: React.SFC<RadioProps> = props => {
       >
         <InnerCircle />
       </RadioButton>
-      <HiddenInput
-        type="radio"
-        name={name}
-        checked={selected}
-        disabled={disabled}
-        onChange={() =>
-          !disabled && onSelect && onSelect({ selected: !selected, value })
-        }
-      />
       <Flex flexDirection="column">
-        <Label htmlFor={name} disabled={disabled}>
+        <Label disabled={disabled}>
+          <HiddenInput
+            type="radio"
+            name={name}
+            checked={selected}
+            disabled={disabled}
+            onChange={() =>
+              !disabled && onSelect && onSelect({ selected: !selected, value })
+            }
+          />
           {label ? label : children}
         </Label>
         {label ? children : null}

--- a/src/elements/Radio/Radio.tsx
+++ b/src/elements/Radio/Radio.tsx
@@ -28,6 +28,8 @@ export interface RadioProps extends FlexProps {
   value?: string
   /** Name of the radio button */
   name?: string
+  /** The label content, if not specified the children will be used  */
+  label?: React.ReactNode
 }
 
 export interface RadioToggleProps
@@ -50,6 +52,7 @@ export const Radio: React.SFC<RadioProps> = props => {
     onSelect,
     selected,
     value,
+    label,
     ...others
   } = props
 
@@ -84,9 +87,12 @@ export const Radio: React.SFC<RadioProps> = props => {
           !disabled && onSelect && onSelect({ selected: !selected, value })
         }
       />
-      <Label htmlFor={name} disabled={disabled}>
-        {children}
-      </Label>
+      <Flex flexDirection="column">
+        <Label htmlFor={name} disabled={disabled}>
+          {label ? label : children}
+        </Label>
+        {label ? children : null}
+      </Flex>
     </Container>
   )
 }

--- a/www/content/docs/elements/inputs/Radio.mdx
+++ b/www/content/docs/elements/inputs/Radio.mdx
@@ -5,27 +5,23 @@ name: Radio
 <Playground title="With state">
   <Toggler>
     {({ on, toggle }) => (
-      <Radio selected={on} onSelect={toggle}>
-        Click me
-      </Radio>
+      <Radio selected={on} onSelect={toggle} label="Click me" />
     )}
   </Toggler>
 </Playground>
 
 <Playground title="Hover">
-  <Radio hover>Click me</Radio>
+  <Radio hover label="Click me" />
 </Playground>
 
 <Playground title="Selected">
-  <Radio selected>Selected</Radio>
+  <Radio selected label="Selected" />
 </Playground>
 
 <Playground title="Disabled">
-  <Radio disabled>Disabled</Radio>
+  <Radio disabled label="Disabled" />
 </Playground>
 
 <Playground title="Selected and disabled">
-  <Radio selected disabled>
-    Disabled
-  </Radio>
+  <Radio selected disabled label="Disabled" />
 </Playground>

--- a/www/content/docs/elements/inputs/RadioGroup.mdx
+++ b/www/content/docs/elements/inputs/RadioGroup.mdx
@@ -7,9 +7,8 @@ additional consecutive decisions, or may reveal additional information.
 
 <Playground>
   <RadioGroup defaultValue="SHIP">
-    <BorderedRadio value="SHIP">Provide shipping address</BorderedRadio>
-    <BorderedRadio value="PICKUP">
-      Arrange for pickup
+    <BorderedRadio value="SHIP" label="Provide shipping address" />
+    <BorderedRadio value="PICKUP" label="Arrange for pickup">
       <Sans size="2" color="black60">
         After you place your order, you’ll be appointed an Artsy Specialist
         within 2 business days to handle pickup logistics.
@@ -20,8 +19,8 @@ additional consecutive decisions, or may reveal additional information.
 
 <Playground>
   <RadioGroup>
-    <Radio value="SHIP">Provide shipping address</Radio>
-    <Radio value="PICKUP">Arrange for pickup</Radio>
+    <Radio value="SHIP" label="Provide shipping address" />
+    <Radio value="PICKUP" label="Arrange for pickup" />
   </RadioGroup>
 </Playground>
 
@@ -29,8 +28,8 @@ additional consecutive decisions, or may reveal additional information.
 
 <Playground>
   <RadioGroup defaultValue="PICKUP">
-    <Radio value="SHIP">Provide shipping address</Radio>
-    <Radio value="PICKUP">Arrange for pickup</Radio>
+    <Radio value="SHIP" label="Provide shipping address" />
+    <Radio value="PICKUP" label="Arrange for pickup" />
   </RadioGroup>
 </Playground>
 
@@ -38,7 +37,7 @@ additional consecutive decisions, or may reveal additional information.
 
 <Playground>
   <RadioGroup defaultValue="SHIP" disabled>
-    <Radio value="SHIP">Provide shipping address</Radio>
-    <Radio value="PICKUP">Arrange for pickup</Radio>
+    <Radio value="SHIP" label="Provide shipping address" />
+    <Radio value="PICKUP" label="Arrange for pickup" />
   </RadioGroup>
 </Playground>


### PR DESCRIPTION
This is a backwards compatible change to improve the API of the `Radio` element

## Why?

Before this PR, anything you pass to the `children` of a `Radio` will be dumped inside a `<label>`. This is bad semantically if you start putting other form elements in there, because the first of those inputs becomes the *labelled input*.  Obviously the radio button should be the labelled input, not any text boxes or other controls you put inside it.

This also causes weird interactions in mobile safari where tapping anything inside the label focuses on the first input inside the label, meaning you can't focus on the second input if there is one (which there is in one of our flows).

## How?

I added another prop which can be used to explicitly set the `label` content. If you pass this prop *and* children, then the children will be rendered *outside* of the `label`. To preserve backwards-compatibility, if you supply only children they will be rendered inside the `label`.

I would suggest adding a warning for supplying `children` but no `label` to prevent people having these issues in the future and to force us to migrate existing usages or `Radio` to this new style. Not sure if we have a pattern for that kind of thing or whether we'd prefer to migrate first and then add an error later?