### PR TITLE
rename MiniSelect to SelectSmall and create separate entry for it in docs

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/Select.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Select.mdx
@@ -1,5 +1,6 @@
 ---
 name: Select
+status: wip
 ---
 
 import { Value } from "react-powerplug"
@@ -79,23 +80,5 @@ of user-benefitting product strategy.
         value: "estimate",
       },
     ]}
-  />
-</Playground>
-
-### Mini select
-
-<Playground>
-  <MiniSelect
-    options={[
-      {
-        text: "First option",
-        value: "firstOption",
-      },
-      {
-        text: "Second option",
-        value: "secondOption",
-      },
-    ]}
-    selected="secondOption"
   />
 </Playground>

--- a/packages/palette-docs/content/docs/elements/inputs/SelectSmall.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/SelectSmall.mdx
@@ -1,0 +1,45 @@
+---
+name: SelectSmall
+status: wip
+---
+
+import { Value } from "react-powerplug"
+
+Used for tight UI moments, when dropdown select needs to recede, or needs to be displayed in multiple.
+
+### SelectSmall with title
+
+<Playground>
+  <SelectSmall
+    options={[
+      {
+        text: "Price",
+        value: "price",
+      },
+      {
+        text: "Estimate with additional details",
+        value: "estimate",
+      },
+    ]}
+    title="Sort"
+  />
+</Playground>
+
+
+### SelectSmall without title
+
+<Playground>
+  <SelectSmall
+    options={[
+      {
+        text: "First option",
+        value: "firstOption",
+      },
+      {
+        text: "Second option",
+        value: "secondOption",
+      },
+    ]}
+    selected="secondOption"
+  />
+</Playground>

--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
-import { LargeSelect, MiniSelect } from "./Select"
+import { LargeSelect, SelectSmall } from "./Select"
 
 storiesOf("Components/Select", module)
   .add("LargeSelect", () => {
@@ -20,9 +20,9 @@ storiesOf("Components/Select", module)
       />
     )
   })
-  .add("MiniSelect with title", () => {
+  .add("SelectSmall with title", () => {
     return (
-      <MiniSelect
+      <SelectSmall
         options={[
           {
             text: "Price",
@@ -37,9 +37,9 @@ storiesOf("Components/Select", module)
       />
     )
   })
-  .add("MiniSelect with includeBackground", () => {
+  .add("SelectSmall without title", () => {
     return (
-      <MiniSelect
+      <SelectSmall
         options={[
           {
             text: "First option",

--- a/packages/palette/src/elements/Select/Select.test.tsx
+++ b/packages/palette/src/elements/Select/Select.test.tsx
@@ -1,9 +1,9 @@
 import { mount } from "enzyme"
 import React from "react"
-import { MiniSelect } from "../Select"
+import { SelectSmall } from "../Select"
 
 describe("Select", () => {
-  describe("MiniSelect", () => {
+  describe("SelectSmall", () => {
     const options = [
       {
         text: "First option",
@@ -16,7 +16,7 @@ describe("Select", () => {
     ]
     it("renders proper options with correct selected one", () => {
       const wrapper = mount(
-        <MiniSelect options={options} selected="secondOption" />
+        <SelectSmall options={options} selected="secondOption" />
       )
 
       expect(wrapper.find("option").length).toBe(2)
@@ -25,7 +25,7 @@ describe("Select", () => {
 
     it("triggers callback on change", () => {
       const spy = jest.fn()
-      const wrapper = mount(<MiniSelect options={options} onSelect={spy} />)
+      const wrapper = mount(<SelectSmall options={options} onSelect={spy} />)
       wrapper
         .find("option")
         .at(1)
@@ -34,7 +34,7 @@ describe("Select", () => {
     })
 
     it("supports title attribute and renders it properly", () => {
-      const wrapper = mount(<MiniSelect options={options} title="Sort" />)
+      const wrapper = mount(<SelectSmall options={options} title="Sort" />)
 
       expect(wrapper.html()).toContain("Sort:")
     })

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -44,6 +44,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
   )
 }
 
+// TODO: Remove this SmallSelect below once all the clients use SelectSmall
 /**
  * A small drop-down select menu
  */
@@ -73,11 +74,11 @@ export const SmallSelect: SFC<SelectProps> = props => {
 }
 
 /**
- * A mini drop-down select menu
+ * A small version of drop-down select menu
  */
-export const MiniSelect: SFC<SelectProps> = props => {
+export const SelectSmall: SFC<SelectProps> = props => {
   return (
-    <MiniSelectContainer {...props}>
+    <SelectSmallContainer {...props}>
       <label>
         {props.title && (
           <Sans size="2" display="inline" mr={0.5}>
@@ -98,7 +99,7 @@ export const MiniSelect: SFC<SelectProps> = props => {
           ))}
         </select>
       </label>
-    </MiniSelectContainer>
+    </SelectSmallContainer>
   )
 }
 
@@ -191,7 +192,7 @@ const SmallSelectContainer = styled.div<SelectProps>`
   ${styledSpace};
 `
 
-const MiniSelectContainer = styled.div<SelectProps>`
+const SelectSmallContainer = styled.div<SelectProps>`
   position: relative;
 
   select {


### PR DESCRIPTION
Current view of `SelectSmall`:
<img width="1239" alt="Screen Shot 2019-05-28 at 2 49 04 PM" src="https://user-images.githubusercontent.com/437156/58504061-d8be5180-8157-11e9-8515-59ae4b5a5c59.png">

Did not do anything to `LargeSelect` for now. I think this is a separate refactor/upgrade.
cc @owendodd, @jeffreytr