### PR TITLE
Add CSS reset for headings (h1-h6) to global styles

### DIFF
--- a/packages/palette/src/helpers/injectGlobalStyles.tsx
+++ b/packages/palette/src/helpers/injectGlobalStyles.tsx
@@ -129,6 +129,14 @@ export function injectGlobalStyles<P>(
       }
     }
 
+    h1, h2, h3, h4, h5, h6 {
+      font-style: inherit;
+      font-family: inherit;
+      font-weight: inherit;
+      font-size: inherit;
+      margin: 0;
+    }
+    
     ${additionalStyles};
   `
 


### PR DESCRIPTION
Force contains a reset that wipes out agent/user-agent styles for headings, but reaction/palette do not. Headings can look different in the palette docs & reaction storybooks than they do when they are deployed via Force.

For example, here's what an h2 looked like in the artwork sidebar in Reaction's storybooks:

<img width="326" alt="headings-before" src="https://user-images.githubusercontent.com/1627089/54567270-350b3500-49a1-11e9-9310-a4dfb53822a3.png">

And here's what it looked like when I linked it into Force:

<img width="398" alt="headings-after" src="https://user-images.githubusercontent.com/1627089/54567274-39375280-49a1-11e9-8706-ee7d84d59b7e.png">

Adding this h1-h6 reset should make it easier for engineers to build things in storybooks, and have them look identical in Force.

