### PR TITLE
If the artwork's highlighted bin is empty, default to showing a minimum-height bar

### DIFF
--- a/packages/palette/src/elements/BarChart/Bar.tsx
+++ b/packages/palette/src/elements/BarChart/Bar.tsx
@@ -151,7 +151,7 @@ export const Bar = ({
   // property
   const finalBarHeight =
     // bar heights start at MIN_BAR_HEIGHT, unless the intended height === 0
-    heightPercent === 0
+    heightPercent === 0 && !highlightLabel
       ? 0
       : MIN_BAR_HEIGHT + (BAR_HEIGHT_RANGE / 100) * heightPercent
   const currentHeight = hasEnteredViewport ? finalBarHeight : 0

--- a/packages/palette/src/elements/BarChart/BarChart.test.tsx
+++ b/packages/palette/src/elements/BarChart/BarChart.test.tsx
@@ -12,7 +12,7 @@ const mockBars = [
   { value: 100 },
   { value: 1000 },
   {
-    value: 4000,
+    value: 0,
     highlightLabel: (
       <Flex alignItems="center" flexDirection="column" id="highlight-label">
         <Sans weight="medium" size="2">
@@ -81,6 +81,17 @@ describe("BarChart", () => {
   it("shows the correct number of bars", () => {
     const chart = getWrapper()
     expect(chart.find(Bar)).toHaveLength(mockBars.length)
+  })
+
+  it("defaults to showing a minimum-height bar if the artwork's highlighted bin is empty", () => {
+    const chart = getWrapper()
+    const highlightedBar = chart.find(Bar).at(2)
+    const computedStyle = getComputedStyle(highlightedBar.getDOMNode())
+
+    // Waiting for animation to finish
+    setTimeout(() => {
+      expect(computedStyle.getPropertyValue("height")).toMatch("10px")
+    }, 1100)
   })
 
   it("shows the highlighted bar in a different color", () => {


### PR DESCRIPTION
See context here: https://artsy.slack.com/archives/C9YNS4X32/p1554200961150900

If a bin has 0 works but is highlighted, display min 10px bar.

__Before:__
<img width="243" alt="Screen Shot 2019-04-03 at 4 11 59 PM" src="https://user-images.githubusercontent.com/5643895/55510020-499b2e80-562b-11e9-9be1-64f71f1aecdd.png">

__After:__
<img width="259" alt="Screen Shot 2019-04-03 at 4 11 17 PM" src="https://user-images.githubusercontent.com/5643895/55510032-5029a600-562b-11e9-8af2-b7b7c4b3a530.png">
