### PR TITLE
Add prop to make button full width

### DIFF
--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -175,7 +175,7 @@ const Container = styled(Box)<ButtonProps>`
   justify-content: center;
   border-width: 1;
   border-radius: 3;
-  width: auto;
+  width: ${p => (p.block ? "100%" : "auto")};
 `
 
 const AnimatedContainer = animated(Container)

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -42,8 +42,9 @@ export interface ButtonBaseProps extends BoxProps {
   disabled?: boolean
   /** Uses inline style for button */
   inline?: boolean
-  /** Callback on click */
+  /** Makes button full width */
   block?: boolean
+  /** Callback on click */
   onClick?: (e) => void
   /** Additional styles to apply to the variant */
   variantStyles?: any // FIXME

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -43,6 +43,7 @@ export interface ButtonBaseProps extends BoxProps {
   /** Uses inline style for button */
   inline?: boolean
   /** Callback on click */
+  block?: boolean
   onClick?: (e) => void
   /** Additional styles to apply to the variant */
   variantStyles?: any // FIXME


### PR DESCRIPTION
Added an optional "block" prop to the ios button component. 