### PR TITLE
Begin stripping attributes from palette elements

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.10.0",
+    "clean-tag": "^3.1.0",
     "moment": "^2.23.0",
     "moment-timezone": "^0.5.23",
     "rc-slider": "^8.6.2",

--- a/packages/palette/src/elements/Flex/Flex.tsx
+++ b/packages/palette/src/elements/Flex/Flex.tsx
@@ -1,4 +1,5 @@
-import { styled as primitives } from "../../platform/primitives"
+import tag from "clean-tag"
+import styled from "styled-components"
 
 import {
   alignContent,
@@ -63,7 +64,7 @@ export interface FlexProps
 /**
  * A utility component that encapsulates flexbox behavior
  */
-export const Flex = primitives.View<FlexProps>`
+export const Flex = styled(tag)<FlexProps>`
   display: flex;
   ${alignContent};
   ${alignItems};

--- a/packages/palette/src/elements/Image/Image.shared.tsx
+++ b/packages/palette/src/elements/Image/Image.shared.tsx
@@ -1,5 +1,5 @@
 // @ts-ignore
-import React from "react"
+import tag from "clean-tag"
 import styled from "styled-components"
 
 import {
@@ -42,7 +42,7 @@ export interface ImageProps
 /**
  * Image component with space, width and height properties
  */
-export const BaseImage = styled.img<ImageProps>`
+export const BaseImage = styled(tag.img)<ImageProps>`
   ${space};
   ${width};
   ${height};
@@ -59,7 +59,7 @@ export interface ResponsiveImageProps
 /**
  * An Image component that responsively resizes within its environment
  */
-export const BaseResponsiveImage = styled.div<ResponsiveImageProps>`
+export const BaseResponsiveImage = styled(tag)<ResponsiveImageProps>`
   background: url(${props => props.src});
   background-size: contain;
   background-repeat: no-repeat;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4783,6 +4783,15 @@ clean-css@4.2.x:
   dependencies:
     source-map "~0.6.0"
 
+clean-tag@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/clean-tag/-/clean-tag-3.1.0.tgz#51d9c8cdd2b8bdd779da0e64ab6124304259ac1d"
+  integrity sha512-UvkRzFThxcNbvMywy4llq1LOUEKlONpNbeGSQr6kO5n2l4ehOOq7izYkxEnXDGBKm0u+768GQKZ/3sgH7YX38w==
+  dependencies:
+    html-tags "^2.0.0"
+    react "^16.8.5"
+    styled-system "^3.2.1"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -9310,6 +9319,11 @@ html-minifier@^3.2.3:
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.4.x"
+
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
+  integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
 html-void-elements@^1.0.0, html-void-elements@^1.0.1:
   version "1.0.3"
@@ -15853,6 +15867,16 @@ react@^16.6.3, react@^16.8.1, react@^16.8.2:
     prop-types "^15.6.2"
     scheduler "^0.13.4"
 
+react@^16.8.5:
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
+  integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.5"
+
 read-chunk@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-1.0.1.tgz#5f68cab307e663f19993527d9b589cace4661194"
@@ -16874,6 +16898,14 @@ scheduler@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.4.tgz#8fef05e7a3580c76c0364d2df5e550e4c9140298"
   integrity sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
+  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -18087,7 +18119,7 @@ styled-components@^4.1.3:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-styled-system@^3.1.11:
+styled-system@^3.1.11, styled-system@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-3.2.1.tgz#491e1e6f88d7ee021f6f49376f12852cde8007cb"
   integrity sha512-ag0Yp7UeVHHc3t+1uM3jvlljaZYzwqpbJ8hMrFvpaKfUd8xsB9JeQXLwMpEsz8iLx8Lz/+9j0coWFZjmw8MogQ==


### PR DESCRIPTION
This loosely depends on https://github.com/styled-system/extras/pull/3 before it can be completed. 

We've had issues for a while where props from styled-system was getting passed down to the DOM. Recently our configuration has changed in reaction to make warnings fail tests. React is warning about these props being passed to DOM elements which cause local tests to fail. 

This PR introduces `clean-tag`, a mechanism to be used on top of `styled-systems` to remove props that are filtering down to the DOM. 

**NOTE**: There are some test failures here because we were relying on those DOM properties in some tests. Those tests will need to be updated.