### PR TITLE
Improve Link API

### DIFF
--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -18,6 +18,7 @@ const computeUnderline = (state: string, behavior: UnderlineBehavior): string =>
 export interface LinkProps extends SpaceProps {
   underlineBehavior: UnderlineBehavior
   color?: Color
+  hoverColor?: Color
 }
 
 /**
@@ -30,10 +31,7 @@ export const Link = styled.a<LinkProps>`
   text-decoration: ${props => (computeUnderline("normal", props.underlineBehavior))};
   &:hover {
     text-decoration: ${props => (computeUnderline("hover", props.underlineBehavior))};
-    color: ${color("black100")};
-  }
-  &:focus {
-    color: ${props => (props.color ? color(props.color) : color("black100"))};
+    color: ${props => props.hoverColor ? color(props.hoverColor) : color("black100")};
   }
   ${space};
   ${styledColor};

--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -15,10 +15,16 @@ const computeUnderline = (state: string, behavior: UnderlineBehavior): string =>
   return none ? "none" : "underline"
 }
 
+const backwardsCompatCompute = (state: string, props: LinkProps) => {
+  const behavior = props.noUnderline ? UnderlineBehavior.Hover : props.underlineBehavior
+  return computeUnderline(state, behavior)
+}
+
 export interface LinkProps extends SpaceProps {
-  underlineBehavior: UnderlineBehavior
   color?: Color
   hoverColor?: Color
+  noUnderline?: boolean
+  underlineBehavior: UnderlineBehavior
 }
 
 /**
@@ -28,9 +34,9 @@ export interface LinkProps extends SpaceProps {
 export const Link = styled.a<LinkProps>`
   color: ${color("black100")};
   transition: color 0.25s;
-  text-decoration: ${props => (computeUnderline("normal", props.underlineBehavior))};
+  text-decoration: ${props => (backwardsCompatCompute("normal", props))};
   &:hover {
-    text-decoration: ${props => (computeUnderline("hover", props.underlineBehavior))};
+    text-decoration: ${props => (backwardsCompatCompute("hover", props))};
     color: ${props => props.hoverColor ? color(props.hoverColor) : color("black100")};
   }
   ${space};

--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -3,8 +3,20 @@ import { color as styledColor, space, SpaceProps } from "styled-system"
 import { color } from "../../helpers"
 import { Color } from "../../Theme"
 
+enum UnderlineBehavior {
+  Default = "default",
+  Hover = "hover",
+  None = "none",
+}
+
+const computeUnderline = (state: string, behavior: UnderlineBehavior): string => {
+  const blocklist: UnderlineBehavior[] = state === "hover" ? [UnderlineBehavior.None] : [UnderlineBehavior.Hover, UnderlineBehavior.None]
+  const none = blocklist.includes(behavior)
+  return none ? "none" : "underline"
+}
+
 export interface LinkProps extends SpaceProps {
-  noUnderline?: boolean
+  underlineBehavior: UnderlineBehavior
   color?: Color
 }
 
@@ -15,10 +27,9 @@ export interface LinkProps extends SpaceProps {
 export const Link = styled.a<LinkProps>`
   color: ${color("black100")};
   transition: color 0.25s;
-  text-decoration: ${props =>
-    props.noUnderline || props.color ? "none" : "underline"};
+  text-decoration: ${props => (computeUnderline("normal", props.underlineBehavior))};
   &:hover {
-    text-decoration: ${props => (props.color ? "none" : "underline")};
+    text-decoration: ${props => (computeUnderline("hover", props.underlineBehavior))};
     color: ${color("black100")};
   }
   &:focus {
@@ -29,3 +40,7 @@ export const Link = styled.a<LinkProps>`
 `
 
 Link.displayName = "Link"
+
+Link.defaultProps = {
+  underlineBehavior: UnderlineBehavior.Default
+}

--- a/www/content/docs/elements/buttons/Link.mdx
+++ b/www/content/docs/elements/buttons/Link.mdx
@@ -7,8 +7,8 @@ never be a suprise functionality within a string of text. Use strategic product
 judgement when deciding which link style (underline, no-underline) is
 appropriate.
 
-Underline is more visible and should therefore be used in the presence with lots
-of static text.
+Underline is more visible and should therefore be used in the presence with
+lots of static text.
 
 <BorderBox width="100%" justifyContent="center">
   <Serif size="3">
@@ -18,24 +18,30 @@ of static text.
 
 <Spacer my={4} />
 
-The prop `noUnderline` should be used when there is available dedicated space,
-many links together, with low chance of confusion for static text.
+The prop `underline` can be set to three values:
+
+* default - link has underline
+* none - link has no underline
+* hover - link has underline only on hover
+
+The `hover` value should be used when there is available dedicated space, many
+links together, with low chance of confusion for static text.
 
 <Playground>
   <Flex justifyContent="center">
     <Flex width="30%" justifyContent="space-between">
-      <Link href="#" noUnderline={true}>
+      <Link href="#" underlineBehavior="hover">
         Delete artwork
       </Link>
-      <Link href="#" noUnderline={true}>
+      <Link href="#" underlineBehavior="hover">
         Publish artwork
       </Link>
     </Flex>
   </Flex>
 </Playground>
 
-Use color-link when needing to call attention to something vital and a button
-isn’t compositionally appropriate. Use sparingly.
+The `none` value should be used with a color to call attention to something
+vital and a button isn’t compositionally appropriate. Use sparingly.
 
 <Playground layout="vertical">
   <Flex justifyContent="center">
@@ -47,7 +53,7 @@ isn’t compositionally appropriate. Use sparingly.
           </Sans>
           <Sans size="2">Subtitle</Sans>
         </Box>
-        <Link href="#" color="purple100" noUnderline>
+        <Link href="#" color="purple100" underlineBehavior="none">
           Edit
         </Link>
       </Flex>

--- a/www/content/docs/elements/buttons/Link.mdx
+++ b/www/content/docs/elements/buttons/Link.mdx
@@ -69,7 +69,7 @@ the same color, supply both:
   <Flex justifyContent="center">
     <Box width="30%" bg="black100" p={3}>
       <Link href="#" color="white100" hoverColor="white100">
-        <Serif>This link text is always white.</Serif>
+        <Serif size="2">This link text is always white.</Serif>
       </Link>
     </Box>
   </Flex>

--- a/www/content/docs/elements/buttons/Link.mdx
+++ b/www/content/docs/elements/buttons/Link.mdx
@@ -18,7 +18,7 @@ lots of static text.
 
 <Spacer my={4} />
 
-The prop `underline` can be set to three values:
+The prop `underlineBehavior` can be set to three values:
 
 * default - link has underline
 * none - link has no underline

--- a/www/content/docs/elements/buttons/Link.mdx
+++ b/www/content/docs/elements/buttons/Link.mdx
@@ -40,7 +40,7 @@ links together, with low chance of confusion for static text.
   </Flex>
 </Playground>
 
-The `none` value should be used with a color to call attention to something
+The `none` value should be used with a `color` to call attention to something
 vital and a button isn’t compositionally appropriate. Use sparingly.
 
 <Playground layout="vertical">
@@ -58,5 +58,19 @@ vital and a button isn’t compositionally appropriate. Use sparingly.
         </Link>
       </Flex>
     </BorderBox>
+  </Flex>
+</Playground>
+
+By default link text is `black100` normally and on hover. If you supply a
+color, the hover defaults to `black100`, so if you want the link to always be
+the same color, supply both:
+
+<Playground layout="vertical">
+  <Flex justifyContent="center">
+    <Box width="30%" bg="black100" p={3}>
+      <Link href="#" color="white100" hoverColor="white100">
+        <Serif>This link text is always white.</Serif>
+      </Link>
+    </Box>
   </Flex>
 </Playground>


### PR DESCRIPTION
After some thought, I took a stab at what I think the API should be for a Link. The problems I'm trying to solve here are how one controls the underline and color properties together and separately. These concepts were intermingled in a way that @pepopowitz and I found difficult to work with - hopefully this is better!! ❤️ 

## Underline behavior

The first thing I did was extract an enum for the three types of underline behaviors I saw:

* underline the link all the time (default)
* never underline the link (none)
* underline the link on hover (hover)

And I added a prop called `underlineBehavior` to replace the `noUnderline` prop. If you were using that prop, it maps to the `hover` value of `underlineBehavior`.

## Color and hover color

Next I looked at how I could improve dealing with color. We want our links to be black by default and when a color is provided, we want a hover effect that transitions to black. That works great unless you want to run the link over something that is also black. Or my use case which was running the link over an image with an overlay. In those cases, we just always want the link to be white.

So, my solution here was to add a new prop called `hoverColor` that will override the default behavior of changing the color of the link on hover to black.

Then I updated the docs to reflect this and showed off the various ways these things can be used.

Would love any feedback on the approach!! 😍 