### PR TITLE
Adds longestText prop to Button component

### DIFF
--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -164,7 +164,7 @@ export class Button extends Component<ButtonProps, ButtonState> {
                     {children}
                   </Sans>
                 </VisibleTextContainer>
-                <HiddenText weight="medium" size={size}>
+                <HiddenText role="presentation" weight="medium" size={size}>
                   {longestText ? longestText : children}
                 </HiddenText>
 

--- a/packages/palette/src/elements/Button/Button.ios.tsx
+++ b/packages/palette/src/elements/Button/Button.ios.tsx
@@ -64,11 +64,11 @@ export class Button extends Component<ButtonProps, ButtonState> {
       }
     }
 
-    const { purple100 } = themeProps.colors
+    const { black100 } = themeProps.colors
 
     return {
-      backgroundColor: purple100,
-      borderColor: purple100,
+      backgroundColor: black100,
+      borderColor: black100,
       color: "transparent",
     }
   }
@@ -111,7 +111,14 @@ export class Button extends Component<ButtonProps, ButtonState> {
   }
 
   render() {
-    const { children, loading, disabled, inline, ...rest } = this.props
+    const {
+      children,
+      loading,
+      disabled,
+      inline,
+      longestText,
+      ...rest
+    } = this.props
     const { px, size, height } = this.getSize()
     const variantColors = getColorsForVariant(this.props.variant)
     const opacity = this.props.disabled ? 0.1 : 1.0
@@ -148,13 +155,18 @@ export class Button extends Component<ButtonProps, ButtonState> {
                 style={{ ...props, ...this.loadingStyles, height, opacity }}
                 px={px}
               >
-                <Sans
-                  weight="medium"
-                  size={size}
-                  color={this.loadingStyles.color || to.color}
-                >
-                  {children}
-                </Sans>
+                <VisibleTextContainer>
+                  <Sans
+                    weight="medium"
+                    color={this.loadingStyles.color || to.color}
+                    size={size}
+                  >
+                    {children}
+                  </Sans>
+                </VisibleTextContainer>
+                <HiddenText weight="medium" size={size}>
+                  {longestText ? longestText : children}
+                </HiddenText>
 
                 {loading && (
                   <Spinner size={this.props.size} color={this.spinnerColor} />
@@ -170,9 +182,24 @@ export class Button extends Component<ButtonProps, ButtonState> {
 
 /** Base props that construct button */
 
+const VisibleTextContainer = styled(Box)`
+  position: absolute;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+`
+
+const HiddenText = styled(Sans)`
+  opacity: 0;
+`
+
 const Container = styled(Box)<ButtonProps>`
   align-items: center;
   justify-content: center;
+  position: relative;
   border-width: 1;
   border-radius: 3;
   width: ${p => (p.block ? "100%" : "auto")};

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -48,6 +48,8 @@ export interface ButtonBaseProps extends BoxProps {
   onClick?: (e) => void
   /** Additional styles to apply to the variant */
   variantStyles?: any // FIXME
+  /** Pass the longest text to the button for the button to keep longest text width */
+  longestText?: string
 }
 
 /**

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -192,7 +192,12 @@ export class ButtonBase extends Component<ButtonBaseProps & SansProps> {
         >
           {children}
         </VisibleText>
-        <HiddenText pt="1px" weight={weight || "medium"} size={size}>
+        <HiddenText
+          role="presentation"
+          pt="1px"
+          weight={weight || "medium"}
+          size={size}
+        >
           {longestText ? longestText : children}
         </HiddenText>
       </Container>

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -166,6 +166,7 @@ export class ButtonBase extends Component<ButtonBaseProps & SansProps> {
       disabled,
       color,
       size,
+      longestText,
       weight,
       onClick,
       ...rest
@@ -183,13 +184,33 @@ export class ButtonBase extends Component<ButtonBaseProps & SansProps> {
       >
         {loading && <Spinner size={this.props.buttonSize} />}
 
-        <Sans pt="1px" weight={weight || "medium"} color={color} size={size}>
+        <VisibleText
+          pt="1px"
+          weight={weight || "medium"}
+          color={color}
+          size={size}
+        >
           {children}
-        </Sans>
+        </VisibleText>
+        <HiddenText pt="1px" weight={weight || "medium"} size={size}>
+          {longestText ? longestText : children}
+        </HiddenText>
       </Container>
     )
   }
 }
+
+const VisibleText = styled(Sans)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`
+
+const HiddenText = styled(Sans)`
+  opacity: 0;
+  pointer-events: none;
+`
 
 const Container = styled.button<ButtonBaseProps>`
   cursor: pointer;

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -52,13 +52,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
       )}
 
       <Flex flexDirection="column" justifyContent="center" width="100%">
-        <Serif
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          size="5"
-          weight="semibold"
-          color="black100"
-        >
+        <Serif size="3" weight="semibold" color="black100">
           {name}
         </Serif>
 

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -52,7 +52,13 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
       )}
 
       <Flex flexDirection="column" justifyContent="center" width="100%">
-        <Serif size="3" weight="semibold" color="black100">
+        <Serif
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          size="5"
+          weight="semibold"
+          color="black100"
+        >
           {name}
         </Serif>
 

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -207,6 +207,8 @@ function createStyledText<P extends StyledTextProps>(
 export interface SansProps extends Partial<TextProps> {
   italic?: boolean
 
+  role?: string
+
   size: SansSize
 
   /**


### PR DESCRIPTION
- Adds a prop to `Button` to pass the longest string to keep the button width fixed at the longest text width. I.e. a button with "Following" and "Follow" states will always retain the width of "Following." This allows for enlarged text sizes and is a fix for otherwise necessitating hard coded button widths.

- Replaces `purple100` for `black100` background color from iOS button transitions on request from design team.

![2019-07-10 15 23 52](https://user-images.githubusercontent.com/21182806/61002960-bc096200-a330-11e9-94bb-1116e57be6c1.gif)


![2019-07-10 16 51 59](https://user-images.githubusercontent.com/21182806/61004095-36d37c80-a333-11e9-8d5a-5be39d32a484.gif)
