### PR TITLE
Fix some urls in the documentation

### DIFF
--- a/packages/palette-docs/content/docs/home/getting-started.mdx
+++ b/packages/palette-docs/content/docs/home/getting-started.mdx
@@ -34,7 +34,8 @@ export const App = props => {
 ```
 
 From there you should be able to access the values from Palette's
-[Theme.tsx](https://github.com/artsy/palette/blob/master/src/Theme.tsx) file:
+[Theme.tsx](https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx)
+file:
 
 ```js
 import { BorderBox, Flex, Sans, Serif } from '@artsy/palette

--- a/packages/palette-docs/content/docs/tokens/Spacing.mdx
+++ b/packages/palette-docs/content/docs/tokens/Spacing.mdx
@@ -5,7 +5,7 @@ subNavOrder: 1
 
 ### Theme
 
-https://github.com/artsy/palette/blob/master/src/Theme.tsx#L116
+https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx#L116
 
 ### API
 
@@ -31,7 +31,7 @@ Spacing units are set in multiples of 10px.
 ## Example
 
 When building layouts and components, palette hooks into a
-[Theme file](https://github.com/artsy/palette/blob/master/src/Theme.tsx#L116)
+[Theme file](https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx#L116)
 for returning values. This allows us to constrain the possibilities available to
 a component to only what's defined in our spacing system and thus reduce drift.
 


### PR DESCRIPTION
Looks like some URLs in the documentation need an update after the recent folder structure reorg.