### PR TITLE
Fix web Collapse component

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/Collapse.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Collapse.mdx
@@ -15,42 +15,38 @@ name: Collapse
   </Toggler>
 </Playground>
 
-## Animating "auto"
-
-When animating height="auto" (or width="auto") sometimes React Spring needs a
-bit more information to determine where to move things. In the below example,
-adding `position="relative"` to the container returns the proper height for the
-multi-line string.
-
-See https://react-spring.surge.sh/gotchas#animating-auto for more info.
+## Nested collapses
 
 <Playground>
-  <Toggler>
+  <Toggler initial={true}>
     {({ on, toggle }) => (
-      <>
-        <Spacer mb={4} />
-        <Flex flexDirection="column" alignItems="center">
-          <Button onClick={toggle} width="300px">
-            Toggle
-          </Button>
-          <Spacer mb={2} />
-          <Flex alignItems="flex-start">
-            <BorderBox width="300px" flexDirection="column" position="relative">
-              <Collapse open={on}>
-                <Box>Hello I am some multiline content inside collapse</Box>
-              </Collapse>
-            </BorderBox>
-          </Flex>
-          <Spacer mb={2} />
-          <Flex alignItems="flex-start">
-            <BorderBox width="300px" flexDirection="column" position="relative">
-              <Collapse open={!on}>
-                <Box>Hello I am some multiline content inside collapse</Box>
-              </Collapse>
-            </BorderBox>
-          </Flex>
-        </Flex>
-      </>
+      <Toggler initial={true}>
+        {({ on: on2, toggle: toggle2 }) => (
+          <BorderBox position="relative" flexDirection="column">
+            <Flex justifyContent="space-between">
+              <Serif size="3">Outer</Serif>
+              <Button size="small" onClick={() => toggle()}>
+                {on ? "close" : "open"}
+              </Button>
+            </Flex>
+            <Collapse open={on}>
+              <BorderBox position="relative" flexDirection="column" mt={2}>
+                <Flex justifyContent="space-between">
+                  <Serif size="3">Inner</Serif>
+                  <Button size="small" onClick={() => toggle2()}>
+                    {on2 ? "close" : "open"}
+                  </Button>
+                </Flex>
+                <Collapse open={on2}>
+                  <BorderBox mt={2}>
+                    <Sans size="2"> hello world! </Sans>
+                  </BorderBox>
+                </Collapse>
+              </BorderBox>
+            </Collapse>
+          </BorderBox>
+        )}
+      </Toggler>
     )}
   </Toggler>
 </Playground>

--- a/packages/palette/src/elements/Collapse/Collapse.test.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.test.tsx
@@ -15,6 +15,6 @@ describe("Collapse", () => {
       <Collapse open={false}>The elegant spiral of the Nautilus ...</Collapse>
     )
 
-    expect(component.find("div").prop("style")).toHaveProperty("height", 0)
+    expect(component.find("div").prop("style")).toHaveProperty("height", "0px")
   })
 })

--- a/packages/palette/src/elements/Collapse/Collapse.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.tsx
@@ -1,35 +1,89 @@
 import React from "react"
-import { animated, Spring } from "react-spring"
 
