### PR TITLE
Make underlineBehavior simpler for consumers

### DIFF
--- a/src/elements/Link/Link.tsx
+++ b/src/elements/Link/Link.tsx
@@ -3,35 +3,27 @@ import { color as styledColor, space, SpaceProps } from "styled-system"
 import { color } from "../../helpers"
 import { Color } from "../../Theme"
 
-enum UnderlineBehavior {
-  Default = "default",
-  Hover = "hover",
-  None = "none",
-}
+type UnderlineBehaviors = "default" | "hover" | "none"
 
 export interface LinkProps extends SpaceProps {
   color?: Color
   hoverColor?: Color
   noUnderline?: boolean
-  underlineBehavior?: UnderlineBehavior
+  underlineBehavior?: UnderlineBehaviors
 }
 
 const computeUnderline = (
   state: string,
-  behavior: UnderlineBehavior
+  behavior: UnderlineBehaviors
 ): string => {
-  const blocklist: UnderlineBehavior[] =
-    state === "hover"
-      ? [UnderlineBehavior.None]
-      : [UnderlineBehavior.Hover, UnderlineBehavior.None]
+  const blocklist: UnderlineBehaviors[] =
+    state === "hover" ? ["none"] : ["hover", "none"]
   const none = blocklist.includes(behavior)
   return none ? "none" : "underline"
 }
 
 const backwardsCompatCompute = (state: string, props: LinkProps) => {
-  const behavior = props.noUnderline
-    ? UnderlineBehavior.Hover
-    : props.underlineBehavior
+  const behavior = props.noUnderline ? "hover" : props.underlineBehavior
   return computeUnderline(state, behavior)
 }
 
@@ -55,5 +47,5 @@ export const Link = styled.a<LinkProps>`
 Link.displayName = "Link"
 
 Link.defaultProps = {
-  underlineBehavior: UnderlineBehavior.Default,
+  underlineBehavior: "default",
 }

--- a/src/helpers/injectGlobalStyles.tsx
+++ b/src/helpers/injectGlobalStyles.tsx
@@ -54,6 +54,7 @@ export function injectGlobalStyles<P>(
       cursor: pointer;
       color: inherit;
       transition: color 0.25s;
+      text-decoration: underline;
 
       &:hover {
         color: ${color("black100")};
@@ -122,7 +123,6 @@ export function injectGlobalStyles<P>(
     ${Display} {
       a {
         color: ${color("black100")};
-        text-decoration: none;
         &:hover {
           text-decoration: underline;
         }

--- a/www/content/docs/elements/buttons/Link.mdx
+++ b/www/content/docs/elements/buttons/Link.mdx
@@ -7,8 +7,8 @@ never be a suprise functionality within a string of text. Use strategic product
 judgement when deciding which link style (underline, no-underline) is
 appropriate.
 
-Underline is more visible and should therefore be used in the presence with
-lots of static text.
+Underline is more visible and should therefore be used in the presence with lots
+of static text.
 
 <BorderBox width="100%" justifyContent="center">
   <Serif size="3">
@@ -20,9 +20,9 @@ lots of static text.
 
 The prop `underlineBehavior` can be set to three values:
 
-* default - link has underline
-* none - link has no underline
-* hover - link has underline only on hover
+- default - link has underline
+- none - link has no underline
+- hover - link has underline only on hover
 
 The `hover` value should be used when there is available dedicated space, many
 links together, with low chance of confusion for static text.
@@ -61,9 +61,9 @@ vital and a button isn’t compositionally appropriate. Use sparingly.
   </Flex>
 </Playground>
 
-By default link text is `black100` normally and on hover. If you supply a
-color, the hover defaults to `black100`, so if you want the link to always be
-the same color, supply both:
+By default link text is `black100` normally and on hover. If you supply a color,
+the hover defaults to `black100`, so if you want the link to always be the same
+color, supply both:
 
 <Playground layout="vertical">
   <Flex justifyContent="center">


### PR DESCRIPTION
Noticed another issue when updating API in reaction - by using an `enum` it forces consumers to pass enums to define the behavior, e.g., `underlineBehavior={UnderlineBehavior.NONE}`, which is a bit verbose. 

```sh
ERROR in /Users/cn/Sites/artsy/reaction/src/Components/NavBar/NavItem.tsx
29:44 Type '"none"' is not assignable to type 'UnderlineBehavior'.
    27 |       onMouseLeave={() => toggleHover(false)}
    28 |     >
  > 29 |       <Link href={href} color={hoverColor} underlineBehavior="none">
```

While strings and enums can be compared within code, passing a string as an prop !== enum.string, unless it's coerced. Also fixes a possible regression where underline behavior wasn't being applied by default in our global styles. It's not apparent in Force because we already have a global set of styles, but in Storybooks I noticed body copy links weren't being underlined. 