### PR TITLE
Add icons necessary for the iOS artwork view

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -116,6 +116,7 @@
     "rc-slider": "^8.6.2",
     "react-lazy-load-image-component": "^1.3.2",
     "react-live": "^1.12.0",
+    "react-native-svg": "^9.4.0",
     "react-powerplug": "^1.0.0",
     "react-spring": "^5.7.2",
     "styled-bootstrap-grid": "1.0.4",

--- a/packages/palette/src/svgs/EyeOpenedIcon.ios.tsx
+++ b/packages/palette/src/svgs/EyeOpenedIcon.ios.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { G, Path } from "react-native-svg"
+import { color } from "../helpers"
+import { Icon, IconProps } from "./Icon"
+
+/** EyeOpenedIcon */
+export const EyeOpenedIcon: React.SFC<IconProps> = props => {
+  return (
+    <Icon {...props} viewBox="0 0 18 18">
+      <G fill={color(props.fill)} fillRule="nonzero">
+        <Path d="M2.249 8.462a.56.56 0 0 0 .016.601C4.172 11.9 6.406 13.286 9 13.286c2.594 0 4.828-1.387 6.736-4.225a.56.56 0 0 0 .017-.6C14.038 5.56 11.808 4.144 9.01 4.144S3.975 5.56 2.25 8.463zm-1.011-.574C3.163 4.652 5.77 3 9.01 3c3.241 0 5.843 1.653 7.755 4.89.331.561.31 1.257-.053 1.798-2.109 3.139-4.69 4.74-7.713 4.74-3.021 0-5.602-1.6-7.711-4.738a1.681 1.681 0 0 1-.05-1.802z" />
+        <Path d="M9 11.571a2.857 2.857 0 1 1 0-5.714 2.857 2.857 0 0 1 0 5.714zm0-1.142A1.714 1.714 0 1 0 9 7a1.714 1.714 0 0 0 0 3.429z" />
+      </G>
+    </Icon>
+  )
+}

--- a/packages/palette/src/svgs/HeartFillIcon.ios.tsx
+++ b/packages/palette/src/svgs/HeartFillIcon.ios.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { Path } from "react-native-svg"
+import { color } from "../helpers"
+import { Icon, IconProps } from "./Icon"
+
+/** HeartFillIcon */
+export const HeartFillIcon: React.SFC<IconProps> = props => {
+  return (
+    <Icon {...props} viewBox="0 0 18 18">
+      <Path
+        d="M12 3a4 4 0 0 0-2.83 1.17L9 4.34l-.17-.17a4.002 4.002 0 0 0-5.66 5.66l5.48 5.47a.48.48 0 0 0 .7 0l5.48-5.47A4 4 0 0 0 12 3z"
+        fill={color(props.fill)}
+        fillRule="nonzero"
+      />
+    </Icon>
+  )
+}

--- a/packages/palette/src/svgs/HeartIcon.ios.tsx
+++ b/packages/palette/src/svgs/HeartIcon.ios.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { Path } from "react-native-svg"
+import { color } from "../helpers"
+import { Icon, IconProps } from "./Icon"
+
+/** HeartIcon */
+export const HeartIcon: React.SFC<IconProps> = props => {
+  return (
+    <Icon {...props} viewBox="0 0 18 18">
+      <Path
+        d="M12 3a4 4 0 0 0-2.83 1.17L9 4.34l-.17-.17a4.002 4.002 0 0 0-5.66 5.66l5.48 5.47a.48.48 0 0 0 .7 0l5.48-5.47A4 4 0 0 0 12 3zm2.12 6.12L9 14.24 3.88 9.12a3 3 0 1 1 4.24-4.24l.53.52.35.36.35-.36.53-.52a3 3 0 0 1 4.24 4.24z"
+        fill={color(props.fill)}
+        fillRule="nonzero"
+      />
+    </Icon>
+  )
+}

--- a/packages/palette/src/svgs/Icon.ios.tsx
+++ b/packages/palette/src/svgs/Icon.ios.tsx
@@ -1,0 +1,47 @@
+// @ts-ignore
+import React from "react"
+import Svg, { SvgProps } from "react-native-svg"
+import styled from "styled-components"
+import {
+  left,
+  LeftProps,
+  position,
+  PositionProps,
+  right,
+  RightProps,
+  space,
+  SpaceProps,
+  top,
+  TopProps,
+} from "styled-system"
+import { Color } from "../Theme"
+
+// : React.SVGProps<SVGSVGElement>
+
+// tslint:disable-next-line:no-empty-interface
+export interface IconProps
+  extends SvgProps,
+    SpaceProps,
+    PositionProps,
+    TopProps,
+    RightProps,
+    LeftProps {
+  fill?: Color
+}
+
+/** Wrapper for icons to include space */
+export const Icon = styled(Svg)<IconProps>`
+  position: relative;
+
+  ${space};
+  ${top};
+  ${right};
+  ${left};
+  ${position};
+`
+
+Icon.defaultProps = {
+  fill: "black100",
+  height: "18px",
+  width: "18px",
+}

--- a/packages/palette/src/svgs/ShareIcon.ios.tsx
+++ b/packages/palette/src/svgs/ShareIcon.ios.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { Path } from "react-native-svg"
+import { color } from "../helpers"
+import { Icon, IconProps } from "./Icon"
+
+/** ShareIcon */
+export const ShareIcon: React.SFC<IconProps> = props => {
+  return (
+    <Icon {...props} viewBox="0 0 18 18">
+      <Path
+        d="M8.547 3.817L5.704 6.203a.25.25 0 0 1-.361-.042l-.3-.401a.25.25 0 0 1 .036-.338l3.579-3.123a.5.5 0 0 1 .672.013l.005.005.017.014 3.6 3.175a.25.25 0 0 1 .035.337l-.3.402a.25.25 0 0 1-.361.042L9.534 3.945V8H13.5a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5v-6a.5.5 0 0 1 .5-.5h4.047V3.817zm0 5.183H5v5h8V9H9.534v2.75a.25.25 0 0 1-.25.25h-.487a.25.25 0 0 1-.25-.25V9z"
+        fill={color(props.fill)}
+        fillRule="evenodd"
+      />
+    </Icon>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18443,6 +18443,11 @@ react-modal@^3.1.5, react-modal@^3.8.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-native-svg@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.4.0.tgz#e428e0eae55aebd2355f1ff4f22675dad4611960"
+  integrity sha512-IVJlVbS2dAPerPr927fEi4uXzrPXzlra5ddgyJXZZ2IKA2ZygyYWFZDM+vsQs+Vj20CfL8nOWszQQV57vdQgFg==
+
 react-native@0.55.4:
   version "0.55.4"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.55.4.tgz#eecffada3750a928e2ddd07cf11d857ae9751c30"


### PR DESCRIPTION
This PR adds icons that can be consumed by emission via the `react-native-svg` library, which is what we're already using within emission.

I can follow-up by updating all of the remaining icons to have a proper iOS counterpart, but wanted to keep this targeted for now.

Confirmed that it works via an emission link:
![image](https://user-images.githubusercontent.com/2081340/58820895-d8afcd00-8601-11e9-95aa-2945db0696ca.png)
