### PR TITLE
Don't try to debounce if onSelect isn't defined

### DIFF
--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -59,7 +59,7 @@ export const Radio: React.SFC<RadioProps> = props => {
 
   // Ensures that only one call to `onSelect` occurs, regardless of whether the
   // user clicks the radio element or the label.
-  const onSelect = debounce(_onSelect, 0)
+  const onSelect = _onSelect && debounce(_onSelect, 0)
 
   return (
     <Container


### PR DESCRIPTION
There was a docs build failure that happened because `onSelect` isn't always passed into radio but debounce requires a function to be passed to it. Gating the check fixes the build. 