### PR TITLE
Add prettier check

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "tslint \"src/*\" -c tslint.json tsconfig.json",
     "prepublishOnly": "yarn clean && yarn compile && yarn type-declarations",
     "prettier": "prettier",
+    "prettier-check": "prettier --check 'src/**/*.{ts,tsx}'",
     "prettier-project": "yarn prettier-write 'src/**/*.{ts,tsx}'",
     "prettier-write": "yarn prettier --write",
     "release": "auto shipit",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs": "cd www && yarn install && yarn start",
     "docs:build": "cd www && yarn build",
     "generate-tokens": "ts-node scripts/generate-tokens.ts",
-    "lint": "tslint \"src/*\" -c tslint.json tsconfig.json",
+    "lint": "tslint \"src/*\" -c tslint.json tsconfig.json && yarn prettier-check",
     "prepublishOnly": "yarn clean && yarn compile && yarn type-declarations",
     "prettier": "prettier",
     "prettier-check": "prettier --check 'src/**/*.{ts,tsx}'",

--- a/src/elements/BarChart/MousePositionContext.tsx
+++ b/src/elements/BarChart/MousePositionContext.tsx
@@ -7,21 +7,18 @@ export const MousePositionContext = React.createContext({ x: 0, y: 0 })
 export const ProvideMousePosition: React.SFC = ({ children }) => {
   const [state, setState] = useState({ x: 0, y: 0 })
 
-  useEffect(
-    () => {
-      const setMousePosition = (ev: MouseEvent) => {
-        setState({
-          x: ev.clientX,
-          y: ev.clientY,
-        })
-      }
-      window.addEventListener("mousemove", setMousePosition)
-      return () => {
-        window.removeEventListener("mousemove", setMousePosition)
-      }
-    },
-    [false]
-  )
+  useEffect(() => {
+    const setMousePosition = (ev: MouseEvent) => {
+      setState({
+        x: ev.clientX,
+        y: ev.clientY,
+      })
+    }
+    window.addEventListener("mousemove", setMousePosition)
+    return () => {
+      window.removeEventListener("mousemove", setMousePosition)
+    }
+  }, [false])
 
   return (
     <MousePositionContext.Provider value={state}>

--- a/src/elements/Typography/determineFontSizes.ts
+++ b/src/elements/Typography/determineFontSizes.ts
@@ -16,13 +16,15 @@ export function determineFontSizes(
     }
   }
 
-  return size.map(s => themeProps.typeSizes[fontType][s]).reduce(
-    (accumulator, current) => {
-      return {
-        fontSize: [...accumulator.fontSize, `${current.fontSize}px`],
-        lineHeight: [...accumulator.lineHeight, `${current.lineHeight}px`],
-      }
-    },
-    { fontSize: [], lineHeight: [] }
-  )
+  return size
+    .map(s => themeProps.typeSizes[fontType][s])
+    .reduce(
+      (accumulator, current) => {
+        return {
+          fontSize: [...accumulator.fontSize, `${current.fontSize}px`],
+          lineHeight: [...accumulator.lineHeight, `${current.lineHeight}px`],
+        }
+      },
+      { fontSize: [], lineHeight: [] }
+    )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6339,9 +6339,9 @@ preserve@^0.2.0:
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
 prettier@^1.12.1:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
-  integrity sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 pretty-format@^23.5.0:
   version "23.5.0"


### PR DESCRIPTION
This PR aims to get prettier added to our CI setup so that formatting mistakes can be corrected when they are being introduced rather than after the fact. I've updated prettier to the latest which includes a new `check` flag (h/t @orta for finding that). This flag will list the files that have formatting mistakes and then a helpful message that maybe prettier was not run. Docs: https://prettier.io/docs/en/cli.html#check.

This is WIP until I'm able to land https://github.com/artsy/orbs/pull/25 and then I'll come back here and update the `.circleci/config.yml` file with the newer orb version and that new job.