### PR TITLE
[Menu] Fix responsive props

### DIFF
--- a/src/elements/Menu/Menu.tsx
+++ b/src/elements/Menu/Menu.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 
+import { display } from "styled-system"
 import { color } from "../../helpers/color"
 import { BorderBox } from "../BorderBox"
 import { Box, BoxProps } from "../Box"
@@ -72,6 +73,8 @@ const MenuLink = styled.a`
   display: flex;
   align-items: center;
   text-decoration: none;
+
+  ${display};
 
   &:hover {
     background-color: ${color("black5")};


### PR DESCRIPTION
Noticed an issue where responsive props weren't being passed through to the menu. (Needed to pass in the `display` styled-system mixin.)

![responsive](https://user-images.githubusercontent.com/236943/54063697-16e44e80-41c3-11e9-80eb-b6aacd24df61.gif)
