### PR TITLE
PURCHASE-1060/PURCHASE-1059: iOs Entity Header palette component

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.ios.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.ios.tsx
@@ -2,13 +2,26 @@ import React, { FunctionComponent } from "react"
 import { Image } from "react-native"
 import { AvatarProps, BaseAvatar } from "./Avatar.shared"
 
+const IOSDiameters = {
+  xs: 45,
+  sm: 70,
+  md: 100,
+}
 /** Avatar */
 export const Avatar: FunctionComponent<AvatarProps> = ({ ...props }) => {
+  const diameter = IOSDiameters[props.size || "md"]
+
   return (
     <BaseAvatar
       renderAvatar={() => (
         <Image
-          style={{ width: props.width, height: props.height }}
+          size={props.size}
+          resizeMode="stretch"
+          style={{
+            width: diameter,
+            height: diameter,
+            borderRadies: diameter / 2,
+          }}
           source={{
             uri: props.src,
           }}

--- a/packages/palette/src/elements/Avatar/Avatar.ios.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.ios.tsx
@@ -1,19 +1,20 @@
 import React, { FunctionComponent } from "react"
-import { styled } from "../../platform/primitives"
-import { AvatarProps, BaseAvatar, sizeValue } from "./Avatar.shared"
+import { Image } from "react-native"
+import { AvatarProps, BaseAvatar } from "./Avatar.shared"
 
 /** Avatar */
 export const Avatar: FunctionComponent<AvatarProps> = ({ ...props }) => {
   return (
-    <BaseAvatar renderAvatar={() => <AvatarImage {...props} />} {...props} />
+    <BaseAvatar
+      renderAvatar={() => (
+        <Image
+          style={{ width: props.width, height: props.height }}
+          source={{
+            uri: props.src,
+          }}
+        />
+      )}
+      {...props}
+    />
   )
 }
-
-/**
- * A circular avatar image component.
- */
-const AvatarImage = styled.Image<AvatarProps>`
-  width: ${props => sizeValue(props).diameter};
-  height: ${props => sizeValue(props).diameter};
-  border-radius: ${props => sizeValue(props).diameter};
-`

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -1,5 +1,4 @@
 import React, { SFC } from "react"
-import { TouchableWithoutFeedback } from "react-native"
 import { Avatar } from "../Avatar"
 import { Box } from "../Box"
 import { Flex } from "../Flex"
@@ -50,32 +49,30 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
             />
           </Flex>
         )}
+        {!!meta && (
+          <Flex ml="10" flexDirection="column">
+            <Serif mb="-2" size="3t" color="black100">
+              {name}
+            </Serif>
 
-        <Flex ml="10" flexDirection="column">
-          <Serif mb="-2" size="3t" color="black100">
-            {name}
-          </Serif>
-          {!!meta && (
             <Sans mt="-2" size="3t" color="black60">
               {meta}
             </Sans>
-          )}
-        </Flex>
+          </Flex>
+        )}
+        {!meta && (
+          <Flex ml="10" flexDirection="column" justifyContent="center">
+            <Serif size="3t" color="black100">
+              {name}
+            </Serif>
+          </Flex>
+        )}
       </Flex>
 
       <Flex>
         {FollowButton && (
           <Box width={102} height={34}>
-            <TouchableWithoutFeedback
-              display="inline-block"
-              onPress={event => {
-                // Capture click event so that interacting with Follow doesn't
-                // trigger Container's link.
-                event.stopPropagation()
-              }}
-            >
-              {FollowButton}
-            </TouchableWithoutFeedback>
+            {FollowButton}
           </Box>
         )}
       </Flex>

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -1,0 +1,85 @@
+import React, { SFC } from "react"
+import { TouchableWithoutFeedback } from "react-native"
+import styled from "styled-components/native"
+import { Avatar } from "../Avatar"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
+import { Link } from "../Link"
+import { SpacerProps } from "../Spacer"
+import { Sans, Serif } from "../Typography"
+
+interface EntityHeaderProps extends SpacerProps {
+  href?: string
+  imageUrl?: string
+  initials?: string
+  meta?: string
+  name: string
+  FollowButton?: JSX.Element
+}
+
+/**
+ * Component that is used as entity header that is paired with rich information about the entity.
+ * Spec: zpl.io/aNoYM6d
+ */
+export const EntityHeader: SFC<EntityHeaderProps> = ({
+  href,
+  imageUrl,
+  initials,
+  name,
+  meta,
+  FollowButton,
+  ...remainderProps
+}) => {
+  const ContainerComponent = href ? FlexLink : Flex
+  // new () => React.Component < any, any >
+  // StyledComponentClass < React.ClassAttributes < HTMLAnchorElement >
+  const containerProps = href
+    ? { color: "black100", noUnderline: true, href }
+    : {}
+
+  return (
+    <ContainerComponent {...remainderProps} {...containerProps}>
+      {(imageUrl || initials) && (
+        <Flex mr={1}>
+          <Avatar size="xs" src={imageUrl} initials={initials} />
+        </Flex>
+      )}
+
+      <Flex flexDirection="column" justifyContent="center" width="100%">
+        <Serif size="3" weight="semibold" color="black100">
+          {name}
+        </Serif>
+
+        <Sans size="2" color="black60">
+          {!!meta && <span>{meta}</span>}
+
+          {FollowButton && (
+            <>
+              {meta && (
+                <Sans size="2" color="black60" mx={0.3} display="inline-block">
+                  •
+                </Sans>
+              )}
+              <TouchableWithoutFeedback
+                display="inline-block"
+                onPress={event => {
+                  // Capture click event so that interacting with Follow doesn't
+                  // trigger Container's link.
+                  event.stopPropagation()
+                }}
+              >
+                {FollowButton}
+              </TouchableWithoutFeedback>
+            </>
+          )}
+        </Sans>
+      </Flex>
+    </ContainerComponent>
+  )
+}
+
+const FlexLink = styled(Link)`
+  display: flex;
+`
+
+EntityHeader.displayName = "EntityHeader"

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -30,13 +30,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
     <Flex flexDirection="row" {...remainderProps}>
       {(imageUrl || initials) && (
         <Flex mr={1} justifyContent="center">
-          <Avatar
-            size="xs"
-            width={45}
-            height={45}
-            src={imageUrl}
-            initials={initials}
-          />
+          <Avatar size="xs" src={imageUrl} initials={initials} />
         </Flex>
       )}
       <Flex flexGrow={1} ml="2px" justifyContent="center">

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -27,15 +27,11 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   FollowButton,
   ...remainderProps
 }) => {
-  const containerProps = href
-    ? { color: "black100", noUnderline: true, href }
-    : {}
   return (
     <Flex
       justifyContent="space-between"
       flexDirection="row"
       {...remainderProps}
-      {...containerProps}
     >
       <Flex justifyContent="space-between" flexDirection="row">
         {(imageUrl || initials) && (
@@ -49,7 +45,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
             />
           </Flex>
         )}
-        <Flex ml="10" flexDirection="column" justifyContent="center">
+        <Flex ml="2px" flexDirection="column" justifyContent="center">
           <Serif mb="-2" size="3t" color="black100">
             {name}
           </Serif>
@@ -61,13 +57,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
         </Flex>
       </Flex>
 
-      <Flex justifyContent="center">
-        {FollowButton && (
-          <Box width={102} height={34}>
-            {FollowButton}
-          </Box>
-        )}
-      </Flex>
+      <Flex justifyContent="center">{FollowButton && <>{FollowButton}</>}</Flex>
     </Flex>
   )
 }

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -1,6 +1,5 @@
 import React, { SFC } from "react"
 import { Avatar } from "../Avatar"