-export interface CollapseProps {
-  /** Determines whether content is expanded or collapsed */
-  open: boolean
-}
+/**
+ * Collapse component for the web
+ */
+export class Collapse extends React.Component<{ open: boolean }> {
+  wrapperModifyTimeout: ReturnType<typeof setTimeout>
+  wrapperRef: HTMLDivElement | null = null
 
-/** Collapses content with animation when open is not true */
-export class Collapse extends React.Component<CollapseProps> {
-  state = {
-    mounted: false,
+  onTransitionEnd = (ev: TransitionEvent) => {
+    if (!this.wrapperRef) {
+      return
+    }
+    if (ev.propertyName === "height") {
+      this.wrapperRef.style.height = this.props.open ? "auto" : "0px"
+    }
+  }
+
+  firstRender: { open: boolean } | null = {
+    open: this.props.open,
   }
 
   componentDidMount() {
-    this.setState({ mounted: true })
+    if (!this.wrapperRef) {
+      return
+    }
+
+    this.wrapperRef.addEventListener("transitionend", this.onTransitionEnd)
+  }
+
+  componentDidUpdate() {
+    if (!this.wrapperRef) {
+      return
+    }
+    if (this.props.open && this.wrapperRef.style.height !== "auto") {
+      // open
+      const prevHeight = this.wrapperRef.style.height || "0px"
+      this.wrapperRef.style.height = "auto"
+      const actualHeight = this.wrapperRef.offsetHeight
+      this.wrapperRef.style.height = prevHeight
+      this.wrapperModifyTimeout = setTimeout(() => {
+        this.wrapperRef.style.height = actualHeight + "px"
+      }, 10)
+    } else if (!this.props.open && this.wrapperRef.style.height !== "0px") {
+      // close
+      const actualHeight = this.wrapperRef.offsetHeight
+      this.wrapperRef.style.height = actualHeight + "px"
+      this.wrapperModifyTimeout = setTimeout(() => {
+        this.wrapperRef.style.height = 0 + "px"
+      }, 10)
+    }
+  }
+
+  componentWillUnmount() {
+    this.wrapperRef.removeEventListener("transitionend", this.onTransitionEnd)
+    clearTimeout(this.wrapperModifyTimeout)
   }
 
   render() {
+    const { children, open } = this.props
+    // render explicit height before first change, to let us render closed
+    // elements on the server
+    let heightProps = {}
+    if (this.firstRender) {
+      // render() might be called multiple times before the first time `open` changes
+      if (this.firstRender.open !== open) {
+        // `open` prop has changed for the first time
+        // ditch explicit height and let `componentDidUpdate` take the wheel
+        this.firstRender = null
+      } else {
+        heightProps = {
+          height: open ? "auto" : "0px",
+        }
+      }
+    }
     return (
-      <Spring
-        native
-        immediate={!this.state.mounted}
-        from={{ height: 0 }}
-        to={{ height: this.props.open ? "auto" : 0 }}
+      <div
+        ref={ref => (this.wrapperRef = ref)}
+        style={{
+          transition: "height 0.3s ease",
+          overflow: "hidden",
+          ...heightProps,
+        }}
       >
-        {props => (
-          <animated.div style={{ ...props, overflow: "hidden" }}>
-            {this.props.children}
-          </animated.div>
-        )}
-      </Spring>
+        {children}
+      </div>
     )
   }
 }

--- a/packages/palette/src/elements/Collapse/Collapse.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.tsx
@@ -1,9 +1,12 @@
 import React from "react"
 
+export interface CollapseProps {
+  open: boolean
+}
 /**
  * Collapse component for the web
  */
-export class Collapse extends React.Component<{ open: boolean }> {
+export class Collapse extends React.Component<CollapseProps> {
   wrapperModifyTimeout: ReturnType<typeof setTimeout>
   wrapperRef: HTMLDivElement | null = null
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-942

![bad-collapse-2](https://user-images.githubusercontent.com/1242537/54922929-72c00e80-4f09-11e9-8c54-fa88c89c0b7f.gif)

On the purchase team we have noticed a couple of issues with the Collapse component animating itself to incorrect heights, or not animating at all when nested. Unfortunately we were not able to resolve them with the current implementation by following the advice outlined [in the react-spring docs](https://www.react-spring.io/docs/props/gotchas#animating-auto)

I therefore propose we use a custom Collapse component with transparent internals. This amounts to ~100 lines of well-commented code.

This approach has a couple of other benefits:

- Lifting the burden on users of Collapse to know about the `height: auto` gotcha and how to mitigate it.
- Reducing web bundle size by 10k gzipped. (Collapse is the only web component so far that uses react-spring)

This is not to say that we should not use `react-spring` in the future. Just that it is not currently appropriate for this Collapse use case.
