### PR TITLE
Updates to Luxon logic

### DIFF
--- a/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
@@ -24,7 +24,14 @@ export const StaticCountdownTimer: React.SFC<{
   const dateTime = DateTime.fromISO(countdownEnd).toLocal()
   const minutes = dateTime.minute < 10 ? "0" + dateTime.minute : dateTime.minute
   const amPm = dateTime.hour >= 12 ? "pm" : "am"
-  const hour = dateTime.hour > 12 ? dateTime.hour - 12 : dateTime.hour
+  let hour
+  if (dateTime.hour > 12) {
+    hour = dateTime.hour - 12
+  } else if (dateTime.hour === 0) {
+    hour = 12
+  } else {
+    hour = dateTime.hour
+  }
   const time = `${hour}:${minutes}${amPm}`
   const actionDeadline = `${dateTime.monthShort} ${dateTime.day}, ${time} ${
     dateTime.offsetNameShort

--- a/packages/palette/src/elements/StaticCountdownTimer/__tests__/StaticCountdownTimer.test.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/__tests__/StaticCountdownTimer.test.tsx
@@ -4,8 +4,14 @@ import React from "react"
 import { StaticCountdownTimer } from "../StaticCountdownTimer"
 
 describe("StaticCountdownTimer", () => {
+  const defaultZone = Settings.defaultZoneName
+
   beforeEach(() => {
     Settings.defaultZoneName = "America/New_York"
+  })
+
+  afterEach(() => {
+    Settings.defaultZoneName = defaultZone
   })
 
   it("renders time in the future with a day in the future and a countdown clock", () => {

--- a/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
+++ b/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
@@ -23,11 +23,11 @@ export const TimeRemaining: React.SFC<{
         "0 days"
       ) : (
         <>
-          {timeRemaining.as("days") > 0 &&
+          {Math.floor(timeRemaining.as("days")) > 0 &&
             pad(Math.floor(timeRemaining.as("days"))) + "d "}
-          {timeRemaining.as("hours") > 0 &&
+          {Math.floor(timeRemaining.as("hours")) > 0 &&
             pad(Math.floor(timeRemaining.as("hours") % 24)) + "h "}
-          {timeRemaining.as("minutes") > 0 &&
+          {Math.floor(timeRemaining.as("minutes")) > 0 &&
             pad(Math.floor(timeRemaining.as("minutes") % 60)) + "m "}
           {pad(Math.floor(timeRemaining.as("seconds") % 60)) + "s"}
         </>

--- a/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
+++ b/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
@@ -16,6 +16,10 @@ export const TimeRemaining: React.SFC<{
       .diff(DateTime.fromISO(currentTime))
       .toString()
   )
+  const days = Math.floor(timeRemaining.as("days"))
+  const hours = Math.floor(timeRemaining.as("hours") % 24)
+  const minutes = Math.floor(timeRemaining.as("minutes") % 60)
+  const seconds = Math.floor(timeRemaining.as("seconds") % 60)
 
   return (
     <Sans size="3" color={highlight} weight="medium">
@@ -23,13 +27,10 @@ export const TimeRemaining: React.SFC<{
         "0 days"
       ) : (
         <>
-          {Math.floor(timeRemaining.as("days")) > 0 &&
-            pad(Math.floor(timeRemaining.as("days"))) + "d "}
-          {Math.floor(timeRemaining.as("hours")) > 0 &&
-            pad(Math.floor(timeRemaining.as("hours") % 24)) + "h "}
-          {Math.floor(timeRemaining.as("minutes")) > 0 &&
-            pad(Math.floor(timeRemaining.as("minutes") % 60)) + "m "}
-          {pad(Math.floor(timeRemaining.as("seconds") % 60)) + "s"}
+          {days > 0 && pad(days) + "d "}
+          {hours > 0 && pad(hours) + "h "}
+          {minutes > 0 && pad(minutes) + "m "}
+          {pad(seconds) + "s"}
         </>
       )}
       <span> left</span>

--- a/packages/palette/src/elements/TimeRemaining/__tests__/TimeRemaining.test.tsx
+++ b/packages/palette/src/elements/TimeRemaining/__tests__/TimeRemaining.test.tsx
@@ -1,0 +1,32 @@
+import { mount } from "enzyme"
+import { Settings } from "luxon"
+import React from "react"
+import { TimeRemaining } from "../TimeRemaining"
+
+describe("TimeRemaining", () => {
+  beforeEach(() => {
+    Settings.defaultZoneName = "America/New_York"
+  })
+
+  it("doesn't render hours if end hour is the same as current hour", () => {
+    const wrapper = mount(
+      <TimeRemaining
+        countdownEnd="2019-01-14T15:30:00.000-04:00"
+        currentTime="2019-01-05T15:00:30.000-04:00"
+        highlight="purple100"
+      />
+    )
+    expect(wrapper.html()).toContain("09d 29m 30s")
+  })
+
+  it("doesn't render minutes if end hour is the same as current hour", () => {
+    const wrapper = mount(
+      <TimeRemaining
+        countdownEnd="2019-01-14T15:30:30.000-04:00"
+        currentTime="2019-01-05T15:30:00.000-04:00"
+        highlight="purple100"
+      />
+    )
+    expect(wrapper.html()).toContain("09d 30s")
+  })
+})

--- a/packages/palette/src/elements/TimeRemaining/__tests__/TimeRemaining.test.tsx
+++ b/packages/palette/src/elements/TimeRemaining/__tests__/TimeRemaining.test.tsx
@@ -4,8 +4,14 @@ import React from "react"
 import { TimeRemaining } from "../TimeRemaining"
 
 describe("TimeRemaining", () => {
+  const defaultZone = Settings.defaultZoneName
+
   beforeEach(() => {
     Settings.defaultZoneName = "America/New_York"
+  })
+
+  afterEach(() => {
+    Settings.defaultZoneName = defaultZone
   })
 
   it("doesn't render hours if end hour is the same as current hour", () => {


### PR DESCRIPTION
- Checks if hour is zero and returns 12
- Doesn't show 0 state times for countdown clock (e.g. `1d 0h 30m 20s` is now `1d 30m 20s`)
- Adds tests for `TimeRemaining` 