### PR TITLE
Add react-native-svg to peerDependencies

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -46,6 +46,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-native": "^0.55.4",
+    "react-native-svg": "^9.4.0",
     "styled-components": "^4"
   },
   "devDependencies": {
@@ -95,6 +96,7 @@
     "react": "16.8.4",
     "react-dom": "16.8.4",
     "react-native": "0.55.4",
+    "react-native-svg": "9.4.0",
     "react-test-renderer": "16.8.6",
     "regenerator-runtime": "0.11.1",
     "simple-progress-webpack-plugin": "1.1.2",
@@ -117,7 +119,6 @@
     "rc-slider": "^8.6.2",
     "react-lazy-load-image-component": "^1.3.2",
     "react-live": "^1.12.0",
-    "react-native-svg": "^9.4.0",
     "react-powerplug": "^1.0.0",
     "react-spring": "^5.7.2",
     "styled-bootstrap-grid": "1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18443,7 +18443,7 @@ react-modal@^3.1.5, react-modal@^3.8.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-native-svg@^9.4.0:
+react-native-svg@9.4.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.4.0.tgz#e428e0eae55aebd2355f1ff4f22675dad4611960"
   integrity sha512-IVJlVbS2dAPerPr927fEi4uXzrPXzlra5ddgyJXZZ2IKA2ZygyYWFZDM+vsQs+Vj20CfL8nOWszQQV57vdQgFg==


### PR DESCRIPTION
As discussed in Slack (https://artsy.slack.com/archives/C02BAQ5K7/p1559667553010600), this PR adds `react-native-svg` to `peerDependencies` of Palette.
