### PR TITLE
[Menu] Fix drop shadow color

### DIFF
--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -40,7 +40,7 @@ export const Menu: React.FC<MenuProps> = ({ title, children, ...props }) => {
 
 const MenuContainer = styled(Box)`
   background-color: white;
-  box-shadow: 2px 2px 4px 2px ${color("black5")};
+  box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.05);
 `
 
 // Menu Item


### PR DESCRIPTION
Ensures that the shadow is black so that it doesn't mix strangely with image overlays. 

#trivial  