### PR TITLE
[RadioGroup] Add deselectable option

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/RadioGroup.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/RadioGroup.mdx
@@ -33,6 +33,15 @@ additional consecutive decisions, or may reveal additional information.
   </RadioGroup>
 </Playground>
 
+### Deselectable
+
+<Playground>
+  <RadioGroup defaultValue="SHIP" deselectable>
+    <Radio value="SHIP" label="Provide shipping address" />
+    <Radio value="PICKUP" label="Arrange for pickup" />
+  </RadioGroup>
+</Playground>
+
 ### Disabled
 
 <Playground>

--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -1,3 +1,4 @@
+import debounce from "lodash/debounce"
 import React from "react"
 import styled, { css } from "styled-components"
 import { Flex, FlexProps } from "../../elements/Flex"
@@ -49,12 +50,16 @@ export const Radio: React.SFC<RadioProps> = props => {
     disabled,
     hover,
     name,
-    onSelect,
+    onSelect: _onSelect,
     selected,
     value,
     label,
     ...others
   } = props
+
+  // Ensures that only one call to `onSelect` occurs, regardless of whether the
+  // user clicks the radio element or the label.
+  const onSelect = debounce(_onSelect, 100)
 
   return (
     <Container

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.test.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.test.tsx
@@ -3,6 +3,8 @@ import React from "react"
 import { Radio } from "../Radio"
 import { RadioGroup } from "../RadioGroup"
 
+jest.mock("lodash/debounce", () => x => x)
+
 describe("RadioGroup", () => {
   it("renders a radio group", () => {
     const spy = jest.fn()

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.tsx
@@ -8,6 +8,8 @@ import { RadioProps } from "../Radio"
 
 export interface RadioGroupProps extends FlexProps {
   /** Disable interactions */
+  deselectable?: boolean
+  /** Disable interactions */
   disabled?: boolean
   /** Callback when selected */
   onSelect?: (selectedOption: string) => void
@@ -37,6 +39,15 @@ export class RadioGroup extends React.Component<
   onSelect = ({ value }) => {
     if (this.props.onSelect) {
       this.props.onSelect(value)
+    }
+
+    if (this.props.deselectable) {
+      if (this.state.selectedOption === value) {
+        this.setState({
+          selectedOption: null,
+        })
+        return
+      }
     }
 
     this.setState({ selectedOption: value })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7808,7 +7808,7 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
@@ -12603,6 +12603,9 @@ mixin-deep@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
   integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"


### PR DESCRIPTION
Fixes https://github.com/artsy/palette/issues/349

Adds a new `deselectable` prop to `<RadioGroup>` which, if `true`, allows an item within a group to be toggled off and the selected item to be set to `null`. 

![desel](https://user-images.githubusercontent.com/236943/55111555-edb72f80-5097-11e9-835b-eb63f1edea5c.gif)
