### PR TITLE
creates a docs-only <ColorComponent> to allow display of separate colors

### DIFF
--- a/packages/palette-docs/content/docs/tokens/Color.mdx
+++ b/packages/palette-docs/content/docs/tokens/Color.mdx
@@ -6,15 +6,6 @@ See [Notion](https://www.notion.so/artsy/Color-a0c24896daf8433d9409aee2146ac267)
 for more detailed spec.
 
 <Box>
-  {Object.entries(themeProps.colors).map(([colorCode, hex], index) => {
-    return (
-      <Box mb={3} key={index}>
-        <Sans size="3" weight="medium">
-          {colorCode}
-        </Sans>
-        <Sans size="3">{hex}</Sans>
-        <Box width="100%" height={5} bg={colorCode} />
-      </Box>
-    )
-  })}
+  <ColorComponent color="black100" hex="#000" />
+  <ColorComponent color="black80" hex="#333" />
 </Box>

--- a/packages/palette-docs/content/docs/tokens/Color.mdx
+++ b/packages/palette-docs/content/docs/tokens/Color.mdx
@@ -6,6 +6,6 @@ See [Notion](https://www.notion.so/artsy/Color-a0c24896daf8433d9409aee2146ac267)
 for more detailed spec.
 
 <Box>
-  <ColorComponent color="black100" hex="#000" />
-  <ColorComponent color="black80" hex="#333" />
+  <ColorComponent color="black100" />
+  <ColorComponent color="purple100" />
 </Box>

--- a/packages/palette-docs/gatsby-config.js
+++ b/packages/palette-docs/gatsby-config.js
@@ -33,10 +33,12 @@ module.exports = {
         // gatsby-mdx. See https://github.com/ChristopherBiscardi/gatsby-mdx/issues/243
         globalScope: `
           import * as Elements from "@artsy/palette"
+          import { ColorComponent } from "components/ColorComponent"
           import { CodeEditor, Playground  } from "components/Playground"
           import { Toggle as Toggler } from 'react-powerplug'
           export default {
             CodeEditor,
+            ColorComponent,
             Playground,
             Toggler,
             ...Elements

--- a/packages/palette-docs/src/components/ColorComponent.jsx
+++ b/packages/palette-docs/src/components/ColorComponent.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, Sans } from "@artsy/palette"
+import { Box, Sans, themeProps } from "@artsy/palette"
 
 export const ColorComponent = props => {
   return (
@@ -7,7 +7,11 @@ export const ColorComponent = props => {
       <Sans size="3" weight="medium">
         {props.color}
       </Sans>
-      <Sans size="3">{props.hex}</Sans>
+      <Sans size="3">
+        {themeProps.colors.hasOwnProperty(`${props.color}`)
+          ? themeProps.colors[`${props.color}`]
+          : ""}
+      </Sans>
       <Box width="100%" height={5} bg={props.color} />
     </Box>
   )

--- a/packages/palette-docs/src/components/ColorComponent.jsx
+++ b/packages/palette-docs/src/components/ColorComponent.jsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { Box, Sans } from "@artsy/palette"
+
+export const ColorComponent = props => {
+  return (
+    <Box mb={3}>
+      <Sans size="3" weight="medium">
+        {props.color}
+      </Sans>
+      <Sans size="3">{props.hex}</Sans>
+      <Box width="100%" height={5} bg={props.color} />
+    </Box>
+  )
+}

--- a/packages/palette-docs/src/components/GlobalComponents.jsx
+++ b/packages/palette-docs/src/components/GlobalComponents.jsx
@@ -93,8 +93,8 @@ export const MarkdownComponents = {
    *
    * Color is the color from Palette's theme, e.g. purple100
    */
-  color: ({ color }) => {
-    return <ColorComponent color={color} />
+  colorComponent: props => {
+    return <ColorComponent color={props.color} />
   },
   div: props => {
     return <div className="contentDiv">{props.children}</div>

--- a/packages/palette-docs/src/components/GlobalComponents.jsx
+++ b/packages/palette-docs/src/components/GlobalComponents.jsx
@@ -3,6 +3,7 @@
 import React from "react"
 import * as Palette from "@artsy/palette"
 import { CodeEditor } from "../components/Playground"
+import { ColorComponent } from "../components/ColorComponent"
 
 import {
   Box,
@@ -86,6 +87,14 @@ export const MarkdownComponents = {
         scope={{}}
       />
     )
+  },
+  /**
+   * Use color to render a color bar and relevant information about it.
+   *
+   * Color is the color from Palette's theme, e.g. purple100
+   */
+  color: ({ color }) => {
+    return <ColorComponent color={color} />
   },
   div: props => {
     return <div className="contentDiv">{props.children}</div>


### PR DESCRIPTION
Discussed with @owendodd and Design would like to have the option to not display every color in Palette in the same section, instead picking out a color or group of colors to display.

This is due to a change in the way we're dealing with colors - in [Notion](https://www.notion.so/artsy/Color-a0c24896daf8433d9409aee2146ac267), you can see Primary, Secondary, and Deprecated colors, and these lists will likely grow and change over time.

The docs update in this PR allows greater flexibility by creating a mini-component that takes a color (e.g. `black100`) and outputting a color bar, hex code, and title in the same manner as the old `Colors` page.

After this is merged, @owendodd can create `<ColorComponents />` using the docs admin to match our current colors.

Two things that could be improved about this implementation:
1. hexes are not automatically generated and have to be input separately from the color code. I feel like this could be fixed, but not sure how.
2. This will have to be manually updated every time we change or add to our colors. Would be great to figure out a way to automate that process.

Old page, which always displayed every color:
<img width="1789" alt="Screen Shot 2019-04-16 at 1 42 00 PM" src="https://user-images.githubusercontent.com/5361806/56231871-7a2c9080-604d-11e9-8f44-d5d67158d4e1.png">

New page, which allows display of select colors:
<img width="1789" alt="Screen Shot 2019-04-16 at 1 42 03 PM" src="https://user-images.githubusercontent.com/5361806/56231872-7a2c9080-604d-11e9-8998-7daa9eb51459.png">
