### PR TITLE
Adds LineChart props type export

### DIFF
--- a/packages/palette/src/elements/LineChart/LineChart.tsx
+++ b/packages/palette/src/elements/LineChart/LineChart.tsx
@@ -14,7 +14,7 @@ import { LineChartSVG } from "./LineChartSVG"
 const margin = space(2)
 const DEFAULT_HEIGHT = 87
 
-interface LineChartProps extends ChartProps {
+export interface LineChartProps extends ChartProps {
   height?: number
 }
 


### PR DESCRIPTION
Adding back `LineChart` props type export that was removed by mistake [here](https://github.com/artsy/palette/pull/495/files#diff-d7d8d5bdf3d113a828a162de67c18d21L18)