### PR TITLE
Add a MiniSelect as a select component

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/Select.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Select.mdx
@@ -81,3 +81,21 @@ of user-benefitting product strategy.
     ]}
   />
 </Playground>
+
+### Mini select
+
+<Playground>
+  <MiniSelect
+    options={[
+      {
+        text: "First option",
+        value: "firstOption",
+      },
+      {
+        text: "Second option",
+        value: "secondOption",
+      },
+    ]}
+    selected="secondOption"
+  />
+</Playground>

--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -1,0 +1,56 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { LargeSelect, MiniSelect } from "./Select"
+
+storiesOf("Components/Select", module)
+  .add("LargeSelect", () => {
+    return (
+      <LargeSelect
+        options={[
+          {
+            text: "First",
+            value: "firstValue",
+          },
+          {
+            text: "Last",
+            value: "lastValue",
+          },
+        ]}
+        selected="lastValue"
+      />
+    )
+  })
+  .add("MiniSelect with title", () => {
+    return (
+      <MiniSelect
+        options={[
+          {
+            text: "Price",
+            value: "price",
+          },
+          {
+            text: "Estimate and some other text",
+            value: "estimate",
+          },
+        ]}
+        title="Sort"
+      />
+    )
+  })
+  .add("MiniSelect with includeBackground", () => {
+    return (
+      <MiniSelect
+        options={[
+          {
+            text: "First option",
+            value: "firstOption",
+          },
+          {
+            text: "Second option that is really long",
+            value: "SecondOption",
+          },
+        ]}
+        selected="SecondOption"
+      />
+    )
+  })

