### PR TITLE
Auto approve chromatic results on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
             branches:
               ignore: master
       - yarn/run:
-          name: visual-test
+          name: visual-test-master
           script: visual-test --auto-accept-changes
           requires:
             - yarn/workflow-queue

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,17 @@ workflows:
           script: visual-test
           requires:
             - yarn/workflow-queue
+          filters:
+            branches:
+              ignore: master
+      - yarn/run:
+          name: visual-test
+          script: visual-test --auto-accept-changes
+          requires:
+            - yarn/workflow-queue
+          filters:
+            branches:
+              only: master
       - yarn/auto-release:
           # The deploy job is the _only_ job that should have access to our npm
           # tokens. We include a context that has our publish credentials


### PR DESCRIPTION
When a chromatic test runs on master let's just auto accept any diffs. 

This is recommended by the chromatic docs: http://docs.chromaticqa.com/setup_ci#maintain-a-clean-master-branch