### PR TITLE
Ensure lazy-loaded images fill placeholder container

### DIFF
--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -13,6 +13,7 @@ import { BaseImage as Image, ImageProps } from "./Image.shared"
 
 const InnerLazyImage = styled(LazyLoadImage)<ImageProps>`
   width: 100%;
+  height: 100%;
   ${borderRadiusStyle}
   transition: opacity 0.25s;
 `


### PR DESCRIPTION
Fix to ensure avatars take up the full placeholder. 