### PR TITLE
Don't strip width and height props from images

### DIFF
--- a/packages/palette/src/helpers/withoutStyleProps.tsx
+++ b/packages/palette/src/helpers/withoutStyleProps.tsx
@@ -7,8 +7,6 @@ import React from "react"
 export const withoutStyleProps = Component => ({
   borderRadius,
   ariaLabel,
-  width,
-  height,
   color,
   fontFamily,
   ...props


### PR DESCRIPTION
@mzikherman found a bug caused by the width and height props being removed from an image. This readds those props. 