### PR TITLE
remove unused SmallSelect and remove margin/padding on label for SelectSmall

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/Select.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Select.mdx
@@ -65,20 +65,3 @@ of user-benefitting product strategy.
     }}
   </Value>
 </Playground>
-
-### Small select
-
-<Playground>
-  <SmallSelect
-    options={[
-      {
-        text: "Price",
-        value: "price",
-      },
-      {
-        text: "Estimate",
-        value: "estimate",
-      },
-    ]}
-  />
-</Playground>

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -44,35 +44,6 @@ export const LargeSelect: SFC<SelectProps> = props => {
   )
 }
 
-// TODO: Remove this SmallSelect below once all the clients use SelectSmall
-/**
- * A small drop-down select menu
- */
-export const SmallSelect: SFC<SelectProps> = props => {
-  return (
-    <SmallSelectContainer {...props}>
-      <label>
-        <Sans size="2" display="inline" mr={0.5}>
-          Sort:
-        </Sans>
-
-        <select
-          value={props.selected}
-          onChange={event =>
-            props.onSelect && props.onSelect(event.target.value)
-          }
-        >
-          {props.options.map(({ value, text }) => (
-            <option value={value} key={value}>
-              {text}
-            </option>
-          ))}
-        </select>
-      </label>
-    </SmallSelectContainer>
-  )
-}
-
 /**
  * A small version of drop-down select menu
  */
@@ -169,38 +140,20 @@ const LargeSelectContainer = styled.div<SelectProps>`
   }
 `
 
-const SmallSelectContainer = styled.div<SelectProps>`
-  position: relative;
-
-  select {
-    font-size: ${themeGet("typeSizes.sans.2.fontSize")}px;
-    line-height: ${themeGet("typeSizes.sans.2.lineHeight")}px;
-    font-weight: bold;
-    ${hideDefaultSkin};
-  }
-
-  &::after {
-    content: "";
-    cursor: pointer;
-    pointer-events: none;
-    position: absolute;
-    top: 10px;
-    margin-left: -8px;
-    ${caretArrow};
-  }
-
-  ${styledSpace};
-`
-
 const SelectSmallContainer = styled.div<SelectProps>`
   position: relative;
+
+  label {
+    padding: 0;
+    margin: 0;
+  }
 
   select {
     ${hideDefaultSkin};
     background-color: ${color("black10")};
     border-radius: 2px;
+    ${themeGet("fontFamily.sans.medium")};
     font-size: ${themeGet("typeSizes.sans.2.fontSize")}px;
-    font-weight: 500;
     line-height: ${themeGet("typeSizes.sans.2.lineHeight")}px;
     padding: ${space(0.5)}px ${space(1) + carretSize * 4}px ${space(0.5)}px
       ${space(1)}px;


### PR DESCRIPTION
I did a global search in our repos on Github and seems like the only place SmallSelect was used is the reaction and the removal was merged here: https://github.com/artsy/reaction/pull/2475. So killing SmallSelect here.

Also added explicit font definition from Theme for SmallSelect. And made sure that label in this select does not include padding/margin. In Volt the global value for label was sneaking in here:(