### PR TITLE
Button & Spinner Component for React Native

### DIFF
--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -1,0 +1,174 @@
+import React, { Component } from "react"
+import { TouchableWithoutFeedback } from "react-native"
+import { animated, Spring } from "react-spring/dist/native"
+import styled from "styled-components/native"
+import { themeProps } from "../../Theme"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
+import { Spinner } from "../Spinner"
+import { Sans } from "../Typography"
+import {
+  ButtonProps,
+  defaultSize,
+  defaultVariant,
+  getColorsForVariant,
+} from "./Button.shared"
+
+/**
+ * Spec: zpl.io/2j8Knq6
+ */
+enum DisplayState {
+  Enabled = "default",
+  Highlighted = "hover",
+  Disabled = "default",
+}
+
+interface ButtonState {
+  previous: DisplayState
+  current: DisplayState
+}
+
+/** A button with various size and color settings */
+export class Button extends Component<ButtonProps, ButtonState> {
+  static defaultProps = {
+    size: defaultSize,
+    variant: defaultVariant,
+    theme: themeProps,
+  }
+
+  state = {
+    previous: DisplayState.Enabled,
+    current: DisplayState.Enabled,
+  }
+
+  getSize(): { height: number; size: "2" | "3t"; px: number } {
+    switch (this.props.size) {
+      case "small":
+        return { height: 26, size: "2", px: 1 }
+      case "medium":
+        return { height: 41, size: "3t", px: 2 }
+      case "large":
+        return { height: 50, size: "3t", px: 3 }
+    }
+  }
+
+  get loadingStyles() {
+    const { inline, loading } = this.props
+
+    if (!loading) {
+      return {}
+    }
+
+    if (inline) {
+      return {
+        backgroundColor: "transparent",
+        color: "transparent",
+        borderWidth: 0,
+      }
+    }
+
+    return {
+      ...getColorsForVariant(this.props.variant).hover,
+      color: "transparent",
+    }
+  }
+
+  onPress = args => {
+    if (this.props.onPress) {
+      // Did someone tap really fast? Flick the highlighted state
+      const { current } = this.state
+
+      if (this.state.current === DisplayState.Enabled) {
+        this.setState({
+          previous: current,
+          current: DisplayState.Highlighted,
+        })
+        setTimeout(
+          () =>
+            this.setState({
+              previous: current,
+              current: DisplayState.Enabled,
+            }),
+          0.3
+        )
+      } else {
+        // Was already selected
+        this.setState({ current: DisplayState.Enabled })
+      }
+
+      this.props.onPress(args)
+    }
+  }
+
+  render() {
+    const { children, loading, disabled, inline, ...rest } = this.props
+    const { px, size, height } = this.getSize()
+    const variantColors = getColorsForVariant(this.props.variant)
+    const opacity = this.props.disabled ? 0.1 : 1.0
+
+    const { current, previous } = this.state
+
+    const from = variantColors[previous]
+    const to = variantColors[current]
+
+    return (
+      <Spring native from={from} to={to}>
+        {props => (
+          <TouchableWithoutFeedback
+            onPress={this.onPress}
+            onPressIn={() => {
+              this.setState({
+                previous: DisplayState.Enabled,
+                current: DisplayState.Highlighted,
+              })
+            }}
+            onPressOut={() => {
+              this.setState({
+                previous: DisplayState.Highlighted,
+                current: DisplayState.Enabled,
+              })
+            }}
+            disabled={disabled}
+          >
+            <Flex flexDirection="row">
+              <AnimatedContainer
+                {...rest}
+                loading={loading}
+                disabled={disabled}
+                style={{ ...props, ...this.loadingStyles, height, opacity }}
+                px={px}
+              >
+                <Sans
+                  weight="medium"
+                  size={size}
+                  color={this.loadingStyles.color || to.color}
+                >
+                  {children}
+                </Sans>
+
+                {loading && (
+                  <Spinner
+                    size={this.props.size}
+                    color={inline ? "black100" : "white100"}
+                  />
+                )}
+              </AnimatedContainer>
+            </Flex>
+          </TouchableWithoutFeedback>
+        )}
+      </Spring>
+    )
+  }
+}
+
+/** Base props that construct button */
+
+const Container = styled(Box)<ButtonProps>`
+  align-items: center;
+  justify-content: center;
+  border-width: 1;
+  border-radius: 3;
+  width: auto;
+`
+
+const AnimatedContainer = animated(Container)

