### PR TITLE
Small fix in StaticCountdownTimer hour logic

### DIFF
--- a/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
@@ -24,7 +24,8 @@ export const StaticCountdownTimer: React.SFC<{
   const dateTime = DateTime.fromISO(countdownEnd).toLocal()
   const minutes = dateTime.minute < 10 ? "0" + dateTime.minute : dateTime.minute
   const amPm = dateTime.hour >= 12 ? "pm" : "am"
-  const time = `${dateTime.hour % 12}:${minutes}${amPm}`
+  const hour = dateTime.hour > 12 ? dateTime.hour - 12 : dateTime.hour
+  const time = `${hour}:${minutes}${amPm}`
   const actionDeadline = `${dateTime.monthShort} ${dateTime.day}, ${time} ${
     dateTime.offsetNameShort
   }`

--- a/packages/palette/src/elements/StaticCountdownTimer/__tests__/StaticCountdownTimer.test.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/__tests__/StaticCountdownTimer.test.tsx
@@ -1,8 +1,13 @@
 import { mount } from "enzyme"
+import { Settings } from "luxon"
 import React from "react"
 import { StaticCountdownTimer } from "../StaticCountdownTimer"
 
 describe("StaticCountdownTimer", () => {
+  beforeEach(() => {
+    Settings.defaultZoneName = "America/New_York"
+  })
+
   it("renders time in the future with a day in the future and a countdown clock", () => {
     const wrapper = mount(
       <StaticCountdownTimer

--- a/packages/palette/src/elements/StaticCountdownTimer/__tests__/StaticCountdownTimer.test.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/__tests__/StaticCountdownTimer.test.tsx
@@ -1,0 +1,45 @@
+import { mount } from "enzyme"
+import React from "react"
+import { StaticCountdownTimer } from "../StaticCountdownTimer"
+
+describe("StaticCountdownTimer", () => {
+  it("renders time in the future with a day in the future and a countdown clock", () => {
+    const wrapper = mount(
+      <StaticCountdownTimer
+        action="Respond"
+        note="Before it's too late."
+        countdownStart="2019-01-01T12:00:00.000-04:00"
+        countdownEnd="2019-01-14T15:30:00.000-04:00"
+        currentTime="2019-01-05T12:00:30.000-04:00"
+      />
+    )
+    expect(wrapper.html()).toContain("Respond by Jan 14, 2:30pm EST")
+    expect(wrapper.html()).toContain("09d 03h 29m 30s")
+  })
+
+  it("renders time in the past and returning 0 days", () => {
+    const wrapper = mount(
+      <StaticCountdownTimer
+        action="Respond"
+        note="Before it's too late."
+        countdownStart="2019-01-01T12:00:00.000-04:00"
+        countdownEnd="2019-01-14T12:00:00.000-04:00"
+        currentTime="2019-01-15T12:00:00.000-04:00"
+      />
+    )
+    expect(wrapper.html()).toContain("0 days")
+  })
+
+  it("renders the hour as 12 if noon", () => {
+    const wrapper = mount(
+      <StaticCountdownTimer
+        action="Respond"
+        note="Before it's too late."
+        countdownStart="2019-01-01T13:00:00.000-04:00"
+        countdownEnd="2019-01-14T13:00:00.000-04:00"
+        currentTime="2019-01-05T13:00:30.000-04:00"
+      />
+    )
+    expect(wrapper.html()).toContain("Jan 14, 12:00pm EST")
+  })
+})


### PR DESCRIPTION
- Previously I had used `% 12` on the hour which was incorrect (would return `0` if noon) as we want to `- 12` from the hour if it's greater than 12. 
- Adds test file for StaticCountdownTimer