### PR TITLE
Pass disabled prop down to button DOM element

### DIFF
--- a/packages/palette-docs/content/docs/elements/buttons/Button.mdx
+++ b/packages/palette-docs/content/docs/elements/buttons/Button.mdx
@@ -2,6 +2,7 @@
 name: Button
 lastPointOfContact: Nicole
 ---
+
 Primary buttons should be used for the primary desired user action. Do not use 2
 primary buttons in the same screen. If there are multiple primary options, use
 secondary-gray.
@@ -13,49 +14,52 @@ secondary-gray.
 Our secondary-outline is our default secondary button style. Avoid using this in
 the presence of inputs, as to not confuse it’s use.
 
-  <Box>
-    <Button width="33%">Purchase</Button>
-    <Spacer mb={1} />
-    <Button variant="secondaryOutline" width="33%">
-      Make offer
-    </Button>
-  </Box>
+<Box>
+  <Button width="33%">Purchase</Button>
+  <Spacer mb={1} />
+  <Button variant="secondaryOutline" width="33%">
+    Make offer
+  </Button>
+</Box>
 
 <Spacer my={2} />
 
-When needing to provide the ability to Show more content, we always use the secondary-outline style.
+When needing to provide the ability to Show more content, we always use the
+secondary-outline style.
 
 <Box>
-    <Button variant="secondaryOutline" width="33%">
-      Show more
-    </Button>
+  <Button variant="secondaryOutline" width="33%">
+    Show more
+  </Button>
 </Box>
 
 <Spacer my={2} />
 
 **Thinking usecases**
 
-The thinking state is used when there may be a delay in response time, ie, bidding, or following an artist.
+The thinking state is used when there may be a delay in response time, ie,
+bidding, or following an artist.
 
-  <Box>
-    <Button variant="primaryBlack" size="large" m={0.5} loading>
-      Show more
-    </Button>
-  </Box>
+<Box>
+  <Button variant="primaryBlack" size="large" m={0.5} loading>
+    Show more
+  </Button>
+</Box>
 
-Thinking inline should be used when the action taken reveals more content in the same context, ie, infinite scroll or expanding information.
+Thinking inline should be used when the action taken reveals more content in the
+same context, ie, infinite scroll or expanding information.
 
-  <Box>
-    <Button variant="secondaryOutline" width="33%">
-      Show more
-    </Button>
-  </Box>
+<Box>
+  <Button variant="secondaryOutline" width="33%">
+    Show more
+  </Button>
+</Box>
 
-  <Box>
-    <Button variant="secondaryGray" size="large" m={0.5} loading>
-      Show more
-    </Button>
-  </Box>
+<Box>
+  <Button variant="secondaryGray" size="large" m={0.5} loading>
+    Show more
+  </Button>
+</Box>
 
 In the presence of inputs, use secondary-gray for the secondary button style.
 
@@ -73,6 +77,16 @@ In the presence of inputs, use secondary-gray for the secondary button style.
 </Playground>
 
 <Spacer mb={4} />
+
+## Disabled
+
+Like other form elements, buttons can be disabled.
+
+<Playground>
+  <BorderBox>
+    <Button disabled>Submit</Button>
+  </BorderBox>
+</Playground>
 
 ## All Variants
 

--- a/packages/palette/src/elements/Button/Button.test.tsx
+++ b/packages/palette/src/elements/Button/Button.test.tsx
@@ -68,4 +68,17 @@ describe("Button", () => {
 
     expect(onClickMock).not.toHaveBeenCalled()
   })
+
+  it("passes the `disabled` prop down to the DOM element", () => {
+    const wrapper = mount(
+      <Theme>
+        <>
+          <Button>Good</Button>
+          <Button disabled>No good</Button>
+        </>
+      </Theme>
+    )
+
+    expect(wrapper.find("button[disabled]")).toHaveLength(1)
+  })
 })

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -224,6 +224,7 @@ export class ButtonBase extends Component<ButtonBaseProps & SansProps> {
         {...rest}
         className={[loadingClass, disabledClass].join(" ")}
         onClick={this.onClick}
+        disabled={disabled}
       >
         {loading && <Spinner size={this.props.buttonSize} />}
 


### PR DESCRIPTION
See:
- https://artsy.slack.com/archives/C9XJKPY9W/p1557249933014500
- https://github.com/artsy/rosalind/pull/180/commits/0b008d9069ad52aa3eebc51409e0b717331ce50f

This makes the Button component consistent with accessibility best practices and with our other form components by ensuring that passing a `disabled` prop to Button results in the rendered `<button>` DOM element having the `disabled` attribute as well (and not just a css class)

### Before

<img width="1336" alt="bad" src="https://user-images.githubusercontent.com/140521/57321689-e3914380-70cf-11e9-9080-6d5d3e167433.png">

### After

<img width="1336" alt="good" src="https://user-images.githubusercontent.com/140521/57321691-e3914380-70cf-11e9-8446-02d8516c8ca2.png">
