### PR TITLE
PURCHASE-1473 - Adds hideCloseXButton prop and allow for closing from wrapper

### DIFF
--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -126,7 +126,6 @@ export const Modal: SFC<ModalProps> = ({
     // If modal X icon is hidden we don't want to close the modal when the wrapper is clicked
     if (!hideCloseXButton) {
       onClose()
-      return
     }
   }
 

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -93,8 +93,10 @@ export const Modal: SFC<ModalProps> = ({
   useEffect(() => {
     if (show) {
       setRenderModal(true)
-      // Binds key event for escape to close modal
-      document.addEventListener("keyup", handleEscapeKey, true)
+      if (!hideCloseXButton) {
+        // Binds key event for escape to close modal
+        document.addEventListener("keyup", handleEscapeKey, true)
+      }
       // Fixes the body to disable scroll
       document.body.style.overflowY = "hidden"
       setVisibleContent(ModalContent)

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -27,7 +27,7 @@ interface ModalProps {
   /*
    * Hide the X button if we don't want the user to be able to exit the modal without another action closing the modal
    */
-  hideCloseXButton?: boolean
+  hideCloseButton?: boolean
 }
 
 interface TransitionElementProps {
@@ -54,7 +54,7 @@ export const Modal: SFC<ModalProps> = ({
   isWide,
   hasLogo,
   onClose,
-  hideCloseXButton,
+  hideCloseButton,
 }) => {
   const [springContentAnimation, setSpringContentAnimation] = useState({
     opacity: 1,
@@ -93,7 +93,7 @@ export const Modal: SFC<ModalProps> = ({
   useEffect(() => {
     if (show) {
       setRenderModal(true)
-      if (!hideCloseXButton) {
+      if (!hideCloseButton) {
         // Binds key event for escape to close modal
         document.addEventListener("keyup", handleEscapeKey, true)
       }
@@ -126,7 +126,7 @@ export const Modal: SFC<ModalProps> = ({
 
   const handleWrapperClick = () => {
     // If modal X icon is hidden we don't want to close the modal when the wrapper is clicked
-    if (!hideCloseXButton) {
+    if (!hideCloseButton) {
       onClose()
     }
   }
@@ -180,7 +180,7 @@ export const Modal: SFC<ModalProps> = ({
         <ModalOuterWrapper show={show} onClick={() => handleWrapperClick()}>
           <ModalWrapper>
             <ModalElement style={modalAnimation} isWide={isWide} show={show}>
-              {!hideCloseXButton && (
+              {!hideCloseButton && (
                 <CloseIconWrapper onClick={() => onClose()}>
                   <CloseIcon fill="black60" />
                 </CloseIconWrapper>

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -24,6 +24,10 @@ interface ModalProps {
   onClose: () => void
   show?: boolean
   title?: string
+  /*
+   * Hide the X button if we don't want the user to be able to exit the modal without another action closing the modal
+   */
+  hideCloseXButton?: boolean
 }
 
 interface TransitionElementProps {
@@ -50,6 +54,7 @@ export const Modal: SFC<ModalProps> = ({
   isWide,
   hasLogo,
   onClose,
+  hideCloseXButton,
 }) => {
   const [springContentAnimation, setSpringContentAnimation] = useState({
     opacity: 1,
@@ -117,6 +122,14 @@ export const Modal: SFC<ModalProps> = ({
     }
   }, [show])
 
+  const handleWrapperClick = () => {
+    // If modal X icon is hidden we don't want to close the modal when the wrapper is clicked
+    if (!hideCloseXButton) {
+      onClose()
+      return
+    }
+  }
+
   const fadeInNewContent = () => {
     // Replaces content
     setVisibleContent(ModalContent)
@@ -163,12 +176,14 @@ export const Modal: SFC<ModalProps> = ({
   return (
     <>
       {renderModal && (
-        <ModalOuterWrapper show={show}>
+        <ModalOuterWrapper show={show} onClick={() => handleWrapperClick()}>
           <ModalWrapper>
             <ModalElement style={modalAnimation} isWide={isWide} show={show}>
-              <CloseIconWrapper onClick={() => onClose()}>
-                <CloseIcon fill="black60" />
-              </CloseIconWrapper>
+              {!hideCloseXButton && (
+                <CloseIconWrapper onClick={() => onClose()}>
+                  <CloseIcon fill="black60" />
+                </CloseIconWrapper>
+              )}
               {visibleContent}
             </ModalElement>
           </ModalWrapper>

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -122,6 +122,7 @@ export const Modal: SFC<ModalProps> = ({
         },
       })
     }
+    return document.removeEventListener("keyup", handleEscapeKey, true)
   }, [show])
 
   const handleWrapperClick = () => {

--- a/packages/palette/src/elements/Modal/__tests__/Modal.test.tsx
+++ b/packages/palette/src/elements/Modal/__tests__/Modal.test.tsx
@@ -114,7 +114,9 @@ describe("Modal", () => {
         vestibulum.
       </Modal>
     )
-    document.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }))
-    expect(show).toEqual(false)
+    setTimeout(() => {
+      document.dispatchEvent(new KeyboardEvent("keyup", { key: "Escape" }))
+      expect(show).toEqual(false)
+    })
   })
 })

--- a/packages/palette/src/elements/Modal/__tests__/Modal.test.tsx
+++ b/packages/palette/src/elements/Modal/__tests__/Modal.test.tsx
@@ -44,11 +44,11 @@ describe("Modal", () => {
     expect(component.find(Button).length).toEqual(1)
   })
 
-  it("doesnt display x if hideCloseXButton is passed", () => {
+  it("doesnt display x if hideCloseButton is passed", () => {
     let show = true
     const onClose = () => (show = false)
     const component = mount(
-      <Modal show={show} onClose={onClose} hideCloseXButton>
+      <Modal show={show} onClose={onClose} hideCloseButton>
         Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
         vestibulum.
       </Modal>
@@ -89,11 +89,11 @@ describe("Modal", () => {
     expect(show).toEqual(false)
   })
 
-  it("wont close when wrapper is clicked if hideCloseXButton is passed", () => {
+  it("wont close when wrapper is clicked if hideCloseButton is passed", () => {
     let show = true
     const onClose = () => (show = false)
     const component = mount(
-      <Modal show={show} hideCloseXButton onClose={onClose}>
+      <Modal show={show} hideCloseButton onClose={onClose}>
         Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
         vestibulum.
       </Modal>

--- a/packages/palette/src/elements/Modal/__tests__/Modal.test.tsx
+++ b/packages/palette/src/elements/Modal/__tests__/Modal.test.tsx
@@ -44,6 +44,18 @@ describe("Modal", () => {
     expect(component.find(Button).length).toEqual(1)
   })
 
+  it("doesnt display x if hideCloseXButton is passed", () => {
+    let show = true
+    const onClose = () => (show = false)
+    const component = mount(
+      <Modal show={show} onClose={onClose} hideCloseXButton>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+        vestibulum.
+      </Modal>
+    )
+    expect(component.find(CloseIcon).length).toEqual(0)
+  })
+
   it("closes when x is clicked", () => {
     let show = true
     const onClose = () => (show = false)
@@ -59,6 +71,38 @@ describe("Modal", () => {
       .props()
       .onClick()
     expect(show).toEqual(false)
+  })
+
+  it("closes when wrapper is clicked", () => {
+    let show = true
+    const onClose = () => (show = false)
+    const component = mount(
+      <Modal show={show} onClose={onClose}>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+        vestibulum.
+      </Modal>
+    )
+    component
+      .childAt(0)
+      .props()
+      .onClick()
+    expect(show).toEqual(false)
+  })
+
+  it("wont close when wrapper is clicked if hideCloseXButton is passed", () => {
+    let show = true
+    const onClose = () => (show = false)
+    const component = mount(
+      <Modal show={show} hideCloseXButton onClose={onClose}>
+        Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+        vestibulum.
+      </Modal>
+    )
+    component
+      .childAt(0)
+      .props()
+      .onClick()
+    expect(show).toEqual(true)
   })
 
   it("closes when escape key is pressed", () => {


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/PURCHASE-1473
- Users can now close the Modal by clicking anywhere outside of the Modal. This however is disabled if the `hideCloseXButton` prop is passed. In some cases we may want a CTA to be the only way to exit out of a modal, this prop can be used in these cases. 