### PR TITLE
Add some help for users who might be confused why their `Radio` isn't selected.

### DIFF
--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -19,7 +19,7 @@ import {
 export interface RadioProps extends FlexProps {
   /** Disable interactions */
   disabled?: boolean
-  /** Select the button on render */
+  /** Select the button on render. If the Radio is inside a RadioGroup, use RadioGroup.defaultValue instead. */
   selected?: boolean
   /** Show hover state on render */
   hover?: boolean


### PR DESCRIPTION
In https://github.com/artsy/reaction/pull/2439, I found a `Radio` that was setting `selected` based on a prop, but it "wasn't working," because it was wrapped in a `RadioGroup`. In that scenario, `RadioGroup`.`defaultValue` is the correct way to mark the individual `Radio` items as selected.

If you'd like different verbiage, please suggest it!