### PR TITLE
Allow override of button type

### DIFF
--- a/packages/palette-docs/content/docs/elements/buttons/Button.mdx
+++ b/packages/palette-docs/content/docs/elements/buttons/Button.mdx
@@ -194,3 +194,35 @@ Use `block` to style a button to be 100% width of its container.
     </Button>
   </>
 </Playground>
+
+## In the context of a form
+
+A button defaults to type submit, so when used in the context of a form, a
+click will submit the form:
+
+<Playground title="noOutline" showToggle={true} expanded={false}>
+  <form>
+    <Button block width="100%" size="medium" m={0.5}>
+      Submit
+    </Button>
+  </form>
+</Playground>
+
+This means that if you have more than one Button in a form, you'll probably
+want to override the type of one of the buttons:
+
+<Playground title="noOutline" showToggle={true} expanded={false}>
+  <form>
+    <Button type="button" block width="100%" size="medium" m={0.5}>
+      Cancel
+    </Button>
+    <Button block width="100%" size="medium" m={0.5}>
+      Submit
+    </Button>
+  </form>
+</Playground>
+
+If you don't do this, then you may have strange behavior when the form is
+submitted by hitting "Enter" on a field. The click handler of the first button
+of type submit will be invoked, so be sure that the only button of this type is
+the one that really is the submit button.

--- a/packages/palette/src/elements/Button/Button.shared.tsx
+++ b/packages/palette/src/elements/Button/Button.shared.tsx
@@ -50,6 +50,8 @@ export interface ButtonBaseProps extends BoxProps {
   variantStyles?: any // FIXME
   /** Pass the longest text to the button for the button to keep longest text width */
   longestText?: string
+  /** The underlying type of button */
+  type?: string
 }
 
 /**


### PR DESCRIPTION
While working through a [bug on the artwork form](https://artsyproduct.atlassian.net/browse/GALL-2100), I discovered that our `Button` does not support the `type` attribute. This PR adds that attr as an optional on the `ButtonBaseProps` interface. I also added a bit to the docs to help on usage.

## Wait, what was the problem?

It turns out that if you don't specify the `type` of a `button`, it will default to `submit`

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

> submit: The button submits the form data to the server. This is the default if the attribute is not specified, or if the attribute is dynamically changed to an empty or invalid value.

So then if your `button` is inside a form with a text input and one hits enter, then the `onClick` of that button will be triggered. The docs remind us to ensure we're using `button` in this case:

> If your buttons are not for submitting form data to a server, be sure to set their type attribute to button.

## Is this enough?

Merging just this should allow me to specify the type of `button` on the couple buttons on this form and fix my bug, but is this enough? I had other ideas for ways we could help ourselves not make similar mistakes...

## Separate button components

One way we could be more declarative about our buttons would be to split up into two kinds:

* `Button` = hard code the type to `button`
* `SubmitButton` = hard code the type to `submit`

I think that's probably how people would use them. When you want to put a button on the page, you probably don't want it to have the `submit` type - you just want to wire up a click handler and do a thing.

But then when you are working on a form, you can use the `SubmitButton` to indicate that this particular component is meant to be clicked by the user to submit the form.

## Require type, no default

This PR makes the `type` attribute optional, but we could require it instead. That would mean all existing uses of Button would need to be updated to specify which type they are. That would certainly be declarative!

## Change the default

Another option would be to keep our `Button` as-is, add the type override but then change the default from `submit` to `button`. My hesitation here is that if one does know the spec and knows the default HTML button behavior is to default to `submit`, our having changed it would be surprising.

## My Recommedation

There might be other options that I'm not thinking of, but my recommendation would be something like this:

* merge this PR, fix my bug
* do a follow up PR that marks type as required on button, but uses `submit` as default with a deprecation warning or something
* do another follow up PR that removes the default so clients are required to specify type on all buttons

So yeah, thanks for coming to my TED talk about buttons and types, I've clearly been thinking about this more than I ever thought I would! What do you think?