### PR TITLE
Add identifier_field to fix page creation errors

### DIFF
--- a/packages/palette-docs/static/admin/config.js
+++ b/packages/palette-docs/static/admin/config.js
@@ -3,6 +3,7 @@ const defaultFields = {
   format: "frontmatter",
   widget: "mdx",
   create: true,
+  identifier_field: "name",
   fields: [
     {
       label: "Name",


### PR DESCRIPTION
@nicoleyeo was having issues creating new pages. She was getting this error: 

![image](https://user-images.githubusercontent.com/3087225/58282391-98379000-7d73-11e9-8ec4-1df602a46953.png)

I found some [documentation](https://github.com/netlify/netlify-cms/blob/master/website/content/docs/collection-types.md#folder-collections) on the netlify-cms docs that mentioned having a field with `{ name: "title" }` was required unless we specify an `identifier_field`. 

I just added the `identifier_field` to hopefully fix the issue. 