### PR TITLE
Deal with warnings

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.ios.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.ios.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from "react"
 import { styled } from "../../platform/primitives"
 import { AvatarProps, BaseAvatar, sizeValue } from "./Avatar.shared"
 
+/** Avatar */
 export const Avatar: FunctionComponent<AvatarProps> = ({ ...props }) => {
   return (
     <BaseAvatar renderAvatar={() => <AvatarImage {...props} />} {...props} />

--- a/packages/palette/src/elements/Avatar/Avatar.shared.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.shared.tsx
@@ -12,6 +12,7 @@ export interface SizeProps {
   }
 }
 
+/** Size */
 export const Size: SizeProps = {
   xs: {
     diameter: "45px",
@@ -29,6 +30,7 @@ export const Size: SizeProps = {
 
 type SizeKey = "xs" | "sm" | "md"
 
+/** sizeValue */
 export const sizeValue = size => {
   switch (size) {
     case "xs":
@@ -90,6 +92,7 @@ export const BaseAvatar = ({
   }
 }
 
+/** InitialsHolder */
 export const InitialsHolder = styledWrapper(Flex)<{ size: SizeKey }>`
   background-color: ${color("black10")};
   border-radius: ${props => sizeValue(props.size).diameter};

--- a/packages/palette/src/elements/Image/Image.ios.tsx
+++ b/packages/palette/src/elements/Image/Image.ios.tsx
@@ -1,7 +1,9 @@
 import { BaseImage, BaseResponsiveImage } from "./Image.shared"
 
+/** Image */
 export const Image = BaseImage
 Image.displayName = "Image"
 
+/** ResponsiveImage */
 export const ResponsiveImage = BaseResponsiveImage
 ResponsiveImage.displayName = "ResponsiveImage"

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -7,10 +7,12 @@ import {
 } from "./Image.shared"
 import { LazyImage } from "./LazyImage"
 
+/** Image */
 export const Image = ({ lazyLoad = false, ...props }: ImageProps) => (
   <LazyImage preload={!lazyLoad} imageComponent={BaseImage} {...props} />
 )
 
+/** ResponsiveImage */
 export const ResponsiveImage = ({
   lazyLoad = false,
   ...props

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -53,6 +53,8 @@ interface LazyImageProps
   /** The image component to render when preload is true */
   imageComponent?: any // FunctionComponent<ImageProps>
 }
+
+/** LazyImage */
 export const LazyImage: React.FC<LazyImageProps> = ({
   preload = false,
   imageComponent: ImageComponent = Image,

--- a/packages/palette/src/elements/LabeledRange/LabeledRange.tsx
+++ b/packages/palette/src/elements/LabeledRange/LabeledRange.tsx
@@ -15,6 +15,7 @@ interface LabeledRangeState {
   max: number
 }
 
+/** LabeledRange */
 export class LabeledRange extends React.Component<
   LabeledRangeProps,
   LabeledRangeState

--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -15,6 +15,7 @@ interface MenuProps {
   children?: React.ReactNode
 }
 
+/** Menu */
 export const Menu: React.FC<MenuProps> = ({ title, children, ...props }) => {
   return (
     <MenuContainer width={230} m="2px" {...props}>
@@ -51,6 +52,7 @@ interface MenuItemProps extends BoxProps {
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
 }
 
+/** MenuItem */
 export const MenuItem: React.FC<MenuItemProps> = ({
   children,
   href,

--- a/packages/palette/src/elements/Pagination/Pagination.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.tsx
@@ -13,6 +13,7 @@ interface Props {
   scrollTo?: string
 }
 
+/** LargePagination */
 export const LargePagination = (props: Props) => {
   const {
     pageCursors: { around, first, last, previous },
@@ -59,6 +60,7 @@ export const LargePagination = (props: Props) => {
   )
 }
 
+/** SmallPagination */
 export const SmallPagination = (props: Props) => {
   const {
     pageCursors: { previous },

--- a/packages/palette/src/elements/PriceRange/PriceRange.tsx
+++ b/packages/palette/src/elements/PriceRange/PriceRange.tsx
@@ -6,6 +6,7 @@ interface PriceRangeProps extends SliderProps {
   disabled?: boolean
 }
 
+/** PriceRange */
 export class PriceRange extends React.Component<PriceRangeProps> {
   static defaultProps = {
     currency: "USD",

--- a/packages/palette/src/elements/ProgressBar/ProgressBar.tsx
+++ b/packages/palette/src/elements/ProgressBar/ProgressBar.tsx
@@ -11,6 +11,7 @@ const ProgressBarBackground = styled.div`
   justify-content: flex-start;
 `
 
+/** ProgressBar */
 export const ProgressBar: React.SFC<{
   percentComplete: number
   highlight: Parameters<typeof color>[0]

--- a/packages/palette/src/elements/ProgressBarTimer/ProgressBarTimer.tsx
+++ b/packages/palette/src/elements/ProgressBarTimer/ProgressBarTimer.tsx
@@ -6,6 +6,7 @@ import React from "react"
 import { ProgressBar } from "../"
 import { color } from "../../helpers"
 
+/** ProgressBarTimer */
 export const ProgressBarTimer: React.SFC<{
   currentTime: string
   countdownStart: string

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -16,6 +16,7 @@ export interface ReadMoreState {
   isExpanded: boolean
 }
 
+/** ReadMore */
 export class ReadMore extends Component<ReadMoreProps, ReadMoreState> {
   private html: string
 

--- a/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
@@ -15,6 +15,7 @@ import { TimerIcon } from "../../svgs"
 
 const FIVE_HOURS_IN_SECONDS = 60 * 60 * 5
 
+/** StaticCountdownTimer */
 export const StaticCountdownTimer: React.SFC<{
   action: string
   note: string

--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -16,6 +16,7 @@ interface StepperProps extends TabsProps {
   disableNavigation?: boolean
 }
 
+/** Stepper */
 export const Stepper = (props: StepperProps) => {
   return (
     <Tabs
@@ -33,6 +34,7 @@ export const Stepper = (props: StepperProps) => {
   )
 }
 
+/** Step */
 export const Step = props => <Tab {...props} />
 
 const DisabledStepButton = ({ children }) => (
@@ -89,6 +91,7 @@ const ChevronWrapper = styled.span`
   line-height: normal;
 `
 
+/** CheckMarkWrapper */
 export const CheckMarkWrapper = styled.span`
   margin-right: ${space(1)}px;
   line-height: normal;

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -54,6 +54,7 @@ export interface TextAreaChange {
   exceedsCharacterLimit: boolean
 }
 
+/** TextArea */
 export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
   state: TextAreaState = {
     value: this.props.defaultValue || "",

--- a/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
+++ b/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
@@ -6,6 +6,7 @@ import { color } from "../../helpers"
 
 const pad = (n: number) => n.toString().padStart(2, "0")
 
+/** TimeRemaining */
 export const TimeRemaining: React.SFC<{
   currentTime: string
   countdownEnd: string

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -56,6 +56,7 @@ const verticalAlign = style({
   prop: "verticalAlign",
 })
 
+/** renderFontValue */
 export const renderFontValue = (fontValue: FontValue) => {
   if (typeof fontValue === "string") {
     return `font-family: ${fontValue}`

--- a/packages/palette/src/svgs/AddCircleFillIcon.tsx
+++ b/packages/palette/src/svgs/AddCircleFillIcon.tsx
@@ -17,4 +17,5 @@ export const AddCircleFillIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** PlusIcon */
 export const PlusIcon = AddCircleFillIcon

--- a/packages/palette/src/svgs/ArtsyLogoBlackIcon.tsx
+++ b/packages/palette/src/svgs/ArtsyLogoBlackIcon.tsx
@@ -16,4 +16,5 @@ export const ArtsyLogoBlackIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** ArtsyLogoIcon */
 export const ArtsyLogoIcon = ArtsyLogoBlackIcon

--- a/packages/palette/src/svgs/ArtsyMarkBlackIcon.tsx
+++ b/packages/palette/src/svgs/ArtsyMarkBlackIcon.tsx
@@ -16,4 +16,5 @@ export const ArtsyMarkBlackIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** ArtsyMarkIcon */
 export const ArtsyMarkIcon = ArtsyMarkBlackIcon

--- a/packages/palette/src/svgs/CheckCircleFillIcon.tsx
+++ b/packages/palette/src/svgs/CheckCircleFillIcon.tsx
@@ -17,4 +17,5 @@ export const CheckCircleFillIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** CircleBlackCheckIcon */
 export const CircleBlackCheckIcon = CheckCircleFillIcon

--- a/packages/palette/src/svgs/CheckCircleIcon.tsx
+++ b/packages/palette/src/svgs/CheckCircleIcon.tsx
@@ -17,5 +17,7 @@ export const CheckCircleIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove these aliases once clients have been updated
+/** CircleWhiteCheckIcon */
 export const CircleWhiteCheckIcon = CheckCircleIcon
+/** WinningBidIcon */
 export const WinningBidIcon = CheckCircleIcon

--- a/packages/palette/src/svgs/CloseCircleIcon.tsx
+++ b/packages/palette/src/svgs/CloseCircleIcon.tsx
@@ -17,4 +17,5 @@ export const CloseCircleIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** LosingBidIcon */
 export const LosingBidIcon = CloseCircleIcon

--- a/packages/palette/src/svgs/EstablishedIcon.tsx
+++ b/packages/palette/src/svgs/EstablishedIcon.tsx
@@ -17,4 +17,5 @@ export const EstablishedIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** TopEstablishedIcon */
 export const TopEstablishedIcon = EstablishedIcon

--- a/packages/palette/src/svgs/EyeClosedIcon.tsx
+++ b/packages/palette/src/svgs/EyeClosedIcon.tsx
@@ -17,4 +17,5 @@ export const EyeClosedIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** ClosedEyeIcon */
 export const ClosedEyeIcon = EyeClosedIcon

--- a/packages/palette/src/svgs/EyeOpenedIcon.tsx
+++ b/packages/palette/src/svgs/EyeOpenedIcon.tsx
@@ -16,4 +16,5 @@ export const EyeOpenedIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** OpenEyeIcon */
 export const OpenEyeIcon = EyeOpenedIcon

--- a/packages/palette/src/svgs/InstitutionIcon.tsx
+++ b/packages/palette/src/svgs/InstitutionIcon.tsx
@@ -21,4 +21,5 @@ export const InstitutionIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** MuseumIcon */
 export const MuseumIcon = InstitutionIcon

--- a/packages/palette/src/svgs/LogoutIcon.tsx
+++ b/packages/palette/src/svgs/LogoutIcon.tsx
@@ -19,4 +19,5 @@ export const LogoutIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** PowerIcon */
 export const PowerIcon = LogoutIcon

--- a/packages/palette/src/svgs/MapPinIcon.tsx
+++ b/packages/palette/src/svgs/MapPinIcon.tsx
@@ -17,4 +17,5 @@ export const MapPinIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** LocationIcon */
 export const LocationIcon = MapPinIcon

--- a/packages/palette/src/svgs/PublicationIcon.tsx
+++ b/packages/palette/src/svgs/PublicationIcon.tsx
@@ -17,4 +17,5 @@ export const PublicationIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** BookIcon */
 export const BookIcon = PublicationIcon

--- a/packages/palette/src/svgs/QuestionCircleIcon.tsx
+++ b/packages/palette/src/svgs/QuestionCircleIcon.tsx
@@ -17,4 +17,5 @@ export const QuestionCircleIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** HelpIcon */
 export const HelpIcon = QuestionCircleIcon

--- a/packages/palette/src/svgs/UserMultiIcon.tsx
+++ b/packages/palette/src/svgs/UserMultiIcon.tsx
@@ -17,4 +17,5 @@ export const UserMultiIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** GroupIcon */
 export const GroupIcon = UserMultiIcon

--- a/packages/palette/src/svgs/UserSingleIcon.tsx
+++ b/packages/palette/src/svgs/UserSingleIcon.tsx
@@ -17,4 +17,5 @@ export const UserSingleIcon: React.SFC<IconProps> = props => {
 }
 
 // TODO: remove this alias once clients have been updated
+/** SoloIcon */
 export const SoloIcon = UserSingleIcon


### PR DESCRIPTION
I'm coming back to palette after a few days away to work on reorganizing things (see #347 and #348) and with fresh eyes I saw an opportunity to clean up some warnings. I updated some weirdo prop names on the LazyImage so that the console.log messages would go away and then added a bunch of missing JSDoc comments (many of which I added! 😝 ). Check it:

### before

<img width="2560" alt="Screen Shot 2019-03-28 at 2 51 17 PM" src="https://user-images.githubusercontent.com/79799/55188380-46a2c880-5169-11e9-9356-56fe3066d27a.png">
<img width="2560" alt="Screen Shot 2019-03-28 at 2 51 03 PM" src="https://user-images.githubusercontent.com/79799/55188393-4f939a00-5169-11e9-8ad5-f7719e522937.png">

### after

<img width="2560" alt="Screen Shot 2019-03-28 at 2 50 17 PM" src="https://user-images.githubusercontent.com/79799/55188412-59b59880-5169-11e9-90cf-495b71fe1f05.png">

So now you can fit all the output on a single screen. 😎 