### PR TITLE
[PURCHASE-1226] Partner card follow button goes off screen if the partner name is too long

### DIFF
--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -44,7 +44,13 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
           {name}
         </Serif>
         {!!meta && (
-          <Sans mt="-2" size="3t" color="black60">
+          <Sans
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            mt="-2"
+            size="3t"
+            color="black60"
+          >
             {meta}
           </Sans>
         )}

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -33,8 +33,14 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
           <Avatar size="xs" src={imageUrl} initials={initials} />
         </Flex>
       )}
-      <Flex flexGrow={1} ml="2px" justifyContent="center">
-        <Serif mb="-2" size="3t" color="black100">
+      <Flex width="150px" flexGrow={1} ml="2px" justifyContent="center">
+        <Serif
+          ellipsizeMode="tail"
+          numberOfLines={1}
+          mb="-2"
+          size="3t"
+          color="black100"
+        >
           {name}
         </Serif>
         {!!meta && (


### PR DESCRIPTION
__Problem:__
Partner card follow button goes off screen if the partner name is too long (i.e. The Metropolitan Museum of Art). 

We should make sure we are truncating both the name and the metadata on the second line. 

__Solution:__
Added ellipsizeMode and numberOfLines to name and metadata text elements

__Before:__
<img width="351" alt="Screen Shot 2019-07-08 at 12 29 45 PM" src="https://user-images.githubusercontent.com/5643895/60829055-07c9d900-a182-11e9-9c17-c2549d507151.png">

__After:__
<img width="350" alt="Screen Shot 2019-07-08 at 12 30 06 PM" src="https://user-images.githubusercontent.com/5643895/60829075-13b59b00-a182-11e9-8c36-71e7f325e871.png">
