### PR TITLE
[Link] Make underlineBehavior optional

### DIFF
--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -9,22 +9,30 @@ enum UnderlineBehavior {
   None = "none",
 }
 
-const computeUnderline = (state: string, behavior: UnderlineBehavior): string => {
-  const blocklist: UnderlineBehavior[] = state === "hover" ? [UnderlineBehavior.None] : [UnderlineBehavior.Hover, UnderlineBehavior.None]
+export interface LinkProps extends SpaceProps {
+  color?: Color
+  hoverColor?: Color
+  noUnderline?: boolean
+  underlineBehavior?: UnderlineBehavior
+}
+
+const computeUnderline = (
+  state: string,
+  behavior: UnderlineBehavior
+): string => {
+  const blocklist: UnderlineBehavior[] =
+    state === "hover"
+      ? [UnderlineBehavior.None]
+      : [UnderlineBehavior.Hover, UnderlineBehavior.None]
   const none = blocklist.includes(behavior)
   return none ? "none" : "underline"
 }
 
 const backwardsCompatCompute = (state: string, props: LinkProps) => {
-  const behavior = props.noUnderline ? UnderlineBehavior.Hover : props.underlineBehavior
+  const behavior = props.noUnderline
+    ? UnderlineBehavior.Hover
+    : props.underlineBehavior
   return computeUnderline(state, behavior)
-}
-
-export interface LinkProps extends SpaceProps {
-  color?: Color
-  hoverColor?: Color
-  noUnderline?: boolean
-  underlineBehavior: UnderlineBehavior
 }
 
 /**
@@ -34,10 +42,11 @@ export interface LinkProps extends SpaceProps {
 export const Link = styled.a<LinkProps>`
   color: ${color("black100")};
   transition: color 0.25s;
-  text-decoration: ${props => (backwardsCompatCompute("normal", props))};
+  text-decoration: ${props => backwardsCompatCompute("normal", props)};
   &:hover {
-    text-decoration: ${props => (backwardsCompatCompute("hover", props))};
-    color: ${props => props.hoverColor ? color(props.hoverColor) : color("black100")};
+    text-decoration: ${props => backwardsCompatCompute("hover", props)};
+    color: ${props =>
+      props.hoverColor ? color(props.hoverColor) : color("black100")};
   }
   ${space};
   ${styledColor};
@@ -46,5 +55,5 @@ export const Link = styled.a<LinkProps>`
 Link.displayName = "Link"
 
 Link.defaultProps = {
-  underlineBehavior: UnderlineBehavior.Default
+  underlineBehavior: UnderlineBehavior.Default,
 }


### PR DESCRIPTION
Noticed type failures over [in reaction](https://circleci.com/gh/artsy/reaction/28523?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). 

Also @jonallured, noticed that Prettier wasn't applied to the code which makes me think your repo environment is configured incorrectly. It's totally cool to have prettier disabled in in yr editor but make sure that githooks work and that all commits are processed by them. There are [quite a few](https://github.com/artsy/palette/blob/master/package.json#L105-L117) checks and auto-fixers that take place before code can be committed and / or pushed, most importantly type-checking. This also applies to Reaction, Force and Positron, where we have a similar husky githook-based setup. 