### PR TITLE
[wip] fix nested collapse edge case

### DIFF
--- a/www/content/docs/elements/layout/Collapse.mdx
+++ b/www/content/docs/elements/layout/Collapse.mdx
@@ -54,3 +54,39 @@ See https://react-spring.surge.sh/gotchas#animating-auto for more info.
     )}
   </Toggler>
 </Playground>
+
+## Nested collapses edge case
+
+<Playground>
+  <Toggler initial={true}>
+    {({ on, toggle }) => (
+      <Toggler initial={true}>
+        {({ on: on2, toggle: toggle2 }) => (
+          <BorderBox position="relative" flexDirection="column">
+            <Flex justifyContent="space-between">
+              <Serif size="3">Outer</Serif>
+              <Button size="small" onClick={() => toggle()}>
+                {on ? "close" : "open"}
+              </Button>
+            </Flex>
+            <Collapse open={on}>
+              <BorderBox position="relative" flexDirection="column" mt={2}>
+                <Flex justifyContent="space-between">
+                  <Serif size="3">Inner</Serif>
+                  <Button size="small" onClick={() => toggle2()}>
+                    {on2 ? "close" : "open"}
+                  </Button>
+                </Flex>
+                <Collapse open={on2}>
+                  <BorderBox mt={2}>
+                    <Sans size="2"> hello world! </Sans>
+                  </BorderBox>
+                </Collapse>
+              </BorderBox>
+            </Collapse>
+          </BorderBox>
+        )}
+      </Toggler>
+    )}
+  </Toggler>
+</Playground>


### PR DESCRIPTION
I encountered this weird behaviour with nested Collapses while working on some MO stuff. Haven't managed to find a workaround, so this is how it behaves in production right now 😢 

Tried various ways to use `position="relative"` around the collapses, but no luck. Seems like the outer collapse is ignoring the height of the inner collapse, but can't imagine why.

![bad-collapse](https://user-images.githubusercontent.com/1242537/52855237-b8263a80-3118-11e9-85b9-eaa299dea427.gif)

