### PR TITLE
Fixes entityheader subtext size

### DIFF
--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -38,24 +38,17 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
           <Avatar size="xs" src={imageUrl} initials={initials} />
         </Flex>
       )}
-      <Flex ml="2px" justifyContent="center" width={0} flexGrow={1}>
+      <Flex justifyContent="center" width={0} flexGrow={1}>
         <Serif
           ellipsizeMode="tail"
           numberOfLines={1}
-          mb="-2"
           size="3t"
           color="black100"
         >
           {name}
         </Serif>
         {!!meta && (
-          <Sans
-            ellipsizeMode="tail"
-            numberOfLines={1}
-            mt="-2"
-            size="3t"
-            color="black60"
-          >
+          <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60">
             {meta}
           </Sans>
         )}


### PR DESCRIPTION
- Subtext in `EntityHeader` should be size `2`

## After change

<img width="438" alt="Screen Shot 2019-08-02 at 1 00 11 PM" src="https://user-images.githubusercontent.com/21182806/62386415-c5e44680-b525-11e9-9463-0deb5dd2fe40.png">
