### PR TITLE
[Menu] Add onClick handler

### DIFF
--- a/src/elements/Menu/Menu.tsx
+++ b/src/elements/Menu/Menu.tsx
@@ -46,8 +46,9 @@ const MenuContainer = styled(Box)`
 
 interface MenuItemProps extends BoxProps {
   children: React.ReactNode
-  href: string
+  href?: string
   color?: string // TODO:  Look into type conflict with styled-system
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void
 }
 
 export const MenuItem: React.FC<MenuItemProps> = ({

--- a/www/content/docs/components/Menu.mdx
+++ b/www/content/docs/components/Menu.mdx
@@ -32,3 +32,18 @@ The `Menu` component has been extracted from the
     </MenuItem>
   </Menu>
 </Playground>
+
+## Custom click actions:
+
+<Playground>
+  <Menu>
+    <MenuItem
+      onClick={event => {
+        event.preventDefault()
+        console.warn("hi!")
+      }}
+    >
+      <HeartIcon mr={1} /> Log hello to the console
+    </MenuItem>
+  </Menu>
+</Playground>


### PR DESCRIPTION
Updates the `<MenuItem>` so that custom, not `<a>` tag events are supported:

```js
<MenuItem href='/'>Normal Link</MenuItem>

<MenuItem onClick={event => {
  event.preventDefault()
  ...   
}>
  Normal Link
</MenuItem>
```