### PR TITLE
Bar chart zero state

### DIFF
--- a/packages/palette/src/elements/BarChart/BarChart.story.tsx
+++ b/packages/palette/src/elements/BarChart/BarChart.story.tsx
@@ -226,3 +226,94 @@ storiesOf("Components/BarChart", module)
       </Box>
     )
   })
+
+  .add("Zero state with highlight and x axis label", () => {
+    return (
+      <Box width="50%">
+        <BarChart
+          bars={[
+            {
+              value: 0,
+              axisLabelX: "Sep 30",
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+              label: { title: "Dec 30", description: "0 clicks" },
+            },
+            {
+              value: 0,
+              label: { title: "Jan 30", description: "0 clicks" },
+            },
+            {
+              value: 0,
+              label: { title: "Feb 30", description: "0 clicks" },
+              axisLabelX: "February 20 - June 20",
+              highlightLabel: {
+                title: "0",
+                description: "No clicks",
+              },
+            },
+            {
+              value: 0,
+              label: { title: "Mar 30", description: "0 clicks" },
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+              axisLabelX: "Jul 30",
+            },
+          ]}
+          minLabel={null}
+          maxLabel={null}
+        />
+      </Box>
+    )
+  })
+
+  .add("Zero state no labels", () => {
+    return (
+      <Box width="50%">
+        <BarChart
+          bars={[
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+            {
+              value: 0,
+            },
+          ]}
+          minLabel="Sep 30"
+          maxLabel="Jul 30"
+        />
+      </Box>
+    )
+  })

--- a/packages/palette/src/elements/BarChart/BarChart.story.tsx
+++ b/packages/palette/src/elements/BarChart/BarChart.story.tsx
@@ -197,6 +197,10 @@ storiesOf("Components/BarChart", module)
               value: 4000,
               label: { title: "Feb 30", description: "423 clicks" },
               axisLabelX: "February 20 - June 20",
+              highlightLabel: {
+                title: "$30,000–$80,000",
+                description: "This artwork",
+              },
             },
             {
               value: 400,
@@ -216,8 +220,8 @@ storiesOf("Components/BarChart", module)
               axisLabelX: "Jul 30",
             },
           ]}
-          minLabel="$500"
-          maxLabel="$50,000+"
+          minLabel={null}
+          maxLabel={null}
         />
       </Box>
     )

--- a/packages/palette/src/elements/BarChart/BarChart.tsx
+++ b/packages/palette/src/elements/BarChart/BarChart.tsx
@@ -11,7 +11,6 @@ import { Bar } from "./Bar"
 
 const ChartContainer = styled(Flex)`
   border-bottom: 1px solid ${color("black10")};
-  flex: 1;
 `
 
 function useHighlightLabelPositionConstraints(
@@ -79,6 +78,7 @@ export const BarChart = ({ bars, minLabel, maxLabel }: BarChartProps) => {
   const hasEnteredViewport = useHasEnteredViewport(wrapperRef)
   const [minHeight, setMinHeight] = useState(0)
   const maxValue: number = maxBy(bars, item => item.value).value
+  const allZero = bars.every(item => item.value === 0)
   return (
     <ProvideMousePosition>
       <Flex
@@ -103,7 +103,7 @@ export const BarChart = ({ bars, minLabel, maxLabel }: BarChartProps) => {
               return (
                 <Bar
                   key={index}
-                  heightPercent={heightPercent}
+                  heightPercent={allZero ? 0 : heightPercent}
                   label={coerceTooltip(label)}
                   axisLabelX={axisLabelX}
                   highlightLabelRef={highlightLabelRef}


### PR DESCRIPTION
### Before:

![Screen Shot 2019-07-19 at 5 13 28 PM](https://user-images.githubusercontent.com/687513/61566805-4f3a4a00-aa4b-11e9-8c2a-b8af478fb38e.png)

### After:

![Screen Shot 2019-07-19 at 5 32 43 PM](https://user-images.githubusercontent.com/687513/61566808-55c8c180-aa4b-11e9-8a53-36e1d1c212da.png)

### Questions:

- Is it by design that the highlighted bar has at least has `10px` height? It is defined [here](https://github.com/artsy/palette/blob/master/packages/palette/src/elements/BarChart/Bar.tsx#L164-L166):

![Screen Shot 2019-07-19 at 5 34 09 PM](https://user-images.githubusercontent.com/687513/61566934-c7a10b00-aa4b-11e9-9e9d-6ebe3271c6e4.png)

- Removed [this](https://github.com/artsy/palette/compare/master...sepans:bar-chart-zero?expand=1#diff-710f36809acea9f66cf6ae101cf56b66L14) `flex: 1`. Doesn't seem to be doing anything except making charts grow from top instead of bottom when there is no `highlightLabel`

![bar_grow](https://user-images.githubusercontent.com/687513/61567220-cde3b700-aa4c-11e9-9078-b7f8a894bfcc.gif)


