### PR TITLE
Support Flexbox order

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/Flex.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Flex.mdx
@@ -1,6 +1,9 @@
 ---
 name: Flex
 ---
+
+### Basics
+
 <Playground>
   <Flex flexDirection="column">
     <Box>
@@ -8,5 +11,17 @@ name: Flex
       related flexbox.
     </Box>
     <Box>It's pretty cool!</Box>
+  </Flex>
+</Playground>
+
+### Flex Item Order
+
+Flex items are displayed in the same order as they appear in the source
+document by default. We can use the `order` property to change the ordering.
+
+<Playground>
+  <Flex>
+    <Flex order="2">Item 2</Flex>
+    <Flex order="1">Item 1</Flex>
   </Flex>
 </Playground>

--- a/packages/palette/src/elements/Flex/Flex.tsx
+++ b/packages/palette/src/elements/Flex/Flex.tsx
@@ -25,6 +25,8 @@ import {
   MaxHeightProps,
   maxWidth,
   MaxWidthProps,
+  order,
+  OrderProps,
   position,
   PositionProps,
   space,
@@ -56,6 +58,7 @@ export interface FlexProps
     JustifyContentProps,
     MaxHeightProps,
     MaxWidthProps,
+    OrderProps,
     PositionProps,
     SpaceProps,
     WidthProps,
@@ -81,6 +84,7 @@ export const Flex = primitives.View<FlexProps>`
   ${justifyContent};
   ${maxHeight};
   ${maxWidth};
+  ${order};
   ${position};
   ${space};
   ${width};


### PR DESCRIPTION
This added [`order`](https://developer.mozilla.org/en-US/docs/Web/CSS/order) to `<Flex>` and so that  we can order flexbox items by:

```jsx
<Flex>
  <Flex order="2">Item 2</Flex>
  <Flex order="1">Item 1</Flex>
</Flex>
```

I also updated the doc to include an example.

<img width="1440" alt="Screen Shot 2019-06-02 at 1 55 24 AM" src="https://user-images.githubusercontent.com/796573/58763333-49ce8200-8527-11e9-87ee-496d342d9992.png">
