### PR TITLE
Add the ability to prevent right-click on <Image> elements

### DIFF
--- a/packages/palette-docs/content/docs/elements/images/Image.mdx
+++ b/packages/palette-docs/content/docs/elements/images/Image.mdx
@@ -24,6 +24,21 @@ prop. This is an important performance optimization.
   />
 </Playground>
 
+### Preventing right-click
+
+We generally don't want artwork images to be downloaded by users. Mark an image
+with the `preventRightClick` prop, and users will be unable to right click to
+"Save Image".
+
+<Playground>
+  <Image
+    width="300px"
+    height="200px"
+    src="https://picsum.photos/300/200/?random"
+    preventRightClick
+  />
+</Playground>
+
 ### Responsive image
 
 Used to fill an area provided regardless of proportions.

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -7,10 +7,25 @@ import {
 } from "./Image.shared"
 import { LazyImage } from "./LazyImage"
 
+interface WebImageProps extends ImageProps {
+  preventRightClick?: boolean
+}
+
 /** Image */
-export const Image = ({ lazyLoad = false, ...props }: ImageProps) => (
-  <LazyImage preload={!lazyLoad} imageComponent={BaseImage} {...props} />
-)
+export const Image = ({
+  lazyLoad = false,
+  preventRightClick = false,
+  ...props
+}: WebImageProps) => {
+  return (
+    <LazyImage
+      preload={!lazyLoad}
+      imageComponent={BaseImage}
+      {...props}
+      onContextMenu={e => preventRightClick && e.preventDefault()}
+    />
+  )
+}
 
 /** ResponsiveImage */
 export const ResponsiveImage = ({

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -7,11 +7,12 @@ import {
 } from "./Image.shared"
 import { LazyImage } from "./LazyImage"
 
+/** Props for a web-only Image component. */
 interface WebImageProps extends ImageProps {
   preventRightClick?: boolean
 }
 
-/** Image */
+/** A web-only Image component. */
 export const Image = ({
   lazyLoad = false,
   preventRightClick = false,
@@ -27,7 +28,7 @@ export const Image = ({
   )
 }
 
-/** ResponsiveImage */
+/** A web-only ResponsiveImage component. */
 export const ResponsiveImage = ({
   lazyLoad = false,
   ...props

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -59,6 +59,7 @@ interface LazyImageProps
   // TODO: Resolve type issues
   /** The image component to render when preload is true */
   imageComponent?: any // FunctionComponent<ImageProps>
+  onContextMenu?: (e: any) => void
 }
 
 /** LazyImage */


### PR DESCRIPTION
Collaboration with @jonallured 

Associated with https://artsyproduct.atlassian.net/browse/DISCO-1059

**Update:** I've cleaned up feedback on this PR, and I think it's in mergeable state.

---

## Background

We used to block users from right-clicking on any artwork images, to discourage them from downloading them. This functionality disappeared from most of the site as pieces were moved from Force to Reaction.

### Why the functionality was lost

The original logic to prevent right-click is [based on the CSS class names applied to images or their parent elements](https://github.com/artsy/force/blob/df49a2ac0bfdf99f0ca98158f7788df1e9e584be/src/desktop/components/prevent_right_click/index.jade#L8). 

```
    if (
      classes.match('artwork') ||
      classes.match('seadragon')
    ) e.preventDefault();
```

As things moved to Reaction, that meant that semantic CSS class names were turned into name-mangled styled-component class names, and they no longer matched the `classes.match('artwork')` line.

The `classes.match('seadragon')` line _is_ still effective - it applies the right click prevention to the large lightbox image on an artwork page. 

But I didn't find any other artwork images on the site that were still being helped by this logic.

## An approach I avoided

I started down the path of applying a `data-` attribute to images and then modifying the above logic to look for those, but I decided I didn't like it:

1. I found that climbing one level up to look for the data attribute wasn't always enough. This is probably not a big deal with [`element.closest()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest), but before I started working on that, I also realized....
2. I would be updating both Reaction _and_ Force to fix this, and it felt wrong. My interpretation is that things that _can_ be done in Reaction (or Palette) _should_ be done in Reaction (or Palette); since I had to add new logic anyway, I might as well put it in the "right" place.

## What Jon and I did instead

From a calling perspective, it makes sense to say `<Image preventRightClick ... />`, and have that take care of the right-click prevention. So that's what we built.

## One thing I haven't thought through yet
One uncovered feature of the old prevent-right-click logic is that [admins can _always_ right click](https://github.com/artsy/force/blob/df49a2ac0bfdf99f0ca98158f7788df1e9e584be/src/desktop/components/prevent_right_click/index.jade#L4). This is really helpful in the stages of development, so we can "Inspect Element" on them, and probably other reasons I haven't thought of.

I _think_ to support this with my current approach, I'd expect that to be handled by the caller. So when your component renders an `<Image>` tag, you'd do something like:

```
const isAdmin = this.props.user.type === "Admin"

return (
  <Image src={...} preventRightClick={!isAdmin} />
)
```

I haven't done a thorough search to know how much annoying repetition this would incur...and I'm open to other suggestions. This feels like the right approach to me, though.

## One other thing we wanted to ask about

**Update**: This section was addressed [in @damassi's comment](https://github.com/artsy/palette/pull/473#issuecomment-495807527). We'll leave it as-is!

We noticed that we support a [relatively small number of props for `<Image>` tags]((https://github.com/artsy/palette/blob/82b5a7ec7da966685601e9c7c1055ee6e3aa6e3d/packages/palette/src/elements/Image/Image.shared.tsx#L22)):

```
export interface BaseImageProps {
  /** The url for the image */
  src: string
  /** Alternate text for image */
  alt?: string
  /** A11y text label */
  ["aria-label"]?: string
  /** The title of the image */
  title?: string
  /** Apply additional styles to component */
  style?: object
  /** Flag for if image should be lazy loaded */
  lazyLoad?: boolean
  /** Event handler for right-clicking on the image */
  onContextMenu?: (e: any) => void
}

export interface ImageProps
  extends BaseImageProps,
    SpaceProps,
    WidthProps,
    HeightProps,
    BorderRadiusProps {
  preventRightClick?: boolean
}
```

Would it be better to support _any_ HTML-standard prop that a user might want to add to the underlying `img`? @damassi @zephraph this feels like a question for the two of you. On the one hand, locking it down to this subset gives us control over what people can do with our design system; on the other, any time someone wants to add an HTML-standard prop to an underlying `img` element, we have to first add support in Palette. 