### PR TITLE
Add Modal component examples to Storybook

### DIFF
--- a/packages/palette/.storybook/config.js
+++ b/packages/palette/.storybook/config.js
@@ -2,6 +2,8 @@ import React from "react"
 import { configure, addDecorator, addParameters } from "@storybook/react"
 import { create } from "@storybook/theming"
 import { Theme } from "../src/Theme"
+import { injectGlobalStyles } from "../src/helpers/injectGlobalStyles"
+
 import "storybook-chromatic"
 
 // automatically import all files ending in *.story.tsx.
@@ -27,6 +29,15 @@ addParameters({
   },
 })
 
-addDecorator(storyFn => <Theme>{storyFn()}</Theme>)
+const { GlobalStyles } = injectGlobalStyles()
+
+addDecorator(storyFn => (
+  <Theme>
+    <>
+      <GlobalStyles />
+      {storyFn()}
+    </>
+  </Theme>
+))
 
 configure(loadStories, module)

--- a/packages/palette/src/elements/Modal/Modal.story.tsx
+++ b/packages/palette/src/elements/Modal/Modal.story.tsx
@@ -1,0 +1,46 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Button } from "../Button"
+import { Modal } from "./Modal"
+
+storiesOf("Components/Modal", module)
+  .add("Default", () => {
+    return (
+      <Modal show onClose={() => null}>
+        Some example content
+      </Modal>
+    )
+  })
+  .add("With title", () => {
+    return (
+      <Modal show title="Modal Title" onClose={() => null}>
+        Some example content
+      </Modal>
+    )
+  })
+  .add("With logo", () => {
+    return (
+      <Modal show title="Modal Title" hasLogo onClose={() => null}>
+        Some example content
+      </Modal>
+    )
+  })
+  .add("Modal with fixed button", () => {
+    return (
+      <Modal
+        show
+        title="Modal Title"
+        onClose={() => null}
+        FixedButton={<Button width="100%">Click me</Button>}
+      >
+        Some example content
+      </Modal>
+    )
+  })
+  .add("Wide modal", () => {
+    return (
+      <Modal show title="Modal Title" isWide onClose={() => null}>
+        Some example content
+      </Modal>
+    )
+  })


### PR DESCRIPTION
This PR ports the Palette documentation examples over to Storybook for visual regression testing.

![screenshot 1566399731](https://user-images.githubusercontent.com/123595/63443639-2539c600-c403-11e9-8317-f3dcbcdf8398.png)
