### PR TITLE
Fix donut chart animation bug

### DIFF
--- a/packages/palette/src/elements/DonutChart/DonutChart.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.tsx
@@ -110,11 +110,7 @@ export const DonutChart: React.FC<DonutChartProps> = ({
     <svg key={"svg"} width={width + margin} height={width + margin}>
       <g transform={`translate(${centerX}, ${centerY})`}>
         {zeroStateArc}
-        <Spring
-          from={animateProps(hasEnteredViewport)}
-          to={animateProps(!hasEnteredViewport)}
-          delay={500}
-        >
+        <Spring from={{ num: -0.1 }} to={animateProps(!hasEnteredViewport)}>
           {({ num }) => {
             if (!labelFadeIn && num > 0.7) {
               setLabelFadeIn(true)
@@ -151,18 +147,14 @@ export const DonutChart: React.FC<DonutChartProps> = ({
     </svg>
   )
 
-  const ChartSVG = () => (
-    <>
-      {tooltip}
-      {labels}
-      {svg}
-    </>
-  )
-
   return (
     <ProvideMousePosition>
       <Box ref={wrapperRef as any} position="relative">
-        <ChartSVG />
+        <>
+          {tooltip}
+          {labels}
+          {svg}
+        </>
       </Box>
     </ProvideMousePosition>
   )


### PR DESCRIPTION
Addresses [GALL-1864](https://artsyproduct.atlassian.net/browse/GALL-1864)

After [react-spring update](https://github.com/artsy/palette/pull/511) animations broke. Each react render causing animation to trigger again:

![donut-bug](https://user-images.githubusercontent.com/687513/59790560-313bc700-929e-11e9-9b99-ba7a95e01fff.gif)

This fixes that. Seems to be `Spring` internal state bug. Will try to find the minimal code for reproducing it to report it but this fixes that.