### PR TITLE
[Tooltip] Add option to have component as tooltip content

### DIFF
--- a/src/elements/Tooltip/Tooltip.tsx
+++ b/src/elements/Tooltip/Tooltip.tsx
@@ -58,7 +58,7 @@ enum TipSize {
 }
 
 export interface TooltipProps {
-  content: string
+  content: string | React.ReactElement<any>
   size: TipSize
   width: number
 }
@@ -134,7 +134,10 @@ export class Tooltip extends React.Component<TooltipProps> {
   }
 
   render() {
-    const content = formattedTip(this.props.content)
+    const content =
+      typeof this.props.content === "string"
+        ? formattedTip(this.props.content)
+        : this.props.content
     return (
       <Wrapper
         onClick={this.handleClick}
@@ -157,7 +160,7 @@ export class Tooltip extends React.Component<TooltipProps> {
   }
 }
 
-const formattedTip = tip => {
+const formattedTip = (tip: string): string => {
   let substring = tip.substring(0, 300)
 
   if (substring !== tip) {

--- a/src/elements/Tooltip/Tooltip.tsx
+++ b/src/elements/Tooltip/Tooltip.tsx
@@ -58,7 +58,7 @@ enum TipSize {
 }
 
 export interface TooltipProps {
-  content: string | React.ReactElement<any>
+  content: React.ReactNode
   size: TipSize
   width: number
 }

--- a/www/content/docs/elements/inputs/Tooltip.mdx
+++ b/www/content/docs/elements/inputs/Tooltip.mdx
@@ -18,6 +18,23 @@ Keep this text brief. Avoid using more than 300 characters.
   </Box>
 </Playground>
 
+<Playground title="with component content">
+  <Box textAlign="center" mt={120}>
+    <Sans size="2">
+      <Tooltip content={
+        <ul>
+          <li>list item 1</li>
+          <li>list item 2</li>
+        </ul>
+        }
+      >
+        <span>Hoverable area</span>
+      </Tooltip>
+    </Sans>
+  </Box>
+</Playground>
+
+
 <Playground title="Sm">
   <Box textAlign="center" mt={4}>
     <Sans size="2">


### PR DESCRIPTION
Mainly to be able to have lists and paragraphs in the tooltip.

<img width="819" alt="Screen Shot 2019-03-11 at 4 08 40 PM" src="https://user-images.githubusercontent.com/687513/54154465-55267b80-4418-11e9-8803-601a6b3a0a72.png">
