### PR TITLE
Update to use the @artsy:lib renovate workflow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,10 @@
 {
   "extends": [
-    "@artsy"
+    "@artsy:lib"
   ],
   "assignees": [
     "zephraph",
     "damassi",
     "l2succes"
-  ],
-  "ignorePaths": [
-    "www"
   ]
 }


### PR DESCRIPTION
Put palette on the `lib` renovate config. It'll create a masterIssue with non `@artsy` dependencies. 