### PR TITLE
Fixes Spring bug and updates Inline to remove padding and height

### DIFF
--- a/packages/palette-docs/content/docs/elements/buttons/Button.mdx
+++ b/packages/palette-docs/content/docs/elements/buttons/Button.mdx
@@ -165,3 +165,32 @@ Like other form elements, buttons can be disabled.
     </Button>
   </>
 </Playground>
+
+## Display Inline and Block
+
+Use `inline` to remove height and padding from the button, can be used in
+combination of `noOutline` to create an inline button.
+
+<Playground title="noOutline" showToggle={true} expanded={false}>
+  <>
+    <Button inline variant="noOutline" size="small" m={0.5}>
+      Reset
+    </Button>
+    <Button inline variant="noOutline" size="medium" m={0.5}>
+      Reset
+    </Button>
+    <Button inline variant="noOutline" size="large" m={0.5}>
+      Reset
+    </Button>
+  </>
+</Playground>
+
+Use `block` to style a button to be 100% width of its container.
+
+<Playground title="noOutline" showToggle={true} expanded={false}>
+  <>
+    <Button block width="100%" size="medium" m={0.5}>
+      Reset
+    </Button>
+  </>
+</Playground>

--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -62,8 +62,6 @@ export class Button extends Component<ButtonProps, ButtonState> {
         backgroundColor: "rgba(0, 0, 0, 0)",
         color: "rgba(0, 0, 0, 0)",
         borderWidth: 0,
-        height: "auto",
-        padding: 0,
       }
     }
 

--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -38,14 +38,15 @@ export class Button extends Component<ButtonProps, ButtonState> {
     current: DisplayState.Enabled,
   }
 
-  getSize(): { height: number; size: "2" | "3t"; px: number } {
+  getSize(): { height: number | string; size: "2" | "3t"; px: number } {
+    const { inline } = this.props
     switch (this.props.size) {
       case "small":
-        return { height: 26, size: "2", px: 1 }
+        return { height: inline ? 17 : 26, size: "2", px: inline ? 0 : 1 }
       case "medium":
-        return { height: 41, size: "3t", px: 2 }
+        return { height: inline ? 21 : 41, size: "3t", px: inline ? 0 : 2 }
       case "large":
-        return { height: 50, size: "3t", px: 3 }
+        return { height: inline ? 21 : 50, size: "3t", px: inline ? 0 : 3 }
     }
   }
 
@@ -58,9 +59,11 @@ export class Button extends Component<ButtonProps, ButtonState> {
 
     if (inline) {
       return {
-        backgroundColor: "transparent",
-        color: "transparent",
+        backgroundColor: "rgba(0, 0, 0, 0)",
+        color: "rgba(0, 0, 0, 0)",
         borderWidth: 0,
+        height: "auto",
+        padding: 0,
       }
     }
 
@@ -69,7 +72,7 @@ export class Button extends Component<ButtonProps, ButtonState> {
     return {
       backgroundColor: black100,
       borderColor: black100,
-      color: "transparent",
+      color: "rgba(0, 0, 0, 0)",
     }
   }
 

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -117,8 +117,8 @@ export function getColorsForVariant(variant: ButtonVariant) {
     case "noOutline":
       return {
         default: {
-          backgroundColor: "transparent",
-          borderColor: "transparent",
+          backgroundColor: "rgba(0, 0, 0, 0)",
+          borderColor: "rgba(0, 0, 0, 0)",
           color: black100,
         },
         hover: {

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -34,7 +34,7 @@ export class Button extends Component<ButtonProps> {
         return {
           height: inline ? "17px" : "26px",
           size: "2",
-          px: inline ? 0 : 1,
+          px: inline ? 0 : 2,
         }
       case "medium":
         return {

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -28,13 +28,26 @@ export class Button extends Component<ButtonProps> {
   }
 
   getSize(): { height: string; size: "2" | "3t"; px: number } {
+    const { inline } = this.props
     switch (this.props.size) {
       case "small":
-        return { height: "26px", size: "2", px: 2 }
+        return {
+          height: inline ? "17px" : "26px",
+          size: "2",
+          px: inline ? 0 : 1,
+        }
       case "medium":
-        return { height: "41px", size: "3t", px: 2 }
+        return {
+          height: inline ? "21px" : "41px",
+          size: "3t",
+          px: inline ? 0 : 2,
+        }
       case "large":
-        return { height: "50px", size: "3t", px: 3 }
+        return {
+          height: inline ? "21px" : "50px",
+          size: "3t",
+          px: inline ? 0 : 3,
+        }
     }
   }
 


### PR DESCRIPTION
- `Inline` now removes `height` and `padding` 
- Fixes React Spring bug where `transparent` background causes crash, replacing `transparent` with `rgba(0, 0, 0, 0)` is the fix.

Example of inline button:

<img width="452" alt="Screen Shot 2019-07-02 at 2 51 37 PM" src="https://user-images.githubusercontent.com/21182806/60538671-06f3fb80-9cd9-11e9-9518-1013945f88a5.png">
