### PR TITLE
Add 'element' property for specifying element type on Typography

### DIFF
--- a/packages/palette-docs/content/docs/tokens/Typography.mdx
+++ b/packages/palette-docs/content/docs/tokens/Typography.mdx
@@ -9,37 +9,39 @@ should be contextually applied. The goal is for this system to increase overall
 design consistency for our product as well as to increase efficiency for both
 the design and engineering teams.
 
-<Flex mt={4} justifyContent="space-between">
-  <Box>
-    <Sans size="16">Sans 16</Sans>
-    <Sans size="14">Sans 14</Sans>
-    <Sans size="12">Sans 12</Sans>
-    <Sans size="10">Sans 10</Sans>
-    <Sans size="8">Sans 8</Sans>
-    <Sans size="6">Sans 6</Sans>
-    <Sans size="5t">Sans 5t</Sans>
-    <Sans size="5">Sans 5</Sans>
-    <Sans size="4t">Sans 4t</Sans>
-    <Sans size="4">Sans 4</Sans>
-    <Sans size="3t">Sans 3t</Sans>
-    <Sans size="3">Sans 3</Sans>
-    <Sans size="2">Sans 2</Sans>
-    <Sans size="1">Sans 1</Sans>
-  </Box>
-  <Flex width="50%" px={2} alignItems="center">
-    <BorderBox>
-      <Sans size="5">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua.
-      </Sans>
-    </BorderBox>
+<Playground showToggle={true} title="Sans" expanded={true}>
+  <Flex mt={4} justifyContent="space-between">
+    <Box>
+      <Sans size="16">Sans 16</Sans>
+      <Sans size="14">Sans 14</Sans>
+      <Sans size="12">Sans 12</Sans>
+      <Sans size="10">Sans 10</Sans>
+      <Sans size="8">Sans 8</Sans>
+      <Sans size="6">Sans 6</Sans>
+      <Sans size="5t">Sans 5t</Sans>
+      <Sans size="5">Sans 5</Sans>
+      <Sans size="4t">Sans 4t</Sans>
+      <Sans size="4">Sans 4</Sans>
+      <Sans size="3t">Sans 3t</Sans>
+      <Sans size="3">Sans 3</Sans>
+      <Sans size="2">Sans 2</Sans>
+      <Sans size="1">Sans 1</Sans>
+    </Box>
+    <Flex width="50%" px={2} alignItems="center">
+      <BorderBox>
+        <Sans size="5">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </Sans>
+      </BorderBox>
+    </Flex>
   </Flex>
-</Flex>
+</Playground>
 
 <Spacer my={4} />
 
 <Playground showToggle={true} title="Serif" expanded={true}>
-  <Flex justifyContent="space-between" flexDirection="column">
+  <Flex justifyContent="space-between">
     <Box>
       <Serif size="12">Serif 12</Serif>
       <Serif size="10">Serif 10</Serif>
@@ -54,7 +56,7 @@ the design and engineering teams.
       <Serif size="2">Serif 2</Serif>
       <Serif size="1">Serif 1</Serif>
     </Box>
-    <Flex py={2}>
+    <Flex width="50%" px={2} alignItems="center">
       <BorderBox>
         <Serif size="5">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -62,5 +64,27 @@ the design and engineering teams.
         </Serif>
       </BorderBox>
     </Flex>
+  </Flex>
+</Playground>
+
+<Spacer my={4} />
+
+<Playground
+  showToggle={true}
+  title="Specifying the element type"
+  expanded={true}
+>
+  <Flex justifyContent="space-between" flexDirection="column">
+    <Box>
+      <Serif size="8" element="h1">
+        This is an h1
+      </Serif>
+      <Serif size="6" element="h2">
+        This is an h2
+      </Serif>
+      <Sans size="4" element="p">
+        And this content is all within a p.
+      </Sans>
+    </Box>
   </Flex>
 </Playground>

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -185,9 +185,13 @@ function createStyledText<P extends StyledTextProps>(
             fontFamilyType && themeProps.fontFamily[fontType][fontFamilyType]
           }
           {...determineFontSizes(fontType, size)}
-          // styled-components wants it called `as`, but this function somehow
-          //  gets skipped when there is an `as` prop passed in. So our clients
-          //  will pass in `element`, and we'll pass it through as `as`.
+          // styled-components supports calling the prop `as`, but there are
+          //  issues when passing it into this component named `as`. See
+          //  https://github.com/styled-components/styled-components/issues/2448
+          //  & https://github.com/artsy/palette/pull/327#issuecomment-473434537
+          //  for context.
+          // So we are naming it `element` on the way into this component, and
+          //  renaming it to `as` when we pass it to through.
           {...(element ? { as: element } : {})}
           {...textProps}
         />

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -91,6 +91,7 @@ export interface TextProps
    * this prop.
    */
   ellipsizeMode?: string
+  element?: keyof JSX.IntrinsicElements | React.ComponentType<any>
 }
 
 /** Base Text component for typography */
@@ -172,7 +173,7 @@ function createStyledText<P extends StyledTextProps>(
   selectFontFamilyType: typeof _selectFontFamilyType = _selectFontFamilyType
 ) {
   return styled<P>(
-    ({ size, weight, italic, ...textProps }: StyledTextProps) => {
+    ({ size, weight, italic, element, ...textProps }: StyledTextProps) => {
       const fontFamilyType = selectFontFamilyType(_fontWeight(weight), italic)
       // This is mostly to narrow the type of `fontFamilyType` to remove `null`.
       if (fontFamilyType === null) {
@@ -184,6 +185,10 @@ function createStyledText<P extends StyledTextProps>(
             fontFamilyType && themeProps.fontFamily[fontType][fontFamilyType]
           }
           {...determineFontSizes(fontType, size)}
+          // styled-components wants it called `as`, but this function somehow
+          //  gets skipped when there is an `as` prop passed in. So our clients
+          //  will pass in `element`, and we'll pass it through as `as`.
+          {...(element ? { as: element } : {})}
           {...textProps}
         />
       )


### PR DESCRIPTION
This PR adds a prop named `element` to the Typography components, allowing the user to specify what type of element gets rendered. The `element` prop flows through to styled-components as [an `as` prop](https://www.styled-components.com/docs/api#as-polymorphic-prop). 

![image](https://user-images.githubusercontent.com/1627089/54318961-fd257b80-45b5-11e9-815c-e9e365e09c61.png)

## Why not name the prop `as`, like styled-components wants?

I attempted to do this, but I ran into a confusing problem. Whenever I specified `as` on a JSX element, the rendered element would lose all other styles that were specified. In fact, the function [`createStyledText`](https://github.com/pepopowitz/palette/blob/62d94bb314a58be2bd93eaece1a87ac3438638d1/packages/palette/src/elements/Typography/Typography.tsx#L171) wouldn't even get called. I dug as far as I could, but I don't really know why it hates the prop being named `as`.

If you've got the courage to investigate why I can't name it `as`, I encourage you. I feel like this accomplishes the goal of being able to specify the element type, even though we'd probably all prefer it be named `as`. I'm also happy to pair if someone feels like they have ideas on the issue.

---

One other thing to note: we'll need to make sure we are properly resetting styles wherever this is consumed. Chrome applies default margins to headings, which we won't want. It looks to me like Force is applying a reset that will eliminate those default margins (see below), but I don't know if I need to worry about anything on the mobile side. 

![image](https://user-images.githubusercontent.com/1627089/54318859-a750d380-45b5-11e9-9529-aac2ae549d2a.png)
