### PR TITLE
adds required prop to textarea

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/TextArea.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/TextArea.mdx
@@ -8,6 +8,17 @@ name: TextArea
   <TextArea placeholder="Start typing..." onChange={console.log} />
 </Playground>
 
+## Required
+
+<Playground>
+  <TextArea
+    title="Note"
+    placeholder="Start typing..."
+    onChange={console.log}
+    required={true}
+  />
+</Playground>
+
 ## With error
 
 <Playground>

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -26,8 +26,13 @@ const StyledTextArea = styled.textarea`
   resize: vertical;
 `
 
+const Required = styled.span`
+  color: ${color("purple100")};
+`
+
 export interface TextAreaProps {
   error?: string
+  required?: boolean
   characterLimit?: number
   title?: React.ReactNode
   description?: React.ReactNode
@@ -93,7 +98,10 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
       <Flex flexDirection="column">
         {title && (
           <>
-            <Serif size="3t">{title}</Serif>
+            <Serif size="3t">
+              {title}
+              {this.props.required && <Required>*</Required>}
+            </Serif>
             <Spacer mb={1} />
           </>
         )}

--- a/packages/palette/src/elements/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/palette/src/elements/TextArea/__tests__/TextArea.test.tsx
@@ -60,6 +60,16 @@ describe("TextArea", () => {
     expect(wrapper.html()).toContain("Error message")
   })
 
+  it("doesn't show a required * if you don't require it", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.html()).not.toContain("*")
+  })
+
+  it("shows a required * if you require it", () => {
+    const wrapper = getWrapper({ required: true })
+    expect(wrapper.html()).toContain("*")
+  })
+
   it("triggers onChange when you type characters", () => {
     const wrapper = getWrapper()
     expect(onChange).not.toHaveBeenCalled()


### PR DESCRIPTION
This PR allows you to specify that a TextArea component is required by passing a `required` prop. Doing so adds a purple `*` after the title:

<img width="893" alt="Screen Shot 2019-03-19 at 4 12 02 PM" src="https://user-images.githubusercontent.com/5361806/54638594-cc37c180-4a61-11e9-92c3-9a47cd72441b.png">
