### PR TITLE
Reorganize image props for web, iOS, and shared Image/ResponsiveImage components

### DIFF
--- a/packages/palette/src/elements/Image/Image.shared.tsx
+++ b/packages/palette/src/elements/Image/Image.shared.tsx
@@ -19,19 +19,12 @@ import {
   WidthProps,
 } from "styled-system"
 
+/** Props for web & iOS images */
 export interface BaseImageProps {
   /** The url for the image */
   src: string
-  /** Alternate text for image */
-  alt?: string
-  /** A11y text label */
-  ["aria-label"]?: string
-  /** The title of the image */
-  title?: string
   /** Apply additional styles to component */
   style?: object
-  /** Flag for if image should be lazy loaded */
-  lazyLoad?: boolean
 }
 
 export interface ImageProps

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -8,7 +8,16 @@ import {
 import { LazyImage } from "./LazyImage"
 
 /** Props for a web-only Image component. */
-interface WebImageProps extends ImageProps {
+export interface WebImageProps extends ImageProps {
+  /** Flag for if image should be lazy loaded */
+  lazyLoad?: boolean
+  /** Alternate text for image */
+  alt?: string
+  /** A11y text label */
+  ["aria-label"]?: string
+  /** The title of the image */
+  title?: string
+  /** Flag indicating that right clicks should be prevented */
   preventRightClick?: boolean
 }
 
@@ -28,11 +37,17 @@ export const Image = ({
   )
 }
 
+/** Props for a web-only ResponsiveImage component. */
+export interface WebResponsiveImageProps extends ResponsiveImageProps {
+  /** Flag for if image should be lazy loaded */
+  lazyLoad?: boolean
+}
+
 /** A web-only ResponsiveImage component. */
 export const ResponsiveImage = ({
   lazyLoad = false,
   ...props
-}: ResponsiveImageProps) => (
+}: WebResponsiveImageProps) => (
   <LazyImage
     preload={!lazyLoad}
     imageComponent={BaseResponsiveImage}

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -10,14 +10,15 @@ import {
 import { color } from "../../helpers/color"
 import { Box, BoxProps } from "../Box"
 import { omitProps, Tag } from "../Tag"
-import { BaseImage as Image, ImageProps } from "./Image.shared"
+import { WebImageProps } from "./Image"
+import { BaseImage as Image } from "./Image.shared"
 
 const imagePropsToOmit = omitProps.filter(
   prop => prop !== "width" && prop !== "height"
 )
 
 const InnerLazyImage = styled(Tag.as(LazyLoadImage))<
-  ImageProps & { onLoad: () => void }
+  WebImageProps & { onLoad: () => void }
 >`
   width: 100%;
   height: 100%;
@@ -49,7 +50,7 @@ const Placeholder = styled(Box)<BoxProps & BorderRadiusProps>`
 `
 
 interface LazyImageProps
-  extends ImageProps,
+  extends WebImageProps,
     WidthProps,
     HeightProps,
     BorderRadiusProps {


### PR DESCRIPTION
## Background

While working on #473, I misunderstood the separation of `Image.tsx`, `Image.ios.tsx`, and `Image.shared.tsx`, and initially added a new web-specific prop to the props that are shared between web _and_ iOS. @zephraph identified my mistake before we merged, but it raised a question of clarity on the roles of these different files. `Image.shared.tsx`, which is intended to be used by both web and iOS, contained several props that are web-specific, and this contributed to me adding another web-specific prop in the wrong place.

## These changes 

This PR moves the web-specific props from `Image.shared.tsx` to `Image.tsx`, via interfaces named `WebImageProps` and `WebResponsiveImageProps`. 

## Open questions

- Did I move the correct props? These are all the ones that I thought were web-specific; let me know if I got any wrong.
- I `yarn link`ed palette to force/reaction _and_ emission with these changes, and did not notice any related `tsc` errors afterward. I _think_ this means the changes are safe for both web & iOS - but please let me know if you think I should do something other than `yarn type-check` to verify they don't break anything.
