### PR TITLE
[Docs] Add docs around required palette structure

### DIFF
--- a/packages/palette/README.md
+++ b/packages/palette/README.md
@@ -5,6 +5,30 @@ Artsy's Design System
 ## What is Palette?
 
 Palette is a collection of primitive, product-agnostic elements that help encapsulate Artsy's look and feel at base level. This project is intended to be used
-across our digital product portfoilo.
+across our digital product portfolio.
 
 Find out more at [github.com/artsy/palette](https://github.com/artsy/palette)
+
+### ⚠️ Development Gotchas
+
+When adding a new component to Palette, it's important to be aware that this library is used on the web as well as in React Native, via Emission, and therefore must follow a few rules in terms of structure, namely:
+
+> Components exported from the main `/elements/index.tsx` must have a corresponding `.ios.tsx` file, even if the component isn't yet used in React Native.
+
+Example:
+
+```
+/elements
+  /MyComponent
+    index.tsx
+    MyComponent.tsx
+    MyComponent.ios.tsx
+```
+
+And from within `/elements/index.tsx`, we export our component:
+
+```tsx
+export * from "./MyComponent"
+```
+
+When React Native imports `@artsy/palette`, it will automatically look for files with a `.ios` extension and import those first, and then secondarily import everything else. If a component contains web-only features but doesn't have a corresponding iOS file stub, React Native tooling will error out.

--- a/packages/palette/README.md
+++ b/packages/palette/README.md
@@ -9,7 +9,7 @@ across our digital product portfolio.
 
 Find out more at [github.com/artsy/palette](https://github.com/artsy/palette)
 
-### ⚠️ Development Gotchas
+### ⚠️ Don't Forget About iOS!
 
 When adding a new component to Palette, it's important to be aware that this library is used on the web as well as in React Native, via Emission, and therefore must follow a few rules in terms of structure, namely:
 


### PR DESCRIPTION
Spent a long time yesterday debugging an issue that ended up resolving to missing `.ios` file stubs. Wanted to add some documentation around this requirement and a why. 