### PR TITLE
Stop palette from automatically including all-webfonts.css

### DIFF
--- a/src/helpers/injectGlobalStyles.tsx
+++ b/src/helpers/injectGlobalStyles.tsx
@@ -10,7 +10,6 @@ export function injectGlobalStyles<P>(
   additionalStyles?: string | ReturnType<typeof css>
 ) {
   const GlobalStyles = createGlobalStyle<P>`
-    @import url("https://webfonts.artsy.net/all-webfonts.css");
 
     *:focus {
       outline: none;

--- a/www/content/docs/home/getting-started.mdx
+++ b/www/content/docs/home/getting-started.mdx
@@ -2,6 +2,7 @@
 name: Getting started
 hideInNav: false
 ---
+
 ### Adding Palette
 
 To bring Palette into your app, install it as a package:
@@ -22,7 +23,7 @@ const { GlobalStyles } = injectGlobalStyles(`
 
 export const App = props => {
   return (
-    <Theme>      
+    <Theme>
       <>
         <GlobalStyles />
         ...
@@ -55,4 +56,25 @@ const Artworks = props => {
     </Flex>
   )
 }
+```
+
+In order to use Artsy's fonts, you'll also want to add our webfont file to the
+CSS in the header of your app:
+
+```
+// Example using Styled Components:
+import { createGlobalStyle, css } from "styled-components"
+
+const GlobalStyles = createGlobalStyle<P>`
+  @import url("https://webfonts.artsy.net/all-webfonts.css");
+`
+
+// React Helmet example:
+<Helmet>
+  <link
+    href="https://webfonts.artsy.net/all-webfonts.css"
+    rel="stylesheet"
+    type="text/css"
+  />
+</Helmet>
 ```

--- a/www/content/docs/home/getting-started.mdx
+++ b/www/content/docs/home/getting-started.mdx
@@ -59,17 +59,29 @@ const Artworks = props => {
 ```
 
 In order to use Artsy's fonts, you'll also want to add our webfont file to the
-CSS in the header of your app:
+CSS in the header of your app. Here are a few examples:
+
+### Using [react-head](https://github.com/tizmagik/react-head) (see [here](https://github.com/tizmagik/react-head/tree/master/example) for more examples)
 
 ```
-// Example using Styled Components:
-import { createGlobalStyle, css } from "styled-components"
+import { HeadProvider, Link } from 'react-head';
 
-const GlobalStyles = createGlobalStyle<P>`
-  @import url("https://webfonts.artsy.net/all-webfonts.css");
-`
+const App = () => (
+  <HeadProvider>
+    <Link
+      href="https://webfonts.artsy.net/all-webfonts.css"
+      rel="stylesheet"
+      type="text/css"
+    />
+  </HeadProvider>
+);
+```
 
-// React Helmet example:
+### Using [React Helmet](https://github.com/nfl/react-helmet)
+
+```
+import {Helmet} from "react-helmet";
+
 <Helmet>
   <link
     href="https://webfonts.artsy.net/all-webfonts.css"
@@ -77,4 +89,14 @@ const GlobalStyles = createGlobalStyle<P>`
     type="text/css"
   />
 </Helmet>
+```
+
+### Using [Styled Components](https://www.styled-components.com/docs/api#createglobalstyle)
+
+```
+import { createGlobalStyle } from "styled-components"
+
+const GlobalStyles = createGlobalStyle`
+  @import url("https://webfonts.artsy.net/all-webfonts.css");
+`
 ```

--- a/www/src/layouts/DefaultLayout.tsx
+++ b/www/src/layouts/DefaultLayout.tsx
@@ -25,6 +25,11 @@ export default function DocsLayout(props) {
       <Flex maxWidth="1200px" style={{ margin: "0 auto" }}>
         <Helmet defaultTitle="Palette" titleTemplate="Palette | %s">
           <title>{name}</title>
+          <link
+            href="https://webfonts.artsy.net/all-webfonts.css"
+            rel="stylesheet"
+            type="text/css"
+          />
         </Helmet>
         <Sidebar />
         <ContentArea flexDirection="column" pt={4} px={6}>


### PR DESCRIPTION
@damassi noticed that Force was making two calls to get all-webfonts.css as a result of the file being referenced both there and in Palette. To keep Palette flexible and prevent duplicate calls, we removed the automatic import from Palette's global styles and instead made it a call in our Gatsby site.