### PR TITLE
Update Component Spec template to include web Zeplin link

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-spec.md
+++ b/.github/ISSUE_TEMPLATE/component-spec.md
@@ -9,20 +9,21 @@ about: Propose additions or updates to palette
 
 ## Component Name
 
-### Zeplin link
+### Zeplin Links
 
-zpl://screen?sid=
+web: <!-- https://zpl.io/aabbccd -->
+app: <!-- zpl://screen?sid=1aaaaaaaaaaaaaaaaaaaaaaa&pid=lbbbbbbbbbbbbbbbbbbbbbbb -->
 
-### Product team
+### Product Team
 
 <!-- Purchase/Sell/etc -->
 
-### Design lead
+### Design Lead
 
 <!-- @person -->
 
 <!-- optional
-### Additional info
+### Additional Info
  Add any additional information here that might not be covered by the spec. Remove if not needed.
 -->
 


### PR DESCRIPTION
This commit updates the Component Step template to prompt for both Zeplin links: web and app. Those interested in the spec are not always on a system with the Zeplin app installed. This prompts issue creators to provide both links so that the spec can be accessed by a wider range of viewers and devices.