--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -76,6 +76,16 @@ export class Button extends Component<ButtonProps, ButtonState> {
     }
   }
 
+  get spinnerColor() {
+    const { inline, variant } = this.props
+
+    if (inline) {
+      return variant === "primaryWhite" ? "white100" : "black100"
+    }
+
+    return "white100"
+  }
+
   onPress = args => {
     if (this.props.onPress) {
       // Did someone tap really fast? Flick the highlighted state
@@ -150,10 +160,7 @@ export class Button extends Component<ButtonProps, ButtonState> {
                 </Sans>
 
                 {loading && (
-                  <Spinner
-                    size={this.props.size}
-                    color={inline ? "black100" : "white100"}
-                  />
+                  <Spinner size={this.props.size} color={this.spinnerColor} />
                 )}
               </AnimatedContainer>
             </Flex>

--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -14,9 +14,6 @@ import {
   getColorsForVariant,
 } from "./Button.shared"
 
-/**
- * Spec: zpl.io/2j8Knq6
- */
 enum DisplayState {
   Enabled = "default",
   Highlighted = "hover",

--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -67,8 +67,11 @@ export class Button extends Component<ButtonProps, ButtonState> {
       }
     }
 
+    const { purple100 } = themeProps.colors
+
     return {
-      ...getColorsForVariant(this.props.variant).hover,
+      backgroundColor: purple100,
+      borderColor: purple100,
       color: "transparent",
     }
   }

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -1,0 +1,154 @@
+import { ReactNode } from "react"
+import { css } from "styled-components"
+import { themeProps } from "../../Theme"
+import { BoxProps } from "../Box"
+
+/**
+ * Spec: zpl.io/2j8Knq6
+ */
+
+/** Different theme variations */
+export type ButtonVariant =
+  | "primaryBlack"
+  | "primaryWhite"
+  | "secondaryGray"
+  | "secondaryOutline"
+  | "noOutline"
+/** Default button color variant */
+export const defaultVariant: ButtonVariant = "primaryBlack"
+
+/** The size of the button */
+export type ButtonSize = "small" | "medium" | "large"
+
+/** Default button size */
+export const defaultSize: ButtonSize = "medium"
+
+export interface ButtonProps extends ButtonBaseProps {
+  children: ReactNode
+  /** The size of the button */
+  size?: ButtonSize
+  /** The theme of the button */
+  variant?: ButtonVariant
+  /** React Native only, Callback on press, use instead of onClick */
+  onPress?: (e) => void
+}
+
+export interface ButtonBaseProps extends BoxProps {
+  /** Size of the button */
+  buttonSize?: ButtonSize
+  /** Displays a loader in the button */
+  loading?: boolean
+  /** Disabled interactions */
+  disabled?: boolean
+  /** Uses inline style for button */
+  inline?: boolean
+  /** Callback on click */
+  onClick?: (e) => void
+  /** Additional styles to apply to the variant */
+  variantStyles?: any // FIXME
+}
+
+/**
+ * Returns various colors for each state given a button variant
+ * @param variant
+ */
+export function getColorsForVariant(variant: ButtonVariant) {
+  const {
+    colors: { black100, black10, black30, black60, white100, purple100 },
+  } = themeProps
+
+  switch (variant) {
+    case "primaryBlack":
+      return {
+        default: {
+          backgroundColor: black100,
+          borderColor: black100,
+          color: white100,
+        },
+        hover: {
+          backgroundColor: purple100,
+          borderColor: purple100,
+          color: white100,
+        },
+      }
+    case "primaryWhite":
+      return {
+        default: {
+          backgroundColor: white100,
+          borderColor: white100,
+          color: black100,
+        },
+        hover: {
+          backgroundColor: purple100,
+          borderColor: purple100,
+          color: white100,
+        },
+      }
+    case "secondaryGray":
+      return {
+        default: {
+          backgroundColor: black10,
+          borderColor: black10,
+          color: black100,
+        },
+        hover: {
+          backgroundColor: black30,
+          borderColor: black30,
+          color: black100,
+        },
+      }
+    case "secondaryOutline":
+      return {
+        default: {
+          backgroundColor: white100,
+          borderColor: black10,
+          color: black100,
+        },
+        hover: {
+          backgroundColor: white100,
+          borderColor: black100,
+          color: black100,
+        },
+      }
+    case "noOutline":
+      return {
+        default: {
+          backgroundColor: "transparent",
+          borderColor: "transparent",
+          color: black60,
+        },
+        hover: {
+          backgroundColor: white100,
+          borderColor: black100,
+          color: black100,
+        },
+      }
+    default:
+  }
+}
+
+/**
+ * Returns css related to the passed in variant
+ * @param variant
+ */
+export const getStylesForVariant = (variant: ButtonVariant) => {
+  const { default: enabled, hover } = getColorsForVariant(variant)
+
+  return css`
+    ${() => {
+      return `
+          background-color: ${enabled.backgroundColor};
+          border-color: ${enabled.borderColor};
+          color: ${enabled.color};
+
+          @media ${themeProps.mediaQueries.hover} {
+            &:hover {
+              background-color: ${hover.backgroundColor};
+              border-color: ${hover.borderColor};
+              color: ${hover.color};
+            }
+          }
+        `
+    }};
+  `
+}

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -1,48 +1,23 @@
-import React, { Component, ReactNode } from "react"
+import React, { Component } from "react"
 import styled, { css } from "styled-components"
 import { themeProps } from "../../Theme"
 import { Spinner } from "../Spinner"
 import { Sans, SansProps } from "../Typography"
 
 import {
-  BorderProps,
   borderRadius,
-  BorderRadiusProps,
   borders,
   height,
-  HeightProps,
   space,
-  SpaceProps,
   textAlign,
-  TextAlignProps,
   width,
-  WidthProps,
 } from "styled-system"
-
-/**
- * Spec: zpl.io/2j8Knq6
- */
-
-/** The size of the button */
-export type ButtonSize = "small" | "medium" | "large"
-const defaultSize: ButtonSize = "medium"
-
-/** Different theme variations */
-export type ButtonVariant =
-  | "primaryBlack"
-  | "primaryWhite"
-  | "secondaryGray"
-  | "secondaryOutline"
-  | "noOutline"
-const defaultVariant: ButtonVariant = "primaryBlack"
-
-export interface ButtonProps extends ButtonBaseProps {
-  children: ReactNode
-  /** The size of the button */
-  size?: ButtonSize
-  /** The theme of the button */
-  variant?: ButtonVariant
-}
+import {
+  ButtonBaseProps,
+  ButtonProps,
+  defaultSize,
+  defaultVariant,
+} from "./Button.shared"
 
 /** A button with various size and color settings */
 export class Button extends Component<ButtonProps> {
@@ -169,26 +144,6 @@ export class Button extends Component<ButtonProps> {
 
     return <ButtonBase {...buttonProps}>{this.props.children}</ButtonBase>
   }
-}
-
-/** Base props that construct button */
-export interface ButtonBaseProps
-  extends BorderProps,
-    BorderRadiusProps,
-    SpaceProps,
-    TextAlignProps,
-    WidthProps,
-    HeightProps {
-  /** Size of the button */
-  buttonSize?: ButtonSize
-  /** Displays a loader in the button */
-  loading?: boolean
-  /** Disabled interactions */
-  disabled?: boolean
-  /** Callback on click */
-  onClick?: (e) => void
-  /** Additional styles to apply to the variant */
-  variantStyles?: any // FIXME
 }
 
 /** A base from which various button implementations can compose from */

--- a/packages/palette/src/elements/Button/index.tsx
+++ b/packages/palette/src/elements/Button/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Button"
+export * from "./Button.shared"

--- a/packages/palette/src/elements/Spinner/Spinner.ios.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.ios.tsx
@@ -1,0 +1,75 @@
+// @ts-ignore
+import React from "react"
+import { Animated, Easing, View } from "react-native"
+import styled from "styled-components/native"
+import { color } from "../../helpers"
+import { getSize, SpinnerProps } from "./Spinner.shared"
+
+/**
+ * Spinner component for React Native
+ */
+export class Spinner extends React.Component<SpinnerProps> {
+  rotation: Animated.Value
+
+  static defaultProps: SpinnerProps = {
+    size: "medium",
+    color: "black100",
+  }
+
+  constructor(props) {
+    super(props)
+    this.rotation = new Animated.Value(0)
+  }
+
+  componentDidMount() {
+    this.startRotation()
+  }
+
+  startRotation() {
+    this.rotation.setValue(0)
+    Animated.timing(this.rotation, {
+      toValue: 1,
+      duration: 1000,
+      easing: Easing.linear,
+      useNativeDriver: true,
+    }).start(() => this.startRotation())
+  }
+
+  render() {
+    const RotateData = this.rotation.interpolate({
+      inputRange: [0, 1],
+      outputRange: ["0deg", "360deg"],
+    })
+
+    return (
+      <Bar
+        as={Animated.View}
+        {...this.props}
+        style={{
+          transform: [{ rotate: RotateData }],
+        }}
+      />
+    )
+  }
+}
+
+/** Generic Spinner component */
+const Bar = styled(View)<SpinnerProps>`
+  background: black;
+  position: absolute;
+
+  ${props => {
+    const { width, height } = getSize(props)
+
+    return `
+      background: ${color(props.color)};
+      width: ${width}px;
+      height: ${height}px;
+    `
+  }};
+`
+
+Bar.defaultProps = {
+  width: 25,
+  height: 6,
+}

--- a/packages/palette/src/elements/Spinner/Spinner.shared.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.shared.tsx
@@ -1,0 +1,43 @@
+import { Color } from "../../Theme"
+
+export interface SpinnerProps {
+  /** Width of the spinner */
+  width?: number
+  /** Height of the spinner */
+  height?: number
+  /** Size of the spinner */
+  size?: "small" | "medium" | "large"
+  /** Color of the spinner */
+  color?: Color
+}
+
+/**
+ * Returns width and height of spinner based on size
+ * @param props
+ */
+export const getSize = (props: SpinnerProps) => {
+  const base = { width: 25, height: 6 }
+
+  switch (props.size) {
+    case "small":
+      return {
+        width: base.width * 0.5,
+        height: base.height * 0.5,
+      }
+    case "medium":
+      return {
+        width: base.width * 0.8,
+        height: base.height * 0.8,
+      }
+    case "large":
+      return {
+        width: base.width,
+        height: base.height,
+      }
+    default:
+      return {
+        width: props.width,
+        height: props.height,
+      }
+  }
+}

--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -1,15 +1,8 @@
 // @ts-ignore
 import React from "react"
 import styled, { keyframes } from "styled-components"
-
-export interface SpinnerProps {
-  /** Width of the spinner */
-  width?: number
-  /** Height of the spinner */
-  height?: number
-  /** Size of the spinner */
-  size?: "small" | "medium" | "large"
-}
+import { color } from "../../helpers"
+import { getSize, SpinnerProps } from "./Spinner.shared"
 
 const spin = keyframes`
   100% {
@@ -17,36 +10,8 @@ const spin = keyframes`
   }
 `
 
-const getSize = (props: SpinnerProps) => {
-  const base = { width: 25, height: 6 }
-
-  switch (props.size) {
-    case "small":
-      return {
-        width: base.width * 0.5,
-        height: base.height * 0.5,
-      }
-    case "medium":
-      return {
-        width: base.width * 0.8,
-        height: base.height * 0.8,
-      }
-    case "large":
-      return {
-        width: base.width,
-        height: base.height,
-      }
-    default:
-      return {
-        width: props.width,
-        height: props.height,
-      }
-  }
-}
-
 /** Generic Spinner component */
 export const Spinner = styled.div<SpinnerProps>`
-  background: black;
   animation: ${spin} 1s infinite linear;
   position: absolute;
 
@@ -54,6 +19,7 @@ export const Spinner = styled.div<SpinnerProps>`
     const { width, height } = getSize(props)
 
     return `
+      background: ${color(props.color)};
       width: ${width}px;
       height: ${height}px;
       top: calc(50% - ${height}px / 2);
@@ -65,6 +31,7 @@ export const Spinner = styled.div<SpinnerProps>`
 Spinner.defaultProps = {
   width: 25,
   height: 6,
+  color: "black100",
 }
 
 Spinner.displayName = "Spinner"

--- a/packages/palette/src/elements/Spinner/index.tsx
+++ b/packages/palette/src/elements/Spinner/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Spinner"
+export * from "./Spinner.shared"


### PR DESCRIPTION
This PR ports the Button and Spinner component from emission into palette. This also sets some guidelines on how to share common code and interfaces between React Native and React Web version of a component.

Note this works best for components that behave essentially the same on both platforms and can thus share a common interface.

![Kapture 2019-06-15 at 1 00 25](https://user-images.githubusercontent.com/296775/59547208-fc7be880-8f08-11e9-92d2-f1d23cb73fa4.gif)

Design spec:

<img width="1094" alt="Screen Shot 2019-06-15 at 1 09 51 AM" src="https://user-images.githubusercontent.com/296775/59547277-503b0180-8f0a-11e9-8f71-0e6f5b17da8e.png">
