### PR TITLE
[Menu] Add onClick event type to interface

### DIFF
--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -13,6 +13,7 @@ import { Sans } from "../Typography"
 interface MenuProps {
   title?: string
   children?: React.ReactNode
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void
 }
 
 /** Menu */


### PR DESCRIPTION
Adds an `onClick` event to the Menu interface 

#trivial 