### PR TITLE
Change the color of Chevron icon

### DIFF
--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -25,7 +25,7 @@ export const Stepper = (props: StepperProps) => {
       key={props.currentStepIndex}
       separator={
         <ChevronWrapper>
-          <ChevronIcon fill={"black60"} />
+          <ChevronIcon fill={"black30"} />
         </ChevronWrapper>
       }
       transformTabBtn={transformTabBtn}


### PR DESCRIPTION
Based on https://artsyproduct.atlassian.net/browse/PURCHASE-982, looks like the color of these icons are slightly brighter than what we currently have, changed it to `black30` with @lilyfromseattle.

We also tried to change the size to make it little smaller to match that design but making it smaller would actually cause some small alignment issues so we didn't do that part.