### PR TITLE
Minor chart fixes

### DIFF
--- a/packages/palette/src/elements/DataVis/ChartTooltip.tsx
+++ b/packages/palette/src/elements/DataVis/ChartTooltip.tsx
@@ -1,11 +1,9 @@
 import React from "react"
 import styled from "styled-components"
-import { space } from "../../helpers"
 import { Flex, FlexProps } from "../Flex"
 import { Sans } from "../Typography"
 
 const ChartTooltipWrapper = styled(Flex)`
-  padding: ${space(0.5)}px ${space(1)}px;
   text-align: center;
   align-items: center;
   flex-direction: column;
@@ -19,9 +17,23 @@ const ChartTooltipWrapper = styled(Flex)`
 export const coerceTooltip = (tooltip: React.ReactNode | ChartTooltipProps) =>
   isChartTooltipProps(tooltip) ? <ChartTooltip {...tooltip} /> : tooltip
 
+/**
+ * Similart to `coerceTooltip` but without padding
+ * @param tooltip
+ */
+export const coerceTooltipWithoutPadding = (
+  tooltip: React.ReactNode | ChartTooltipProps
+) =>
+  isChartTooltipProps(tooltip) ? (
+    <ChartTooltip noPadding {...tooltip} />
+  ) : (
+    tooltip
+  )
+
 export interface ChartTooltipProps extends FlexProps {
   title: React.ReactNode
   description: React.ReactNode
+  noPadding: boolean
 }
 
 // tslint:disable-next-line:completed-docs
@@ -41,9 +53,14 @@ export function isChartTooltipProps(obj: any): obj is ChartTooltipProps {
 export const ChartTooltip = ({
   title,
   description,
+  noPadding,
   ...others
 }: ChartTooltipProps) => (
-  <ChartTooltipWrapper {...others}>
+  <ChartTooltipWrapper
+    px={noPadding ? 0 : 0.5}
+    py={noPadding ? 0 : 1}
+    {...others}
+  >
     <Sans color={"black100"} weight="medium" size="2">
       {title}
     </Sans>

--- a/packages/palette/src/elements/DataVis/ChartTooltip.tsx
+++ b/packages/palette/src/elements/DataVis/ChartTooltip.tsx
@@ -57,8 +57,8 @@ export const ChartTooltip = ({
   ...others
 }: ChartTooltipProps) => (
   <ChartTooltipWrapper
-    px={noPadding ? 0 : 0.5}
-    py={noPadding ? 0 : 1}
+    py={noPadding ? 0 : 0.5}
+    px={noPadding ? 0 : 1}
     {...others}
   >
     <Sans color={"black100"} weight="medium" size="2">

--- a/packages/palette/src/elements/DonutChart/DonutChart.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.tsx
@@ -7,7 +7,10 @@ import { color, space } from "../../helpers"
 import { Color } from "../../Theme"
 import { Box } from "../Box"
 import { ChartHoverTooltip } from "../DataVis/ChartHoverTooltip"
-import { coerceTooltip } from "../DataVis/ChartTooltip"
+import {
+  coerceTooltip,
+  coerceTooltipWithoutPadding,
+} from "../DataVis/ChartTooltip"
 import { ProvideMousePosition } from "../DataVis/MousePositionContext"
 import { ChartProps } from "../DataVis/utils/SharedTypes"
 import { useHasEnteredViewport } from "../DataVis/utils/useHasEnteredViewPort"
@@ -86,7 +89,7 @@ export const DonutChart: React.FC<DonutChartProps> = ({
           center={centerX}
         >
           <Sans color="black60" size="2">
-            {coerceTooltip(axisLabelX)}
+            {coerceTooltipWithoutPadding(axisLabelX)}
           </Sans>
         </DonutLabelContainer>
       )

--- a/packages/palette/src/elements/LineChart/LineChart.tsx
+++ b/packages/palette/src/elements/LineChart/LineChart.tsx
@@ -112,7 +112,7 @@ const HoverHandler: React.FC<HoverHandlerProps> = ({
 export const PointHoverArea = styled.div`
   flex: 1;
   z-index: 1;
-  margin-right: 1%; /* gap between area enabling tooptips */
+  margin: 0 1%; /* gap between area enabling tooptips */
   opacity: 0;
   transition: opacity 0.4s ease-in;
 `


### PR DESCRIPTION
Minor fixes:

* Make the gap around invisible line chart hover label area on both sides instead of just right side

<img width="533" alt="Screen Shot 2019-07-22 at 12 33 12 PM" src="https://user-images.githubusercontent.com/687513/61648167-e9cd9f80-ac7c-11e9-829e-30efcdc76d35.png">

* Remove padding around donut chart labels

<img width="400" alt="Screen Shot 2019-07-22 at 11 20 24 AM" src="https://user-images.githubusercontent.com/687513/61644763-4f1c9300-ac73-11e9-8bf3-731c7eb2b2dc.png">