### PR TITLE
Add pointer-event: none to tooltip content

### DIFF
--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -38,6 +38,7 @@ const Tip = styled(BorderBox)<TipProps>`
     p.tipPosition.center ? "translate(-50%)" : "none"};
   transition: opacity 250ms ease-out;
   width: ${(p: TipProps) => p.width}px;
+  pointer-events: none;
 
   &:hover {
     cursor: default;


### PR DESCRIPTION
## Problem:
When there are multiple tooltips vertically aligned the tooltip content of the one on the bottom can block the hover area of the one above:

<img width="350" alt="Screen Shot 2019-06-11 at 4 32 49 PM" src="https://user-images.githubusercontent.com/687513/59305743-d89a7780-8c68-11e9-8cfd-53d690ae9816.png">

## Solution: 
adding `pointer-evnets: none` to content. It is also possible to fix this with changing `z-index` along with `opacity` but `pointer-events` is simpler and in fact it is not even possible to get the mouse over the content area when it is visible.
