### PR TITLE
Always allow scroll on tabs

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -253,12 +253,12 @@ const TabsPaddingContainer = styled(Flex)`
 `
 
 const TabsScrollContainer = styled(Flex)`
+  overflow-y: hidden;
+  overflow-x: scroll;
+  margin-bottom: 0;
   ${media.xs`
-    overflow-y: hidden;
-    overflow-x: scroll;
     -webkit-overflow-scrolling: touch;
   `};
-  margin-bottom: 0;
 `
 
 const TabContainer = styled.div`


### PR DESCRIPTION
- Enables scrolling on the x-axis as default for all breakpoints on tabs
- This is a necessary feature now that we're adding more tab items to search results: https://artsyproduct.atlassian.net/browse/DISCO-1048

## Example

![2019-06-13 16 46 38](https://user-images.githubusercontent.com/21182806/59466341-1cbd8180-8dfb-11e9-8ca1-f9098e17dbdc.gif)
