### PR TITLE
Add storybook for Join component and a couple of more tests.

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -29,7 +29,7 @@
     "watch:emission": "yarn clean:emission && concurrently --raw --kill-others 'yarn compile:emission -w' 'yarn type-declarations -w --outDir ../../../emission/node_modules/@artsy/palette/dist'",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "visual-test": "chromatic test --exit-zero-on-changes"
+    "visual-test": "chromatic test --exit-zero-on-changes --app-code n02zjqmdqq"
   },
   "repository": {
     "type": "git",

--- a/packages/palette/src/elements/Join/Join.story.tsx
+++ b/packages/palette/src/elements/Join/Join.story.tsx
@@ -1,11 +1,31 @@
 import { storiesOf } from "@storybook/react"
-import React from "react"
+import React, { Component } from "react"
 import { Box } from "../Box/Box"
 import { Separator } from "../Separator/Separator"
 import { Join } from "./Join"
 
-const BlankComponent = () => {
+const BlankFunction = () => {
   return null
+}
+
+const NonBlankFunction = () => {
+  return <div>Non blank Function</div>
+}
+
+const BlankSFC: React.SFC = () => null
+
+const NonBlankSFC: React.SFC = () => <div>Non blanks stateless component</div>
+
+class BlankComponent extends Component {
+  render() {
+    return null
+  }
+}
+
+class NonBlankComponent extends Component {
+  render() {
+    return <Box>Non Blank Component</Box>
+  }
 }
 
 storiesOf("Components/Join", module)
@@ -28,7 +48,12 @@ storiesOf("Components/Join", module)
     return (
       <Join separator={<Separator m={1} />}>
         <Box>Fist in the list</Box>
+        <BlankFunction />
+        <NonBlankFunction />
+        <BlankSFC />
+        <NonBlankSFC />
         <BlankComponent />
+        <NonBlankComponent />
         <Box m="2" />
         <div>Some div with the content</div>
         <div />

--- a/packages/palette/src/elements/Join/Join.story.tsx
+++ b/packages/palette/src/elements/Join/Join.story.tsx
@@ -1,0 +1,39 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Box } from "../Box/Box"
+import { Separator } from "../Separator/Separator"
+import { Join } from "./Join"
+
+const BlankComponent = () => {
+  return null
+}
+
+storiesOf("Components/Join", module)
+  .add("with multiple components", () => {
+    return (
+      <Join separator={<Separator m={1} />}>
+        <Box>Fist in the list</Box>
+        <Box>Second in the list</Box>
+      </Join>
+    )
+  })
+  .add("with one component", () => {
+    return (
+      <Join separator={<Separator m={1} />}>
+        <Box>Only one component here</Box>
+      </Join>
+    )
+  })
+  .add("with some of the children empty", () => {
+    return (
+      <Join separator={<Separator m={1} />}>
+        <Box>Fist in the list</Box>
+        <BlankComponent />
+        <Box m="2" />
+        <div>Some div with the content</div>
+        <div />
+        <Box>Another box with content</Box>
+        <div />
+      </Join>
+    )
+  })

--- a/packages/palette/src/elements/Join/Join.test.tsx
+++ b/packages/palette/src/elements/Join/Join.test.tsx
@@ -19,12 +19,25 @@ describe("Join", () => {
     expect(wrapper.html()).toContain("foundSeparator")
   })
 
-  it("does not render blank component", () => {
+  it("renders blank component with separator unfortunately", () => {
     const wrapper = mount(
       <div>
         <Join separator={<div className="foundSeparator">,</div>}>
           <div>hi</div>
           <div />
+        </Join>
+      </div>
+    )
+
+    expect(wrapper.text()).toEqual("hi,")
+    expect(wrapper.html()).toContain("foundSeparator")
+  })
+
+  it("does not render separator with only one component in children", () => {
+    const wrapper = mount(
+      <div>
+        <Join separator={<div className="foundSeparator">,</div>}>
+          <div>hi</div>
         </Join>
       </div>
     )

--- a/packages/palette/src/elements/Join/Join.test.tsx
+++ b/packages/palette/src/elements/Join/Join.test.tsx
@@ -18,4 +18,18 @@ describe("Join", () => {
     expect(wrapper.text()).toEqual("hi,how,are,you")
     expect(wrapper.html()).toContain("foundSeparator")
   })
+
+  it("does not render blank component", () => {
+    const wrapper = mount(
+      <div>
+        <Join separator={<div className="foundSeparator">,</div>}>
+          <div>hi</div>
+          <div />
+        </Join>
+      </div>
+    )
+
+    expect(wrapper.text()).toEqual("hi")
+    expect(wrapper.html()).not.toContain("foundSeparator")
+  })
 })

--- a/packages/palette/src/elements/Join/Join.tsx
+++ b/packages/palette/src/elements/Join/Join.tsx
@@ -26,15 +26,18 @@ interface JoinProps {
  */
 export const Join: SFC<JoinProps> = ({ separator, children }) => {
   const childArray = React.Children.toArray(children) as any
+  const filteredChildren = childArray.filter(
+    child => child && child.props && child.props.children
+  )
 
-  return childArray.reduce((acc, curr, currentIndex) => {
+  return filteredChildren.reduce((acc, curr, currentIndex) => {
     acc.push(
       React.cloneElement(curr as React.ReactElement<any>, {
         key: `join-${currentIndex}`,
       })
     )
 
-    if (currentIndex !== childArray.length - 1) {
+    if (currentIndex !== filteredChildren.length - 1) {
       acc.push(
         separator &&
           React.cloneElement(separator, {

--- a/packages/palette/src/elements/Join/Join.tsx
+++ b/packages/palette/src/elements/Join/Join.tsx
@@ -26,18 +26,15 @@ interface JoinProps {
  */
 export const Join: SFC<JoinProps> = ({ separator, children }) => {
   const childArray = React.Children.toArray(children) as any
-  const filteredChildren = childArray.filter(
-    child => child && child.props && child.props.children
-  )
 
-  return filteredChildren.reduce((acc, curr, currentIndex) => {
+  return childArray.reduce((acc, curr, currentIndex) => {
     acc.push(
       React.cloneElement(curr as React.ReactElement<any>, {
         key: `join-${currentIndex}`,
       })
     )
 
-    if (currentIndex !== filteredChildren.length - 1) {
+    if (currentIndex !== childArray.length - 1) {
       acc.push(
         separator &&
           React.cloneElement(separator, {


### PR DESCRIPTION
The original idea was to skip rendering blank components if those are passed as children to Join. But that is very hard to do without pre-rendering the components first. I've abandoned that idea but added a storybook and a couple of tests in a process for Join component. So those could stay :)

The Storybook entry:
<img width="1253" alt="Screen Shot 2019-05-01 at 4 17 06 PM" src="https://user-images.githubusercontent.com/437156/57040319-097c9b00-6c2d-11e9-9d06-2bcaa29a91d4.png">

