### PR TITLE
noOutline button color

### DIFF
--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -119,7 +119,7 @@ export function getColorsForVariant(variant: ButtonVariant) {
         default: {
           backgroundColor: "transparent",
           borderColor: "transparent",
-          color: black60,
+          color: black100,
         },
         hover: {
           backgroundColor: white100,

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -58,7 +58,7 @@ export interface ButtonBaseProps extends BoxProps {
  */
 export function getColorsForVariant(variant: ButtonVariant) {
   const {
-    colors: { black100, black10, black30, black60, white100, purple100 },
+    colors: { black100, black10, black30, white100, purple100 },
   } = themeProps
 
   switch (variant) {

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -126,7 +126,7 @@ export class Button extends Component<ButtonProps> {
             return `
                 background-color: transparent;
                 border-color: transparent;
-                color: ${colors.black60};
+                color: ${colors.black100};
               `
           }};
         `


### PR DESCRIPTION
- Design team has requested the `noOutline` button have black text

- Before 

![Screen Shot 2019-07-11 at 11 49 35 AM](https://user-images.githubusercontent.com/21182806/61066342-5ae69a80-a3d3-11e9-9342-0b27f4e17683.png)

- After

![Screen Shot 2019-07-11 at 11 52 35 AM](https://user-images.githubusercontent.com/21182806/61066347-5f12b800-a3d3-11e9-9c73-fb755408102b.png)