-import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { SpacerProps } from "../Spacer"
 import { Sans, Serif } from "../Typography"

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -39,7 +39,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
     >
       <Flex justifyContent="space-between" flexDirection="row">
         {(imageUrl || initials) && (
-          <Flex mr={1}>
+          <Flex mr={1} justifyContent="center">
             <Avatar
               size="xs"
               width={45}
@@ -49,27 +49,19 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
             />
           </Flex>
         )}
-        {!!meta && (
-          <Flex ml="10" flexDirection="column">
-            <Serif mb="-2" size="3t" color="black100">
-              {name}
-            </Serif>
-
+        <Flex ml="10" flexDirection="column" justifyContent="center">
+          <Serif mb="-2" size="3t" color="black100">
+            {name}
+          </Serif>
+          {!!meta && (
             <Sans mt="-2" size="3t" color="black60">
               {meta}
             </Sans>
-          </Flex>
-        )}
-        {!meta && (
-          <Flex ml="10" flexDirection="column" justifyContent="center">
-            <Serif size="3t" color="black100">
-              {name}
-            </Serif>
-          </Flex>
-        )}
+          )}
+        </Flex>
       </Flex>
 
-      <Flex>
+      <Flex justifyContent="center">
         {FollowButton && (
           <Box width={102} height={34}>
             {FollowButton}

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -27,36 +27,34 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   ...remainderProps
 }) => {
   return (
-    <Flex
-      justifyContent="space-between"
-      flexDirection="row"
-      {...remainderProps}
-    >
-      <Flex justifyContent="space-between" flexDirection="row">
-        {(imageUrl || initials) && (
-          <Flex mr={1} justifyContent="center">
-            <Avatar
-              size="xs"
-              width={45}
-              height={45}
-              src={imageUrl}
-              initials={initials}
-            />
-          </Flex>
-        )}
-        <Flex ml="2px" flexDirection="column" justifyContent="center">
-          <Serif mb="-2" size="3t" color="black100">
-            {name}
-          </Serif>
-          {!!meta && (
-            <Sans mt="-2" size="3t" color="black60">
-              {meta}
-            </Sans>
-          )}
+    <Flex flexDirection="row" {...remainderProps}>
+      {(imageUrl || initials) && (
+        <Flex mr={1} justifyContent="center">
+          <Avatar
+            size="xs"
+            width={45}
+            height={45}
+            src={imageUrl}
+            initials={initials}
+          />
         </Flex>
+      )}
+      <Flex flexGrow={1} ml="2px" justifyContent="center">
+        <Serif mb="-2" size="3t" color="black100">
+          {name}
+        </Serif>
+        {!!meta && (
+          <Sans mt="-2" size="3t" color="black60">
+            {meta}
+          </Sans>
+        )}
       </Flex>
 
-      <Flex justifyContent="center">{FollowButton && <>{FollowButton}</>}</Flex>
+      {FollowButton && (
+        <Flex ml={1} justifyContent="center">
+          {FollowButton}
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -1,10 +1,8 @@
 import React, { SFC } from "react"
 import { TouchableWithoutFeedback } from "react-native"
-import styled from "styled-components/native"
 import { Avatar } from "../Avatar"
 import { Box } from "../Box"
 import { Flex } from "../Flex"
-import { Link } from "../Link"
 import { SpacerProps } from "../Spacer"
 import { Sans, Serif } from "../Typography"
 
@@ -30,56 +28,59 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   FollowButton,
   ...remainderProps
 }) => {
-  const ContainerComponent = href ? FlexLink : Flex
-  // new () => React.Component < any, any >
-  // StyledComponentClass < React.ClassAttributes < HTMLAnchorElement >
   const containerProps = href
     ? { color: "black100", noUnderline: true, href }
     : {}
-
   return (
-    <ContainerComponent {...remainderProps} {...containerProps}>
-      {(imageUrl || initials) && (
-        <Flex mr={1}>
-          <Avatar size="xs" src={imageUrl} initials={initials} />
-        </Flex>
-      )}
+    <Flex
+      justifyContent="space-between"
+      flexDirection="row"
+      {...remainderProps}
+      {...containerProps}
+    >
+      <Flex justifyContent="space-between" flexDirection="row">
+        {(imageUrl || initials) && (
+          <Flex mr={1}>
+            <Avatar
+              size="xs"
+              width={45}
+              height={45}
+              src={imageUrl}
+              initials={initials}
+            />
+          </Flex>
+        )}
 
-      <Flex flexDirection="column" justifyContent="center" width="100%">
-        <Serif size="3" weight="semibold" color="black100">
-          {name}
-        </Serif>
-
-        <Sans size="2" color="black60">
-          {!!meta && <span>{meta}</span>}
-
-          {FollowButton && (
-            <>
-              {meta && (
-                <Sans size="2" color="black60" mx={0.3} display="inline-block">
-                  •
-                </Sans>
-              )}
-              <TouchableWithoutFeedback
-                display="inline-block"
-                onPress={event => {
-                  // Capture click event so that interacting with Follow doesn't
-                  // trigger Container's link.
-                  event.stopPropagation()
-                }}
-              >
-                {FollowButton}
-              </TouchableWithoutFeedback>
-            </>
+        <Flex ml="10" flexDirection="column">
+          <Serif mb="-2" size="3t" color="black100">
+            {name}
+          </Serif>
+          {!!meta && (
+            <Sans mt="-2" size="3t" color="black60">
+              {meta}
+            </Sans>
           )}
-        </Sans>
+        </Flex>
       </Flex>
-    </ContainerComponent>
+
+      <Flex>
+        {FollowButton && (
+          <Box width={102} height={34}>
+            <TouchableWithoutFeedback
+              display="inline-block"
+              onPress={event => {
+                // Capture click event so that interacting with Follow doesn't
+                // trigger Container's link.
+                event.stopPropagation()
+              }}
+            >
+              {FollowButton}
+            </TouchableWithoutFeedback>
+          </Box>
+        )}
+      </Flex>
+    </Flex>
   )
 }
-
-const FlexLink = styled(Link)`
-  display: flex;
-`
 
 EntityHeader.displayName = "EntityHeader"


### PR DESCRIPTION
Reusable palette component created to be used for partner card and other follow button components.

<img width="352" alt="Screen Shot 2019-06-11 at 11 49 20 AM" src="https://user-images.githubusercontent.com/5643895/59287128-0bc81100-8c3f-11e9-8163-be1e5cfb0787.png">

__User story__
As a user, I can tap the “follow” button to follow, or “unfollow” button to unfollow the entity.

__Spec__
https://zpl.io/2Egzy5y