### PR TITLE
Add background to <Flex>

### DIFF
--- a/packages/palette/src/elements/Flex/Flex.tsx
+++ b/packages/palette/src/elements/Flex/Flex.tsx
@@ -5,6 +5,8 @@ import {
   AlignContentProps,
   alignItems,
   AlignItemsProps,
+  background,
+  BackgroundProps,
   bottom,
   BottomProps,
   display,
@@ -44,6 +46,7 @@ const flexGrow = style({
 export interface FlexProps
   extends AlignItemsProps,
     AlignContentProps,
+    BackgroundProps,
     BottomProps,
     DisplayProps,
     FlexBasisProps,
@@ -67,6 +70,7 @@ export const Flex = primitives.View<FlexProps>`
   display: flex;
   ${alignContent};
   ${alignItems};
+  ${background};
   ${bottom};
   ${display};
   ${flexBasis};


### PR DESCRIPTION
I had the need of using `background` with `<Flex>` but it doesn't seem to accept it. This will help clean up [the code in Prediction](https://github.com/artsy/prediction/blob/5ddf80542f35b45c4f2a281c434f3e2597799ec6/src/apps/operator/operator3/StartingAsk.tsx#L130-L133): 

```tsx
// TODO: The <Flex /> component should accept the `bg` prop
const Container = styled(Flex)`
  background-color: ${theme.colors.white100};
`
```