### PR TITLE
Adds fontsize props to TimeRemaining

### DIFF
--- a/packages/palette-docs/content/docs/components/TimeRemaining.mdx
+++ b/packages/palette-docs/content/docs/components/TimeRemaining.mdx
@@ -2,6 +2,10 @@
 name: TimeRemaining
 ---
 
+- TimeRemaining will countdown if `currentTime` isn't directly passed to the
+  component. Try it yourself by removing the prop and setting `countDownEnd` to
+  the near future.
+
 <Playground>
   <TimeRemaining
     currentTime="2019-01-02T20:15:00.000-04:00"
@@ -15,5 +19,9 @@ name: TimeRemaining
     currentTime="2019-01-02T20:15:00.000-04:00"
     countdownEnd="2019-01-03T20:15:00.000-04:00"
     highlight="purple100"
+    labelWithoutTimeRemaining="Custom label without time remaining"
+    labelWithTimeRemaining="Custom label with time remaining"
+    timerFontSize="4"
+    labelFontSize="2"
   />
 </Playground>

--- a/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
+++ b/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
@@ -12,24 +12,24 @@ function padWithZero(num: number) {
 /** TimeRemaining */
 export const TimeRemaining: React.SFC<{
   countdownEnd: string
-  labelWithTimeRemaining?: string
-  labelWithoutTimeRemaining?: string
-  timeEndedDisplayText?: string
-  trailingText?: string
   currentTime?: string | DateTime
-  timerFontSize?: SansSize
-  labelFontSize?: SansSize
   highlight: Parameters<typeof color>[0]
+  labelFontSize?: SansSize
+  labelWithoutTimeRemaining?: string
+  labelWithTimeRemaining?: string
+  timeEndedDisplayText?: string
+  timerFontSize?: SansSize
+  trailingText?: string
 }> = ({
   countdownEnd,
-  highlight = "purple100",
-  labelWithTimeRemaining,
-  labelWithoutTimeRemaining,
-  timeEndedDisplayText,
-  trailingText,
-  timerFontSize,
-  labelFontSize,
   currentTime,
+  highlight = "purple100",
+  labelFontSize = "3",
+  labelWithoutTimeRemaining,
+  labelWithTimeRemaining,
+  timeEndedDisplayText,
+  timerFontSize = "3",
+  trailingText,
 }) => {
   const duration = Duration.fromISO(
     DateTime.fromISO(countdownEnd)
@@ -52,11 +52,7 @@ export const TimeRemaining: React.SFC<{
 
   return (
     <Flex flexDirection="column" alignItems="center">
-      <Sans
-        size={timerFontSize ? timerFontSize : "3"}
-        color={highlight}
-        weight="medium"
-      >
+      <Sans size={timerFontSize} color={highlight} weight="medium">
         {hasEnded && timeEndedDisplayText ? (
           timeEndedDisplayText
         ) : (
@@ -70,7 +66,7 @@ export const TimeRemaining: React.SFC<{
         )}
       </Sans>
       {(labelWithTimeRemaining || labelWithoutTimeRemaining) && (
-        <Sans size={labelFontSize ? labelFontSize : "3"} weight="medium">
+        <Sans size={labelFontSize} weight="medium">
           {hasEnded ? labelWithoutTimeRemaining : labelWithTimeRemaining}
         </Sans>
       )}

--- a/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
+++ b/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
@@ -2,6 +2,7 @@ import { DateTime, Duration } from "luxon"
 import React from "react"
 import { Flex, Sans } from "../"
 import { color } from "../../helpers"
+import { SansSize } from "../../Theme"
 import { useCurrentTime } from "../../utils/useCurrentTime"
 
 function padWithZero(num: number) {
@@ -16,6 +17,8 @@ export const TimeRemaining: React.SFC<{
   timeEndedDisplayText?: string
   trailingText?: string
   currentTime?: string | DateTime
+  timerFontSize?: SansSize
+  labelFontSize?: SansSize
   highlight: Parameters<typeof color>[0]
 }> = ({
   countdownEnd,
@@ -24,6 +27,8 @@ export const TimeRemaining: React.SFC<{
   labelWithoutTimeRemaining,
   timeEndedDisplayText,
   trailingText,
+  timerFontSize,
+  labelFontSize,
   currentTime,
 }) => {
   const duration = Duration.fromISO(
@@ -47,7 +52,11 @@ export const TimeRemaining: React.SFC<{
 
   return (
     <Flex flexDirection="column" alignItems="center">
-      <Sans size="3" color={highlight} weight="medium">
+      <Sans
+        size={timerFontSize ? timerFontSize : "3"}
+        color={highlight}
+        weight="medium"
+      >
         {hasEnded && timeEndedDisplayText ? (
           timeEndedDisplayText
         ) : (
@@ -61,7 +70,7 @@ export const TimeRemaining: React.SFC<{
         )}
       </Sans>
       {(labelWithTimeRemaining || labelWithoutTimeRemaining) && (
-        <Sans size="3" weight="medium">
+        <Sans size={labelFontSize ? labelFontSize : "3"} weight="medium">
           {hasEnded ? labelWithoutTimeRemaining : labelWithTimeRemaining}
         </Sans>
       )}


### PR DESCRIPTION
- Adds custom font sizes to `TimeRemaining` API for new iOS artwork page. The default font sizes do not match the iOS spec, and after speaking with design the best solution is to pass optional custom font sizes.