--- a/packages/palette/src/elements/Select/Select.test.tsx
+++ b/packages/palette/src/elements/Select/Select.test.tsx
@@ -1,47 +1,42 @@
-// import { selectProps } from "Apps/__test__/Fixtures/Select"
-// import { Boot } from "Artsy/Router"
-// import { mount } from "enzyme"
-// import React from "react"
-// import { LargeSelect, Select, SmallSelect } from "elements/Select"
+import { mount } from "enzyme"
+import React from "react"
+import { MiniSelect } from "../Select"
 
 describe("Select", () => {
-  it("TODO", () => {
-    //
+  describe("MiniSelect", () => {
+    const options = [
+      {
+        text: "First option",
+        value: "firstOption",
+      },
+      {
+        text: "Second option that is really long",
+        value: "secondOption",
+      },
+    ]
+    it("renders proper options with correct selected one", () => {
+      const wrapper = mount(
+        <MiniSelect options={options} selected="secondOption" />
+      )
+
+      expect(wrapper.find("option").length).toBe(2)
+      expect(wrapper.find("select").props().value).toBe("secondOption")
+    })
+
+    it("triggers callback on change", () => {
+      const spy = jest.fn()
+      const wrapper = mount(<MiniSelect options={options} onSelect={spy} />)
+      wrapper
+        .find("option")
+        .at(1)
+        .simulate("change")
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it("supports title attribute and renders it properly", () => {
+      const wrapper = mount(<MiniSelect options={options} title="Sort" />)
+
+      expect(wrapper.html()).toContain("Sort:")
+    })
   })
 })
-//   beforeAll(() => {
-//     window.matchMedia = undefined // Immediately set matching media query in Boot
-//   })
-
-//   it("is responsive", () => {
-//     const small = mount(
-//       <Boot initialMatchingMediaQueries={["xs"]}>
-//         <Select {...selectProps} />
-//       </Boot>
-//     )
-//     expect(small.find(LargeSelect).length).toEqual(1) // Inverted
-
-//     const large = mount(
-//       <Boot initialMatchingMediaQueries={["lg"]}>
-//         <Select {...selectProps} />
-//       </Boot>
-//     )
-//     expect(large.find(SmallSelect).length).toEqual(1)
-//     expect(small.find("option").length).toBe(3)
-//     expect(large.find("option").length).toBe(3)
-//   })
-
-//   it("triggers callback on change", () => {
-//     const spy = jest.fn()
-//     const wrapper = mount(
-//       <Boot initialMatchingMediaQueries={["xs"]}>
-//         <Select {...selectProps} onSelect={spy} />
-//       </Boot>
-//     )
-//     wrapper
-//       .find("option")
-//       .at(1)
-//       .simulate("change")
-//     expect(spy).toHaveBeenCalled()
-//   })
-// })

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -199,6 +199,7 @@ const MiniSelectContainer = styled.div<SelectProps>`
     background-color: ${color("black10")};
     border-radius: 2px;
     font-size: ${themeGet("typeSizes.sans.2.fontSize")}px;
+    font-weight: 500;
     line-height: ${themeGet("typeSizes.sans.2.lineHeight")}px;
     padding: ${space(0.5)}px ${space(1) + carretSize * 4}px ${space(0.5)}px
       ${space(1)}px;

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -19,6 +19,7 @@ export interface SelectProps extends PositionProps, SpaceProps {
   selected?: string
   disabled?: boolean
   error?: string
+  title?: string
   onSelect?: (value) => void
 }
 
@@ -71,6 +72,36 @@ export const SmallSelect: SFC<SelectProps> = props => {
   )
 }
 
+/**
+ * A mini drop-down select menu
+ */
+export const MiniSelect: SFC<SelectProps> = props => {
+  return (
+    <MiniSelectContainer {...props}>
+      <label>
+        {props.title && (
+          <Sans size="2" display="inline" mr={0.5}>
+            {props.title}:
+          </Sans>
+        )}
+
+        <select
+          value={props.selected}
+          onChange={event =>
+            props.onSelect && props.onSelect(event.target.value)
+          }
+        >
+          {props.options.map(({ value, text }) => (
+            <option value={value} key={value}>
+              {text}
+            </option>
+          ))}
+        </select>
+      </label>
+    </MiniSelectContainer>
+  )
+}
+
 const hideDefaultSkin = css`
   background: none;
   border: none;
@@ -91,11 +122,11 @@ const hideDefaultSkin = css`
     color: black; /* prevent <option>s from becoming transparent as well */
   }
 `
-
+const carretSize = 4
 const caretArrow = css<SelectProps>`
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 4px solid
+  border-left: ${carretSize}px solid transparent;
+  border-right: ${carretSize}px solid transparent;
+  border-top: ${carretSize}px solid
     ${props => (props.disabled ? color("black10") : color("black100"))};
   width: 0;
   height: 0;
@@ -158,4 +189,35 @@ const SmallSelectContainer = styled.div<SelectProps>`
   }
 
   ${styledSpace};
+`
+
+const MiniSelectContainer = styled.div<SelectProps>`
+  position: relative;
+
+  select {
+    ${hideDefaultSkin};
+    background-color: ${color("black10")};
+    border-radius: 2px;
+    font-size: ${themeGet("typeSizes.sans.2.fontSize")}px;
+    line-height: ${themeGet("typeSizes.sans.2.lineHeight")}px;
+    padding: ${space(0.5)}px ${space(1) + carretSize * 4}px ${space(0.5)}px
+      ${space(1)}px;
+
+    &:hover {
+      background-color: ${color("black30")};
+    }
+    &:focus {
+      border-color: ${color("purple100")};
+    }
+  }
+
+  &::after {
+    ${caretArrow};
+    content: "";
+    cursor: pointer;
+    margin-left: -${space(1) + carretSize * 2}px;
+    pointer-events: none;
+    position: absolute;
+    top: ${5 + space(0.5)}px;
+  }
 `


### PR DESCRIPTION
For now I've created this MiniSelect as an additional Select component. The idea is that once it's merged we can go ahead and update all the uses of SmallSelect with MiniSelect and then just kill SmallSelect option here.

The looks:
<img width="331" alt="Screen Shot 2019-05-22 at 3 31 36 PM" src="https://user-images.githubusercontent.com/437156/58203223-a029fe00-7ca7-11e9-944e-7f40a487a7d8.png">

<img width="278" alt="Screen Shot 2019-05-22 at 3 31 20 PM" src="https://user-images.githubusercontent.com/437156/58203230-a3bd8500-7ca7-11e9-8804-402f404afd20.png">

<img width="288" alt="Screen Shot 2019-05-22 at 3 31 30 PM" src="https://user-images.githubusercontent.com/437156/58203235-a7510c00-7ca7-11e9-8d2f-fd763554d1e1.png">
