### PR TITLE
Fix error when all linechart values are zero

### DIFF
--- a/packages/palette/src/elements/LineChart/LineChartSVG.tsx
+++ b/packages/palette/src/elements/LineChart/LineChartSVG.tsx
@@ -39,7 +39,7 @@ export const LineChartSVG: React.FC<LineChartSVGProps> = ({
   const h = height - 2 * margin
 
   // maps value to x/y position
-  const displayYPosition = d => h - (d * h) / maxValue
+  const displayYPosition = d => (maxValue ? h - (d * h) / maxValue : h)
   const displayXPosition = (_d, i) => (i / (points.length - 1)) * w
 
   const line = d3Line()


### PR DESCRIPTION
When all values are zero, `maxValue` ends up being zero causing division by zero.

We currently don't support negative values for line chart so this would fix the problem.