### PR TITLE
Add tests for SVG chart animations

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -93,6 +93,7 @@
     "jest": "23.6.0",
     "jest-styled-components": "7.0.0-2",
     "lint-staged": "8.1.5",
+    "mock-raf": "^1.0.1",
     "prettier": "1.17.0",
     "react": "16.8.4",
     "react-dom": "16.8.4",

--- a/packages/palette/src/elements/BarChart/BarChart.story.tsx
+++ b/packages/palette/src/elements/BarChart/BarChart.story.tsx
@@ -5,315 +5,342 @@ import { Serif } from "../Typography"
 import { BarChart } from "./BarChart"
 
 storiesOf("Components/BarChart", module)
-  .add("BarChart with labels", () => {
-    return (
-      <Box width="50%">
-        <BarChart
-          bars={[
-            {
-              value: 2000,
-              label: { title: "Sept 30", description: "423 clicks" },
-              onClick: () => {
-                window.open("https://calmingmanatee.com/")
+  .add(
+    "BarChart with labels",
+    () => {
+      return (
+        <Box width="50%">
+          <BarChart
+            bars={[
+              {
+                value: 2000,
+                label: { title: "Sept 30", description: "423 clicks" },
+                onClick: () => {
+                  window.open("https://calmingmanatee.com/")
+                },
               },
-            },
-            {
-              value: 1400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 3200,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 4000,
-              highlightLabel: { title: "$30,000", description: "This artwork" },
-            },
-            {
-              value: 400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 800,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 100,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 3000,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-          ]}
-          minLabel="$500"
-          maxLabel="$50,000+"
-        />
-      </Box>
-    )
-  })
-
-  .add("Height label constrained to left", () => {
-    return (
-      <Box width="50%">
-        <BarChart
-          bars={[
-            {
-              value: 2000,
-              highlightLabel: {
-                title: "$30,000–$80,000",
-                description: "This artwork",
+              {
+                value: 1400,
+                label: { title: "Sept 30", description: "423 clicks" },
               },
-            },
-            {
-              value: 1400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 3200,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 4000,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 800,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 100,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 3000,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-          ]}
-          minLabel="$500"
-          maxLabel="$50,000+"
-        />
-      </Box>
-    )
-  })
-
-  .add("Height label constrained to right", () => {
-    return (
-      <Box width="50%">
-        <BarChart
-          bars={[
-            {
-              value: 2000,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 1400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 3200,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 4000,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 400,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 800,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 100,
-              label: { title: "Sept 30", description: "423 clicks" },
-            },
-            {
-              value: 3000,
-              highlightLabel: {
-                title: "$30,000–$80,000",
-                description: "This artwork",
+              {
+                value: 400,
+                label: { title: "Sept 30", description: "423 clicks" },
               },
-            },
-          ]}
-          minLabel="$500"
-          maxLabel="$50,000+"
-        />
-      </Box>
-    )
-  })
-
-  .add("With x-axis labels", () => {
-    return (
-      <Box width="50%">
-        <BarChart
-          bars={[
-            {
-              value: 2000,
-              label: { title: "Sep 30", description: "423 clicks" },
-              axisLabelX: "Sep 30",
-            },
-            {
-              value: 1400,
-              label: { title: "Nov 30", description: "423 clicks" },
-            },
-            {
-              value: 400,
-              label: { title: "Dec 30", description: "423 clicks" },
-              axisLabelX: <Serif size="2">DECEMBER 30</Serif>,
-            },
-            {
-              value: 3200,
-              label: { title: "Jan 30", description: "423 clicks" },
-            },
-            {
-              value: 4000,
-              label: { title: "Feb 30", description: "423 clicks" },
-              axisLabelX: "February 20 - June 20",
-              highlightLabel: {
-                title: "$30,000–$80,000",
-                description: "This artwork",
+              {
+                value: 3200,
+                label: { title: "Sept 30", description: "423 clicks" },
               },
-            },
-            {
-              value: 400,
-              label: { title: "Mar 30", description: "423 clicks" },
-            },
-            {
-              value: 800,
-              label: { title: "Apr 30", description: "423 clicks" },
-              axisLabelX: <Serif size="2">APRIL</Serif>,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 100,
-              label: { title: "Jul 30", description: "423 clicks" },
-              axisLabelX: "Jul 30",
-            },
-          ]}
-          minLabel={null}
-          maxLabel={null}
-        />
-      </Box>
-    )
-  })
-
-  .add("Zero state with highlight and x axis label", () => {
-    return (
-      <Box width="50%">
-        <BarChart
-          bars={[
-            {
-              value: 0,
-              axisLabelX: "Sep 30",
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-              label: { title: "Dec 30", description: "0 clicks" },
-            },
-            {
-              value: 0,
-              label: { title: "Jan 30", description: "0 clicks" },
-            },
-            {
-              value: 0,
-              label: { title: "Feb 30", description: "0 clicks" },
-              axisLabelX: "February 20 - June 20",
-              highlightLabel: {
-                title: "0",
-                description: "No clicks",
+              {
+                value: 4000,
+                highlightLabel: {
+                  title: "$30,000",
+                  description: "This artwork",
+                },
               },
-            },
-            {
-              value: 0,
-              label: { title: "Mar 30", description: "0 clicks" },
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-              axisLabelX: "Jul 30",
-            },
-          ]}
-          minLabel={null}
-          maxLabel={null}
-        />
-      </Box>
-    )
-  })
+              {
+                value: 400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 800,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 100,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 3000,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+            ]}
+            minLabel="$500"
+            maxLabel="$50,000+"
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 500 } }
+  )
 
-  .add("Zero state no labels", () => {
-    return (
-      <Box width="50%">
-        <BarChart
-          bars={[
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-            {
-              value: 0,
-            },
-          ]}
-          minLabel="Sep 30"
-          maxLabel="Jul 30"
-        />
-      </Box>
-    )
-  })
+  .add(
+    "Height label constrained to left",
+    () => {
+      return (
+        <Box width="50%">
+          <BarChart
+            bars={[
+              {
+                value: 2000,
+                highlightLabel: {
+                  title: "$30,000–$80,000",
+                  description: "This artwork",
+                },
+              },
+              {
+                value: 1400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 3200,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 4000,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 800,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 100,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 3000,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+            ]}
+            minLabel="$500"
+            maxLabel="$50,000+"
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 500 } }
+  )
+
+  .add(
+    "Height label constrained to right",
+    () => {
+      return (
+        <Box width="50%">
+          <BarChart
+            bars={[
+              {
+                value: 2000,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 1400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 3200,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 4000,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 400,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 800,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 100,
+                label: { title: "Sept 30", description: "423 clicks" },
+              },
+              {
+                value: 3000,
+                highlightLabel: {
+                  title: "$30,000–$80,000",
+                  description: "This artwork",
+                },
+              },
+            ]}
+            minLabel="$500"
+            maxLabel="$50,000+"
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 500 } }
+  )
+
+  .add(
+    "With x-axis labels",
+    () => {
+      return (
+        <Box width="50%">
+          <BarChart
+            bars={[
+              {
+                value: 2000,
+                label: { title: "Sep 30", description: "423 clicks" },
+                axisLabelX: "Sep 30",
+              },
+              {
+                value: 1400,
+                label: { title: "Nov 30", description: "423 clicks" },
+              },
+              {
+                value: 400,
+                label: { title: "Dec 30", description: "423 clicks" },
+                axisLabelX: <Serif size="2">DECEMBER 30</Serif>,
+              },
+              {
+                value: 3200,
+                label: { title: "Jan 30", description: "423 clicks" },
+              },
+              {
+                value: 4000,
+                label: { title: "Feb 30", description: "423 clicks" },
+                axisLabelX: "February 20 - June 20",
+                highlightLabel: {
+                  title: "$30,000–$80,000",
+                  description: "This artwork",
+                },
+              },
+              {
+                value: 400,
+                label: { title: "Mar 30", description: "423 clicks" },
+              },
+              {
+                value: 800,
+                label: { title: "Apr 30", description: "423 clicks" },
+                axisLabelX: <Serif size="2">APRIL</Serif>,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 100,
+                label: { title: "Jul 30", description: "423 clicks" },
+                axisLabelX: "Jul 30",
+              },
+            ]}
+            minLabel={null}
+            maxLabel={null}
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 500 } }
+  )
+
+  .add(
+    "Zero state with highlight and x axis label",
+    () => {
+      return (
+        <Box width="50%">
+          <BarChart
+            bars={[
+              {
+                value: 0,
+                axisLabelX: "Sep 30",
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+                label: { title: "Dec 30", description: "0 clicks" },
+              },
+              {
+                value: 0,
+                label: { title: "Jan 30", description: "0 clicks" },
+              },
+              {
+                value: 0,
+                label: { title: "Feb 30", description: "0 clicks" },
+                axisLabelX: "February 20 - June 20",
+                highlightLabel: {
+                  title: "0",
+                  description: "No clicks",
+                },
+              },
+              {
+                value: 0,
+                label: { title: "Mar 30", description: "0 clicks" },
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+                axisLabelX: "Jul 30",
+              },
+            ]}
+            minLabel={null}
+            maxLabel={null}
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 500 } }
+  )
+
+  .add(
+    "Zero state no labels",
+    () => {
+      return (
+        <Box width="50%">
+          <BarChart
+            bars={[
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+              {
+                value: 0,
+              },
+            ]}
+            minLabel="Sep 30"
+            maxLabel="Jul 30"
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 500 } }
+  )

--- a/packages/palette/src/elements/DonutChart/DonutChart.story.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.story.tsx
@@ -5,52 +5,56 @@ import { Box } from "../Box"
 import { Serif } from "../Typography"
 import { DonutChart } from "./DonutChart"
 
-storiesOf("Components/DonutChart", module).add("DonutChart with labels", () => {
-  return (
-    <Box width="50%">
-      <DonutChart
-        points={[
-          {
-            value: 423,
-            axisLabelX: "Sep 10",
-            tooltip: { title: "Sep 10", description: "423 clicks" },
-          },
-          {
-            value: 567,
-            tooltip: (
-              <Serif size="3" p={0.5}>
-                yay!
-              </Serif>
-            ),
-          },
-          {
-            value: 300,
-            axisLabelX: "Sep 12",
-            tooltip: { title: "Sep 12", description: "300 clicks" },
-          },
-          {
-            value: 200,
-            tooltip: { title: "Sep 13", description: "200 clicks" },
-          },
-          {
-            value: 501,
-            axisLabelX: "Sep 14",
-            tooltip: { title: "Sep 14", description: "501 clicks" },
-          },
-          {
-            value: 400,
-            tooltip: { title: "Sep 15", description: "400 clicks" },
-          },
-          {
-            value: 800,
-            axisLabelX: "Sep 16",
-            tooltip: { title: "Sep 16", description: "800 clicks" },
-          },
-        ]}
-      />
-    </Box>
-  )
-})
+storiesOf("Components/DonutChart", module).add(
+  "DonutChart with labels",
+  () => {
+    return (
+      <Box width="50%">
+        <DonutChart
+          points={[
+            {
+              value: 423,
+              axisLabelX: "Sep 10",
+              tooltip: { title: "Sep 10", description: "423 clicks" },
+            },
+            {
+              value: 567,
+              tooltip: (
+                <Serif size="3" p={0.5}>
+                  yay!
+                </Serif>
+              ),
+            },
+            {
+              value: 300,
+              axisLabelX: "Sep 12",
+              tooltip: { title: "Sep 12", description: "300 clicks" },
+            },
+            {
+              value: 200,
+              tooltip: { title: "Sep 13", description: "200 clicks" },
+            },
+            {
+              value: 501,
+              axisLabelX: "Sep 14",
+              tooltip: { title: "Sep 14", description: "501 clicks" },
+            },
+            {
+              value: 400,
+              tooltip: { title: "Sep 15", description: "400 clicks" },
+            },
+            {
+              value: 800,
+              axisLabelX: "Sep 16",
+              tooltip: { title: "Sep 16", description: "800 clicks" },
+            },
+          ]}
+        />
+      </Box>
+    )
+  },
+  { chromatic: { delay: 500 } }
+)
 
 storiesOf("Components/DonutChart", module).add(
   "DonutChart with custom margin",
@@ -103,7 +107,8 @@ storiesOf("Components/DonutChart", module).add(
         />
       </Box>
     )
-  }
+  },
+  { chromatic: { delay: 500 } }
 )
 
 storiesOf("Components/DonutChart", module).add(
@@ -157,7 +162,8 @@ storiesOf("Components/DonutChart", module).add(
         />
       </Box>
     )
-  }
+  },
+  { chromatic: { delay: 500 } }
 )
 
 storiesOf("Components/DonutChart", module).add(
@@ -204,7 +210,8 @@ storiesOf("Components/DonutChart", module).add(
         />
       </Box>
     )
-  }
+  },
+  { chromatic: { delay: 500 } }
 )
 
 storiesOf("Components/DonutChart", module).add(
@@ -257,7 +264,8 @@ storiesOf("Components/DonutChart", module).add(
         </GrowingBox>
       </>
     )
-  }
+  },
+  { chromatic: { delay: 500 } }
 )
 
 const GrowingBox = styled(Box)`

--- a/packages/palette/src/elements/DonutChart/DonutChart.story.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.story.tsx
@@ -215,6 +215,54 @@ storiesOf("Components/DonutChart", module).add(
 )
 
 storiesOf("Components/DonutChart", module).add(
+  "Chart minimum width",
+  () => {
+    return (
+      <Box width="1px" p={2}>
+        <DonutChart
+          margin={0}
+          points={[
+            {
+              value: 423,
+              tooltip: { title: "Sep 10", description: "423 clicks" },
+            },
+            {
+              value: 567,
+              tooltip: (
+                <Serif size="3" p={0.5}>
+                  yay!
+                </Serif>
+              ),
+            },
+            {
+              value: 300,
+              tooltip: { title: "Sep 12", description: "300 clicks" },
+            },
+            {
+              value: 200,
+              tooltip: { title: "Sep 13", description: "200 clicks" },
+            },
+            {
+              value: 501,
+              tooltip: { title: "Sep 14", description: "501 clicks" },
+            },
+            {
+              value: 400,
+              tooltip: { title: "Sep 15", description: "400 clicks" },
+            },
+            {
+              value: 800,
+              tooltip: { title: "Sep 16", description: "800 clicks" },
+            },
+          ]}
+        />
+      </Box>
+    )
+  },
+  { chromatic: { delay: 500 } }
+)
+
+storiesOf("Components/DonutChart", module).add(
   "DonutChart resizes when container size changes",
   () => {
     return (

--- a/packages/palette/src/elements/DonutChart/DonutChart.test.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme"
 import "jest-styled-components"
+import createMockRaf from "mock-raf"
 import React from "react"
 import { Theme } from "../../Theme"
 import { useWrapperWidth } from "../DataVis/utils/useWrapperWidth"
@@ -9,12 +10,15 @@ import { DonutChart, DonutChartProps } from "./DonutChart"
 
 jest.useFakeTimers()
 
+const mockRaf = createMockRaf()
+const globalAny: any = global
+globalAny.requestAnimationFrame = mockRaf.raf
 
 jest.mock("../DataVis/utils/useWrapperWidth")
 ;(useWrapperWidth as jest.Mock).mockImplementation(() => 400)
 
 const mockPoints = [
-  { value: 0, axisLabelX: "x axis label" },
+  { value: 40, axisLabelX: "x axis label" },
   { value: 100, axisLabelX: <div id="x-axis">lol</div> },
   {
     value: 200,
@@ -55,11 +59,21 @@ describe("DonutChart", () => {
   it("shows hover labels when you hover over the bar", () => {
     const chart = getWrapper()
     const hoverArea = chart.find("path").last()
-    // .find("div")
-    // .first()
     hoverArea.simulate("mouseenter")
     expect(chart.text()).toContain("423 views")
     hoverArea.simulate("mouseleave")
     expect(chart.text()).not.toContain("423 views")
+  })
+  it("animates", () => {
+    const chart = getWrapper()
+    let aSlice = chart.find("path").last()
+    const pathBeforeAnimation = aSlice.prop("d")
+
+    mockRaf.step({ count: 3000 })
+    chart.update()
+    aSlice = chart.find("path").last()
+    const pathAfterAnimation = aSlice.prop("d")
+
+    expect(pathBeforeAnimation).not.toEqual(pathAfterAnimation)
   })
 })

--- a/packages/palette/src/elements/DonutChart/DonutChart.test.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.test.tsx
@@ -2,11 +2,16 @@ import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
 import { Theme } from "../../Theme"
+import { useWrapperWidth } from "../DataVis/utils/useWrapperWidth"
 import { Flex } from "../Flex"
 import { Sans } from "../Typography"
 import { DonutChart, DonutChartProps } from "./DonutChart"
 
 jest.useFakeTimers()
+
+
+jest.mock("../DataVis/utils/useWrapperWidth")
+;(useWrapperWidth as jest.Mock).mockImplementation(() => 400)
 
 const mockPoints = [
   { value: 0, axisLabelX: "x axis label" },

--- a/packages/palette/src/elements/DonutChart/DonutChart.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.tsx
@@ -18,6 +18,7 @@ import { useWrapperWidth } from "../DataVis/utils/useWrapperWidth"
 import { Sans } from "../Typography"
 
 const colors: Color[] = ["black10", "black30", "black60"]
+const MIN_CHART_SIZE = 30
 
 export interface DonutChartProps extends ChartProps {
   margin?: number
@@ -38,7 +39,7 @@ export const DonutChart: React.FC<DonutChartProps> = ({
 
   const hasEnteredViewport = useHasEnteredViewport(wrapperRef)
 
-  const width = useWrapperWidth(wrapperRef)
+  const width = Math.max(useWrapperWidth(wrapperRef), MIN_CHART_SIZE)
 
   // width of the arc is %12 of chart width
   const donutWidth = width * 0.12
@@ -155,7 +156,7 @@ export const DonutChart: React.FC<DonutChartProps> = ({
       <Box ref={wrapperRef as any} position="relative">
         <>
           {tooltip}
-          {labels}
+          {width !== MIN_CHART_SIZE && labels}
           {svg}
         </>
       </Box>

--- a/packages/palette/src/elements/LineChart/LineChart.story.tsx
+++ b/packages/palette/src/elements/LineChart/LineChart.story.tsx
@@ -5,133 +5,141 @@ import { Serif } from "../Typography"
 import { LineChart } from "./LineChart"
 
 storiesOf("Components/LineChart", module)
-  .add("LineChart with labels", () => {
-    return (
-      <Box width="50%">
-        <LineChart
-          points={[
-            {
-              value: 423,
-              axisLabelX: "Sep 10",
-              tooltip: { title: "Sep 10", description: "423 clicks" },
-            },
-            {
-              value: 567,
-              tooltip: (
-                <Serif size="3" p={0.5}>
-                  yay!
-                </Serif>
-              ),
-            },
-            {
-              value: 300,
-              axisLabelX: "Sep 12",
-              tooltip: { title: "Sep 12", description: "300 clicks" },
-            },
-            {
-              value: 200,
-              tooltip: { title: "Sep 13", description: "200 clicks" },
-            },
-            {
-              value: 501,
-              axisLabelX: "Sep 14",
-              tooltip: { title: "Sep 14", description: "501 clicks" },
-            },
-            {
-              value: 400,
-              tooltip: { title: "Sep 15", description: "400 clicks" },
-            },
-            {
-              value: 800,
-              axisLabelX: "Sep 16",
-              tooltip: { title: "Sep 16", description: "800 clicks" },
-            },
-            {
-              value: 0,
-              tooltip: { title: "Sep 17", description: "0 clicks" },
-            },
-            {
-              value: 100,
-              axisLabelX: "Sep 18",
-              tooltip: { title: "Sep 18", description: "100 clicks" },
-            },
-            {
-              value: 200,
-              tooltip: { title: "Sep 19", description: "200 clicks" },
-            },
-            {
-              value: 500,
-              axisLabelX: "Sep 20",
-              tooltip: { title: "Sep 20", description: "500 clicks" },
-            },
-          ]}
-        />
-      </Box>
-    )
-  })
+  .add(
+    "LineChart with labels",
+    () => {
+      return (
+        <Box width="50%">
+          <LineChart
+            points={[
+              {
+                value: 423,
+                axisLabelX: "Sep 10",
+                tooltip: { title: "Sep 10", description: "423 clicks" },
+              },
+              {
+                value: 567,
+                tooltip: (
+                  <Serif size="3" p={0.5}>
+                    yay!
+                  </Serif>
+                ),
+              },
+              {
+                value: 300,
+                axisLabelX: "Sep 12",
+                tooltip: { title: "Sep 12", description: "300 clicks" },
+              },
+              {
+                value: 200,
+                tooltip: { title: "Sep 13", description: "200 clicks" },
+              },
+              {
+                value: 501,
+                axisLabelX: "Sep 14",
+                tooltip: { title: "Sep 14", description: "501 clicks" },
+              },
+              {
+                value: 400,
+                tooltip: { title: "Sep 15", description: "400 clicks" },
+              },
+              {
+                value: 800,
+                axisLabelX: "Sep 16",
+                tooltip: { title: "Sep 16", description: "800 clicks" },
+              },
+              {
+                value: 0,
+                tooltip: { title: "Sep 17", description: "0 clicks" },
+              },
+              {
+                value: 100,
+                axisLabelX: "Sep 18",
+                tooltip: { title: "Sep 18", description: "100 clicks" },
+              },
+              {
+                value: 200,
+                tooltip: { title: "Sep 19", description: "200 clicks" },
+              },
+              {
+                value: 500,
+                axisLabelX: "Sep 20",
+                tooltip: { title: "Sep 20", description: "500 clicks" },
+              },
+            ]}
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 1000 } }
+  )
 
-  .add("LineChart with custom height", () => {
-    return (
-      <Box width="50%">
-        <LineChart
-          height={250}
-          points={[
-            {
-              value: 423,
-              axisLabelX: "Sep 10",
-              tooltip: { title: "Sep 10", description: "423 clicks" },
-            },
-            {
-              value: 567,
-              tooltip: (
-                <Serif size="3" p={0.5}>
-                  yay!
-                </Serif>
-              ),
-            },
-            {
-              value: 300,
-              axisLabelX: "Sep 12",
-              tooltip: { title: "Sep 12", description: "300 clicks" },
-            },
-            {
-              value: 200,
-              tooltip: { title: "Sep 13", description: "200 clicks" },
-            },
-            {
-              value: 501,
-              axisLabelX: "Sep 14",
-              tooltip: { title: "Sep 14", description: "501 clicks" },
-            },
-            {
-              value: 400,
-              tooltip: { title: "Sep 15", description: "400 clicks" },
-            },
-            {
-              value: 800,
-              axisLabelX: "Sep 16",
-              tooltip: { title: "Sep 16", description: "800 clicks" },
-            },
-            {
-              value: 0,
-              tooltip: { title: "Sep 17", description: "0 clicks" },
-            },
-            {
-              value: 100,
-              axisLabelX: "Sep 18",
-              tooltip: { title: "Sep 18", description: "100 clicks" },
-            },
-            {
-              value: 200,
-              tooltip: { title: "Sep 19", description: "200 clicks" },
-            },
-            {
-              value: 500,
-              axisLabelX: "Sep 20",
-              tooltip: { title: "Sep 20", description: "500 clicks" },
-            },
-          ]}
-        />
-      </Box>
-    )
-  })
+  .add(
+    "LineChart with custom height",
+    () => {
+      return (
+        <Box width="50%">
+          <LineChart
+            height={250}
+            points={[
+              {
+                value: 423,
+                axisLabelX: "Sep 10",
+                tooltip: { title: "Sep 10", description: "423 clicks" },
+              },
+              {
+                value: 567,
+                tooltip: (
+                  <Serif size="3" p={0.5}>
+                    yay!
+                  </Serif>
+                ),
+              },
+              {
+                value: 300,
+                axisLabelX: "Sep 12",
+                tooltip: { title: "Sep 12", description: "300 clicks" },
+              },
+              {
+                value: 200,
+                tooltip: { title: "Sep 13", description: "200 clicks" },
+              },
+              {
+                value: 501,
+                axisLabelX: "Sep 14",
+                tooltip: { title: "Sep 14", description: "501 clicks" },
+              },
+              {
+                value: 400,
+                tooltip: { title: "Sep 15", description: "400 clicks" },
+              },
+              {
+                value: 800,
+                axisLabelX: "Sep 16",
+                tooltip: { title: "Sep 16", description: "800 clicks" },
+              },
+              {
+                value: 0,
+                tooltip: { title: "Sep 17", description: "0 clicks" },
+              },
+              {
+                value: 100,
+                axisLabelX: "Sep 18",
+                tooltip: { title: "Sep 18", description: "100 clicks" },
+              },
+              {
+                value: 200,
+                tooltip: { title: "Sep 19", description: "200 clicks" },
+              },
+              {
+                value: 500,
+                axisLabelX: "Sep 20",
+                tooltip: { title: "Sep 20", description: "500 clicks" },
+              },
+            ]}
+          />
+        </Box>
+      )
+    },
+    { chromatic: { delay: 1000 } }
+  )

--- a/packages/palette/src/elements/LineChart/LineChartSVG.tsx
+++ b/packages/palette/src/elements/LineChart/LineChartSVG.tsx
@@ -45,7 +45,6 @@ export const LineChartSVG: React.FC<LineChartSVGProps> = ({
   const line = d3Line()
     .x(displayXPosition)
     .y(displayYPosition)
-
   return (
     <Svg width={width} height={height}>
       <g transform={`translate(0, ${margin})`}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15190,6 +15190,13 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+mock-raf@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mock-raf/-/mock-raf-1.0.1.tgz#7567d23fa1220439853317a8ff0eaad1588e9535"
+  integrity sha512-+25y56bblLzEnv+G4ODsHNck07A5uP5HFfu/1VBKeFrUXoFT9oru+R+jLxLz6rwdM5drUHFdqX9LYBsMP4dz/w==
+  dependencies:
+    object-assign "^3.0.0"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"


### PR DESCRIPTION
It turned out that the SVG chart animations (currently donut and line charts) are sensitive to the version of `react-spring` it is using. This hopefully catches that.

- Why not chromatic? The chart may render correctly without animation and chromatic wouldn't catch that
- Why `mock-raf` dependency? It is a small dev dependency but definitely can make our own, though it will be _very_ similar. 