### PR TITLE
Updates modal to allow for updates prop changes

### DIFF
--- a/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
+++ b/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
@@ -2,16 +2,12 @@
 name: Modal
 ---
 
-## Notes
+## Modal with animated transitions
 
 - This component supports an optional prop `refreshModalContentKey` as a string,
   which when updated refreshes the modal content with a fade in/fade out
   animation. See example by pressing the `Change content` button in this
   example.
-
-## Modal with animated transitions
-
-- Content will fade out and in when `refreshModalContentKey` key changes
 
 <Playground title="Variable text size">
   <State

--- a/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
+++ b/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
@@ -2,12 +2,20 @@
 name: Modal
 ---
 
+## Notes
+
+- This component supports an optional prop `refreshModalContentKey` as a string,
+  which when updated refreshes the modal content with a fade in/fade out
+  animation. See example by pressing the `Change content` button in this
+  example.
+
 <Playground title="Variable text size">
   <State
     initial={{
       children:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Etiam porta sem malesuada magna mollis euismod. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Nulla vitae elit libero, a pharetra augue.",
       show: false,
+      contentKey: "123",
     }}
   >
     {({ state, setState }) => (
@@ -16,6 +24,7 @@ name: Modal
         <Modal
           title="Tellus Ligula Sit"
           hasLogo
+          refreshModalContentKey={state.contentKey}
           show={state.show}
           onClose={() => setState({ show: false })}
           FixedButton={
@@ -24,6 +33,7 @@ name: Modal
               width="100%"
               onClick={() =>
                 setState({
+                  contentKey: "456",
                   children:
                     "Donec ullamcorper nulla non metus auctor fringilla. Nullam id dolor id nibh ultricies vehicula ut id elit. Etiam porta sem malesuada magna mollis euismod. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id ligula porta felis euismod semper. Maecenas faucibus mollis interdum.",
                 })

--- a/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
+++ b/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
@@ -9,6 +9,10 @@ name: Modal
   animation. See example by pressing the `Change content` button in this
   example.
 
+## Modal with refreshModalContentKey
+
+- Content will fade out and in when
+
 <Playground title="Variable text size">
   <State
     initial={{
@@ -20,7 +24,9 @@ name: Modal
   >
     {({ state, setState }) => (
       <>
-        <Button onClick={() => setState({ show: true })}>Open modal</Button>
+        <Button onClick={() => setState({ show: true })}>
+          Open modal with refresh key
+        </Button>
         <Modal
           title="Tellus Ligula Sit"
           hasLogo
@@ -34,6 +40,50 @@ name: Modal
               onClick={() =>
                 setState({
                   contentKey: "456",
+                  children:
+                    "Donec ullamcorper nulla non metus auctor fringilla. Nullam id dolor id nibh ultricies vehicula ut id elit. Etiam porta sem malesuada magna mollis euismod. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id ligula porta felis euismod semper. Maecenas faucibus mollis interdum.",
+                })
+              }
+            >
+              Change content
+            </Button>
+          }
+        >
+          {state.children}
+        </Modal>
+      </>
+    )}
+  </State>
+</Playground>
+
+## Modal without refreshModalContentKey
+
+- Content will update immediately without fade
+
+<Playground title="Variable text size">
+  <State
+    initial={{
+      children:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Etiam porta sem malesuada magna mollis euismod. Maecenas faucibus mollis interdum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Nulla vitae elit libero, a pharetra augue.",
+      show: false,
+    }}
+  >
+    {({ state, setState }) => (
+      <>
+        <Button onClick={() => setState({ show: true })}>
+          Open modal without refresh key
+        </Button>
+        <Modal
+          title="Tellus Ligula Sit"
+          hasLogo
+          show={state.show}
+          onClose={() => setState({ show: false })}
+          FixedButton={
+            <Button
+              block
+              width="100%"
+              onClick={() =>
+                setState({
                   children:
                     "Donec ullamcorper nulla non metus auctor fringilla. Nullam id dolor id nibh ultricies vehicula ut id elit. Etiam porta sem malesuada magna mollis euismod. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id ligula porta felis euismod semper. Maecenas faucibus mollis interdum.",
                 })

--- a/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
+++ b/packages/palette-docs/content/docs/elements/dialogs/Modal.mdx
@@ -9,9 +9,9 @@ name: Modal
   animation. See example by pressing the `Change content` button in this
   example.
 
-## Modal with refreshModalContentKey
+## Modal with animated transitions
 
-- Content will fade out and in when
+- Content will fade out and in when `refreshModalContentKey` key changes
 
 <Playground title="Variable text size">
   <State
@@ -56,7 +56,7 @@ name: Modal
   </State>
 </Playground>
 
-## Modal without refreshModalContentKey
+## Modal without animationed transitions
 
 - Content will update immediately without fade
 

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -4,15 +4,18 @@ import styled from "styled-components"
 import { color, media, space } from "../../helpers"
 import { CloseIcon } from "../../svgs"
 import { ArtsyLogoBlackIcon } from "../../svgs/ArtsyLogoBlackIcon"
+import { usePrevious } from "../../utils/usePrevious"
 import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { Spacer } from "../Spacer"
 import { Serif } from "../Typography"
 
+/**
+ * refreshModalContentKey should change if the modal displays new content and should fade in/fade out with content update
+ */
 interface ModalProps {
   FixedButton?: JSX.Element
-  // refreshModalContent should change if the modal displays new content
-  refreshModalContent?: string
+  refreshModalContentKey?: string
   hasLogo?: boolean
   height?: string
   isWide?: boolean
@@ -38,7 +41,7 @@ const AnimatedView = animated(Box)
  */
 export const Modal: SFC<ModalProps> = ({
   children,
-  refreshModalContent,
+  refreshModalContentKey,
   FixedButton,
   title,
   show,
@@ -52,10 +55,11 @@ export const Modal: SFC<ModalProps> = ({
   })
   const [springModalAnimation, setSpringModalAnimation] = useState({
     transform: "translate(-50%, 0%) translateY(50vh)",
-    opacity: 1,
+    opacity: 0,
     onRest: null,
   })
   const [visibleContent, setVisibleContent] = useState(null)
+  const previousChangeKey = usePrevious(refreshModalContentKey)
 
   const contentAnimation = useSpring(springContentAnimation)
   const modalAnimation = useSpring(springModalAnimation)
@@ -65,6 +69,18 @@ export const Modal: SFC<ModalProps> = ({
       onClose()
     }
   }
+
+  useEffect(() => {
+    if (previousChangeKey === refreshModalContentKey) {
+      setVisibleContent(ModalContent)
+    } else {
+      // Fades out content if changeKey updates
+      setSpringContentAnimation({
+        opacity: 0,
+        onRest: () => fadeInNewContent(),
+      })
+    }
+  }, [children])
 
   useEffect(() => {
     if (show) {
@@ -96,7 +112,7 @@ export const Modal: SFC<ModalProps> = ({
     }
   }, [show])
 
-  const updateVisibleContent = () => {
+  const fadeInNewContent = () => {
     // Replaces content
     setVisibleContent(ModalContent)
     // Fades in new content
@@ -105,14 +121,6 @@ export const Modal: SFC<ModalProps> = ({
       onRest: null,
     })
   }
-
-  // Listens for props to change and fades in new content
-  useEffect(() => {
-    setSpringContentAnimation({
-      opacity: 0,
-      onRest: () => updateVisibleContent(),
-    })
-  }, [refreshModalContent])
 
   const ModalContent = () => {
     return (

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -11,7 +11,9 @@ import { Spacer } from "../Spacer"
 import { Serif } from "../Typography"
 
 /**
- * refreshModalContentKey should change if the modal displays new content and should fade in/fade out with content update
+ * refreshModalContentKey should change if the modal displays new content and should fade
+ * in/fade out with content update. If refreshModalContentKey does not change, the content
+ * updates immedately.
  */
 interface ModalProps {
   FixedButton?: JSX.Element

--- a/packages/palette/src/utils/usePrevious.ts
+++ b/packages/palette/src/utils/usePrevious.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * usePrevious
+ * Stores state or props in a ref to compare against new props or state
+ */
+export function usePrevious(value) {
+  const ref = useRef(value)
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref.current
+}


### PR DESCRIPTION
- We were seeing issues where new props were not correctly being rendered. This PR updates the Modal to always pass new body content as props unless the `refreshModalContentKey ` updates.
- This PR also removes an issue where the Modal fade in animation was firing twice due to the `refreshModalContent` `useEffect` call firing on render. This removes that function and only calls the fade when `refreshModalContentKey` updates.

## Props update after initial render

![2019-07-31 12 15 59](https://user-images.githubusercontent.com/21182806/62229175-20966a80-b38d-11e9-97db-fab0e9cf7fc0.gif)

## Modal properly fades out/in when key changes

![2019-07-31 12 14 38](https://user-images.githubusercontent.com/21182806/62229099-f6dd4380-b38c-11e9-8bfe-be1d6c41114c.gif)

## Opening modal

![2019-07-31 12 16 48](https://user-images.githubusercontent.com/21182806/62229239-402d9300-b38d-11e9-8af7-a76d4c86ae49.gif)
