### PR TITLE
WIP: Add placeholder api to Select

### DIFF
--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -71,3 +71,20 @@ storiesOf("Components/Select", module)
       />
     )
   })
+  .add("SelectSmall with placeholder", () => {
+    return (
+      <SelectSmall
+        placeholder="You must choose small-ly"
+        options={[
+          {
+            text: "First",
+            value: "firstValue",
+          },
+          {
+            text: "Last",
+            value: "lastValue",
+          },
+        ]}
+      />
+    )
+  })

--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -20,6 +20,23 @@ storiesOf("Components/Select", module)
       />
     )
   })
+  .add("LargeSelect with placeholder", () => {
+    return (
+      <LargeSelect
+        placeholder="You must choose wisely"
+        options={[
+          {
+            text: "First",
+            value: "firstValue",
+          },
+          {
+            text: "Last",
+            value: "lastValue",
+          },
+        ]}
+      />
+    )
+  })
   .add("SelectSmall with title", () => {
     return (
       <SelectSmall

--- a/packages/palette/src/elements/Select/Select.test.tsx
+++ b/packages/palette/src/elements/Select/Select.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme"
 import React from "react"
 import { SelectSmall } from "../Select"
+import { LargeSelect } from "./Select"
 
 describe("Select", () => {
   describe("SelectSmall", () => {
@@ -25,11 +26,12 @@ describe("Select", () => {
 
     it("renders with a placeholder value", () => {
       const wrapper = mount(
-        <SelectSmall options={options} selected="secondOption" />
+        <LargeSelect options={options} placeholder="I'm a placeholder" />
       )
-
-      expect(wrapper.find("option").length).toBe(2)
-      expect(wrapper.find("select").props().value).toBe("secondOption")
+      expect(wrapper.find("select").text()).toMatch(
+        new RegExp("^I'm a placeholder")
+      )
+      expect(wrapper.find("option").length).toBe(3)
     })
 
     it("triggers callback on change", () => {

--- a/packages/palette/src/elements/Select/Select.test.tsx
+++ b/packages/palette/src/elements/Select/Select.test.tsx
@@ -23,6 +23,15 @@ describe("Select", () => {
       expect(wrapper.find("select").props().value).toBe("secondOption")
     })
 
+    it("renders with a placeholder value", () => {
+      const wrapper = mount(
+        <SelectSmall options={options} selected="secondOption" />
+      )
+
+      expect(wrapper.find("option").length).toBe(2)
+      expect(wrapper.find("select").props().value).toBe("secondOption")
+    })
+
     it("triggers callback on change", () => {
       const spy = jest.fn()
       const wrapper = mount(<SelectSmall options={options} onSelect={spy} />)

--- a/packages/palette/src/elements/Select/Select.test.tsx
+++ b/packages/palette/src/elements/Select/Select.test.tsx
@@ -4,17 +4,28 @@ import { SelectSmall } from "../Select"
 import { LargeSelect } from "./Select"
 
 describe("Select", () => {
+  const options = [
+    {
+      text: "First option",
+      value: "firstOption",
+    },
+    {
+      text: "Second option that is really long",
+      value: "secondOption",
+    },
+  ]
+  describe("LargeSelect", () => {
+    it("renders with a placeholder value", () => {
+      const wrapper = mount(
+        <LargeSelect options={options} placeholder="I'm a placeholder" />
+      )
+      expect(wrapper.find("select").text()).toMatch(
+        new RegExp("^I'm a placeholder")
+      )
+      expect(wrapper.find("option").length).toBe(3)
+    })
+  })
   describe("SelectSmall", () => {
-    const options = [
-      {
-        text: "First option",
-        value: "firstOption",
-      },
-      {
-        text: "Second option that is really long",
-        value: "secondOption",
-      },
-    ]
     it("renders proper options with correct selected one", () => {
       const wrapper = mount(
         <SelectSmall options={options} selected="secondOption" />
@@ -26,7 +37,7 @@ describe("Select", () => {
 
     it("renders with a placeholder value", () => {
       const wrapper = mount(
-        <LargeSelect options={options} placeholder="I'm a placeholder" />
+        <SelectSmall options={options} placeholder="I'm a placeholder" />
       )
       expect(wrapper.find("select").text()).toMatch(
         new RegExp("^I'm a placeholder")

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -36,7 +36,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
         onChange={event => props.onSelect && props.onSelect(event.target.value)}
       >
         {placeholderActive(props) && (
-          <option value="" disabled selected>
+          <option selected value="" disabled>
             {props.placeholder}
           </option>
         )}
@@ -70,7 +70,7 @@ export const SelectSmall: SFC<SelectProps> = props => {
           }
         >
           {placeholderActive(props) && (
-            <option value="" disabled selected>
+            <option selected value="" disabled>
               {props.placeholder}
             </option>
           )}

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -35,7 +35,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
         disabled={props.disabled}
         onChange={event => props.onSelect && props.onSelect(event.target.value)}
       >
-        {Boolean(props.placeholder) && !Boolean(props.selected) && (
+        {placeholderActive(props) && (
           <option value="" disabled selected>
             {props.placeholder}
           </option>
@@ -69,6 +69,11 @@ export const SelectSmall: SFC<SelectProps> = props => {
             props.onSelect && props.onSelect(event.target.value)
           }
         >
+          {placeholderActive(props) && (
+            <option value="" disabled selected>
+              {props.placeholder}
+            </option>
+          )}
           {props.options.map(({ value, text }) => (
             <option value={value} key={value}>
               {text}
@@ -109,6 +114,9 @@ const caretArrow = css<SelectProps>`
   width: 0;
   height: 0;
 `
+
+const placeholderActive = props =>
+  Boolean(props.placeholder) && !Boolean(props.selected)
 
 const LargeSelectContainer = styled.div<SelectProps>`
   position: relative;

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -21,6 +21,7 @@ export interface SelectProps extends PositionProps, SpaceProps {
   error?: string
   title?: string
   onSelect?: (value) => void
+  placeholder?: string
 }
 
 /**
@@ -34,6 +35,11 @@ export const LargeSelect: SFC<SelectProps> = props => {
         disabled={props.disabled}
         onChange={event => props.onSelect && props.onSelect(event.target.value)}
       >
+        {Boolean(props.placeholder) && !Boolean(props.selected) && (
+          <option value="" disabled selected>
+            {props.placeholder}
+          </option>
+        )}
         {props.options.map(({ value, text }) => (
           <option value={value} key={value}>
             {text}


### PR DESCRIPTION
This pr implements select placeholder values based on the suggestion of @ds300 [here](https://github.com/artsy/reaction/pull/2708#issuecomment-522952081).

TODOS:
- [ ] Resolve a `Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.` I tried to do this but was unable to make it work without getting new warnings about controlled v uncontrolled components or breaking the input altogether.
- [ ] A few more tests. 


![2019-08-20 13 24 53](https://user-images.githubusercontent.com/9088720/63369440-f1509900-c34d-11e9-80de-ca919cde7b90.gif)


_Edit about this bit: The `color` property needs to be set on the `select` element, not the option, and then it works- but it does not change when a different option is selected. Need to investigate further._
I tried to make the placeholder text a lighter shade of gray by adding this style to the select container. It showed correctly in the devtools but the text color did not apply.
```
  option:disabled {
    color: ${color("purple100")};
  }
```
![image](https://user-images.githubusercontent.com/9088720/63369603-442a5080-c34e-11e9-9059-9d79d562ab0a.png)
