### PR TITLE
Tooltip related changes

### DIFF
--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -52,14 +52,9 @@ const Tip = styled(BorderBox)<TipProps>`
   }
 `
 
-enum TipSize {
-  Sm = "sm",
-  Lg = "lg",
-}
-
 export interface TooltipProps {
   content: React.ReactNode
-  size: TipSize
+  size: "sm" | "lg"
   width: number
 }
 
@@ -68,7 +63,7 @@ export interface TooltipProps {
  */
 export class Tooltip extends React.Component<TooltipProps> {
   static defaultProps = {
-    size: TipSize.Lg,
+    size: "lg",
     width: 230,
   }
 
@@ -146,7 +141,7 @@ export class Tooltip extends React.Component<TooltipProps> {
       >
         <Tip
           className={this.state.active && "active"}
-          p={this.props.size === TipSize.Sm ? 0.5 : 2}
+          p={this.props.size === "sm" ? 0.5 : 2}
           tipPosition={this.state.tipPosition}
           width={this.props.width}
         >

--- a/packages/palette/src/svgs/QuestionCircleIcon.tsx
+++ b/packages/palette/src/svgs/QuestionCircleIcon.tsx
@@ -6,7 +6,6 @@ import { Icon, IconProps } from "./Icon"
 export const QuestionCircleIcon: React.SFC<IconProps> = props => {
   return (
     <Icon {...props} viewBox="0 0 18 18">
-      <title>Help</title>
       <path
         d="M9 1.889A7.111 7.111 0 1 1 9 16.11 7.111 7.111 0 0 1 9 1.89zM9 1a8 8 0 1 0 0 16A8 8 0 0 0 9 1zm-.658 9.92v-.142c0-1.111.214-1.458 1.307-2.418.405-.294.66-.753.693-1.253a1.182 1.182 0 0 0-1.298-1.254 1.422 1.422 0 0 0-1.448 1.6H6.573a2.391 2.391 0 0 1 2.534-2.4 2.089 2.089 0 0 1 2.32 2c0 1.716-2.143 2.01-2.143 3.69v.177h-.942zm-.089 2.027V11.8H9.41v1.147H8.253z"
         fill={color(props.fill)}


### PR DESCRIPTION
Removed unused title from help icon
All uses of HelpIcon/QuestionCircleIcon have their own custom tooltip

https://github.com/artsy/reaction/blob/7eb428eb4c16dac01b39efce581f1bf991d90925/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBidAction.tsx#L186-L189

https://github.com/artsy/reaction/blob/7eb428eb4c16dac01b39efce581f1bf991d90925/src/Components/Artist/MarketInsights/MarketInsights.tsx#L134-L138

----

replaced TipSize enum with plain strings. After discussion with Alloy we concluded the enum wasn't adding much and strings were simpler.
