### PR TITLE
Algolia updates

### DIFF
--- a/packages/palette-docs/content/docs/elements/data-visualization/BarChart.mdx
+++ b/packages/palette-docs/content/docs/elements/data-visualization/BarChart.mdx
@@ -70,7 +70,7 @@ not relativity to other graphs.
   </>
 </Playground>
 
-# Scroll down to see enter animation 👇
+**Scroll down to see enter animation 👇**
 
 <Playground showEditor={true}>
   <>
@@ -139,7 +139,7 @@ not relativity to other graphs.
   </>
 </Playground>
 
-# Highlight label constrained to left edge
+## Highlight label constrained to left edge
 
 <Playground showEditor={true}>
   <>
@@ -202,7 +202,7 @@ not relativity to other graphs.
   </>
 </Playground>
 
-# Highlight label constrained to right edge
+## Highlight label constrained to right edge
 
 <Playground showEditor={true}>
   <>
@@ -265,7 +265,7 @@ not relativity to other graphs.
   </>
 </Playground>
 
-# With X axis labels
+## With X axis labels
 
 <Playground showEditor={true}>
   <>

--- a/packages/palette-docs/content/docs/elements/data-visualization/DonutChart.mdx
+++ b/packages/palette-docs/content/docs/elements/data-visualization/DonutChart.mdx
@@ -50,7 +50,7 @@ name: DonutChart
   </Box>
 </Playground>
 
-# Two charts in the same row (each take the entire width available)
+## Two charts in the same row (each take the entire width available)
 
 <Playground>
   <>
@@ -147,7 +147,7 @@ name: DonutChart
   </>
 </Playground>
 
-# Custom margin for long labels
+## Custom margin for long labels
 
 <Playground>
   <Box width="50%">
@@ -198,7 +198,7 @@ name: DonutChart
   </Box>
 </Playground>
 
-# No labels, only tooltips and 0 margin
+## No labels, only tooltips and 0 margin
 
 <Playground>
   <Box width="30%" my={2}>
@@ -242,7 +242,7 @@ name: DonutChart
   </Box>
 </Playground>
 
-# With title/description labels
+## With title/description labels
 
 <Playground>
   <Box width="50%">

--- a/packages/palette-docs/content/docs/elements/data-visualization/LineChart.mdx
+++ b/packages/palette-docs/content/docs/elements/data-visualization/LineChart.mdx
@@ -63,7 +63,7 @@ name: LineChart
   />
 </Playground>
 
-# Scroll down to see enter animation 👇
+**Scroll down to see enter animation 👇**
 
 <Playground showEditor={true}>
   <>
@@ -139,7 +139,7 @@ name: LineChart
   </>
 </Playground>
 
-# With height passed to the component
+## With height passed to the component
 
 <Playground>
   <LineChart

--- a/packages/palette-docs/content/docs/elements/images/Image.mdx
+++ b/packages/palette-docs/content/docs/elements/images/Image.mdx
@@ -10,7 +10,7 @@ name: Image
   />
 </Playground>
 
-### Lazy loaded image
+## Lazy loaded image
 
 For situations where an image is displayed below the fold, use the `lazyLoad`
 prop. This is an important performance optimization.
@@ -24,7 +24,7 @@ prop. This is an important performance optimization.
   />
 </Playground>
 
-### Preventing right-click
+## Preventing right-click
 
 We generally don't want artwork images to be downloaded by users. Mark an image
 with the `preventRightClick` prop, and users will be unable to right click to
@@ -39,7 +39,7 @@ with the `preventRightClick` prop, and users will be unable to right click to
   />
 </Playground>
 
-### Responsive image
+## Responsive image
 
 Used to fill an area provided regardless of proportions.
 

--- a/packages/palette-docs/content/docs/elements/inputs/Checkbox.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Checkbox.mdx
@@ -6,19 +6,19 @@ name: Checkbox
   <Checkbox>Default</Checkbox>
 </Playground>
 
-### Hover
+## Hover
 
 <Playground>
   <Checkbox hover>Default</Checkbox>
 </Playground>
 
-### Selected
+## Selected
 
 <Playground>
   <Checkbox selected>Click me</Checkbox>
 </Playground>
 
-### Disabled
+## Disabled
 
 <Playground>
   <Checkbox disabled>Click me</Checkbox>

--- a/packages/palette-docs/content/docs/elements/inputs/RadioGroup.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/RadioGroup.mdx
@@ -3,15 +3,13 @@ name: RadioGroup
 status: ""
 ---
 
-# Guidelines
-
 Use this component when user must make a decision, which may result in
 additional consecutive decisions, or may reveal additional information.
 
 Group radio selects are consistent at all screen widths. Width is flexible
 dependent on grid.
 
-### With additional content
+## With additional content
 
 When option is selected, more information is revealed
 
@@ -30,7 +28,7 @@ When option is selected, more information is revealed
 When option is selected, and contains an input, the input is active upon radio
 selection.
 
-### No items pre-selected
+## No items pre-selected
 
 <Playground>
   <RadioGroup>
@@ -39,7 +37,7 @@ selection.
   </RadioGroup>
 </Playground>
 
-### With default value
+## With default value
 
 <Playground>
   <RadioGroup defaultValue="PICKUP">
@@ -48,7 +46,7 @@ selection.
   </RadioGroup>
 </Playground>
 
-### Deselectable
+## Deselectable
 
 <Playground>
   <RadioGroup defaultValue="SHIP" deselectable>
@@ -57,7 +55,7 @@ selection.
   </RadioGroup>
 </Playground>
 
-### Disabled
+## Disabled
 
 <Playground>
   <RadioGroup defaultValue="SHIP" disabled>

--- a/packages/palette-docs/content/docs/elements/inputs/Select.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Select.mdx
@@ -2,9 +2,12 @@
 name: Select
 status: wip
 ---
-## Usage guidelines
 
-Selects should be used in instances where we require users to enter information that requires explanation or context. These usages tend to be more complex and therefore require structured inputs with a variety of contextual info. For light-weight applications we recommend using the [mini-dropdown](https://palette.artsy.net/elements/inputs/select/).
+Selects should be used in instances where we require users to enter information
+that requires explanation or context. These usages tend to be more complex and
+therefore require structured inputs with a variety of contextual info. For
+light-weight applications we recommend using the
+[mini-dropdown](https://palette.artsy.net/elements/inputs/select/).
 
 import { Value } from "react-powerplug"
 
@@ -42,7 +45,7 @@ of user-benefitting product strategy.
 
 <Spacer my={6} />
 
-### Error state
+## Error state
 
 <Playground>
   <Value>

--- a/packages/palette-docs/content/docs/elements/inputs/SelectSmall.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/SelectSmall.mdx
@@ -5,9 +5,10 @@ status: wip
 
 import { Value } from "react-powerplug"
 
-Used for tight UI moments, when dropdown select needs to recede, or needs to be displayed in multiple.
+Used for tight UI moments, when dropdown select needs to recede, or needs to be
+displayed in multiple.
 
-### SelectSmall with title
+## SelectSmall with title
 
 <Playground>
   <SelectSmall
@@ -25,8 +26,7 @@ Used for tight UI moments, when dropdown select needs to recede, or needs to be 
   />
 </Playground>
 
-
-### SelectSmall without title
+## SelectSmall without title
 
 <Playground>
   <SelectSmall

--- a/packages/palette-docs/content/docs/elements/inputs/Slider.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Slider.mdx
@@ -5,7 +5,7 @@ name: Slider
 Sliders can either control a single value (e.g. volume, or position in a video),
 or a range of values (e.g. price ranges or height/width ranges).
 
-### Disabled
+## Disabled
 
 <Playground>
   <Box p={1}>
@@ -20,7 +20,7 @@ or a range of values (e.g. price ranges or height/width ranges).
   </Box>
 </Playground>
 
-### With label
+## With label
 
 <Playground>
   <Box p={1}>

--- a/packages/palette-docs/content/docs/elements/layout/CSSGrid.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/CSSGrid.mdx
@@ -8,7 +8,7 @@ related to CSS grid.
 Palette also offers a [Grid element](/elements/layout/grid/), which can be used
 for layouts based on a Bootstrap-style twelve column grid.
 
-### A Simple CSSGrid
+## A Simple CSSGrid
 
 <Playground>
   <CSSGrid gridTemplateColumns="repeat(2, 1fr)" gridGap={2} my={2}>
@@ -19,7 +19,7 @@ for layouts based on a Bootstrap-style twelve column grid.
   </CSSGrid>
 </Playground>
 
-### A Responsive CSSGrid
+## A Responsive CSSGrid
 
 <Playground>
   <CSSGrid

--- a/packages/palette-docs/content/docs/elements/layout/Flex.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Flex.mdx
@@ -2,7 +2,7 @@
 name: Flex
 ---
 
-### Basics
+## Basics
 
 <Playground>
   <Flex flexDirection="column">
@@ -14,10 +14,10 @@ name: Flex
   </Flex>
 </Playground>
 
-### Flex Item Order
+## Flex Item Order
 
-Flex items are displayed in the same order as they appear in the source
-document by default. We can use the `order` property to change the ordering.
+Flex items are displayed in the same order as they appear in the source document
+by default. We can use the `order` property to change the ordering.
 
 <Playground>
   <Flex>

--- a/packages/palette-docs/content/docs/elements/layout/Grid.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Grid.mdx
@@ -13,7 +13,7 @@ full documentation.
 Palette also offers a [CSSGrid element](/elements/layout/cssgrid/), which can be
 used for layouts based on the `display:grid` CSS feature.
 
-### Examples
+## Examples
 
 <Grid>
   <Row>

--- a/packages/palette-docs/content/docs/elements/layout/ReadMore.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/ReadMore.mdx
@@ -2,7 +2,7 @@
 name: ReadMore
 ---
 
-### With character cap
+## With character cap
 
 <Playground>
   <Serif size="3">
@@ -23,7 +23,7 @@ name: ReadMore
   </Serif>
 </Playground>
 
-### Short content
+## Short content
 
 <Playground>
   <ReadMore
@@ -37,7 +37,7 @@ name: ReadMore
   />
 </Playground>
 
-### As string
+## As string
 
 <Playground>
   <ReadMore
@@ -46,7 +46,7 @@ name: ReadMore
   />
 </Playground>
 
-### Character cap with html
+## Character cap with html
 
 <Playground>
   <ReadMore

--- a/packages/palette-docs/content/docs/home/getting-started.mdx
+++ b/packages/palette-docs/content/docs/home/getting-started.mdx
@@ -3,7 +3,7 @@ name: Getting started
 hideInNav: false
 ---
 
-### Adding Palette
+## Adding Palette
 
 To bring Palette into your app, install it as a package:
 
@@ -62,7 +62,7 @@ const Artworks = props => {
 In order to use Artsy's fonts, you'll also want to add our webfont file to the
 CSS in the header of your app. Here are a few examples:
 
-### Using [react-head](https://github.com/tizmagik/react-head) (see [here](https://github.com/tizmagik/react-head/tree/master/example) for more examples)
+## Using [react-head](https://github.com/tizmagik/react-head) (see [here](https://github.com/tizmagik/react-head/tree/master/example) for more examples)
 
 ```
 import { HeadProvider, Link } from 'react-head';
@@ -78,7 +78,7 @@ const App = () => (
 );
 ```
 
-### Using [React Helmet](https://github.com/nfl/react-helmet)
+## Using [React Helmet](https://github.com/nfl/react-helmet)
 
 ```
 import {Helmet} from "react-helmet";
@@ -92,7 +92,7 @@ import {Helmet} from "react-helmet";
 </Helmet>
 ```
 
-### Using [Styled Components](https://www.styled-components.com/docs/api#createglobalstyle)
+## Using [Styled Components](https://www.styled-components.com/docs/api#createglobalstyle)
 
 ```
 import { createGlobalStyle } from "styled-components"

--- a/packages/palette-docs/content/docs/home/process.mdx
+++ b/packages/palette-docs/content/docs/home/process.mdx
@@ -3,7 +3,7 @@ name: Process
 status: wip
 ---
 
-### Terminology
+## Terminology
 
 **Token:** Should primarily be a value, functionally agnostic. <br/>
 **Element:** Composition of various tokens. Specific function, content agnostic.
@@ -14,7 +14,7 @@ status: wip
 that applies to a variety of content use cases.<br/> **Utility:** Specific
 function, is either not visible or exists temporarily.
 
-### Proposals
+## Proposals
 
 1. Designer or engineer identifies a need for a new shared component in a
    project within sprint work.
@@ -30,7 +30,7 @@ function, is either not visible or exists temporarily.
    The issue includes a responsible engineer and designer.
 5. This issue is shared in #design-system.
 
-### Build
+## Build
 
 1. Engineer starts building the component in Palette (link to Readme docs),
    publishes the component as "WIP" with a reference to the issue created by the
@@ -47,7 +47,7 @@ The same process applies for updates to existing components as well — the
 emphasis on communication ensures visibility, trust and successful adoption of
 this system.
 
-### Project board
+## Project board
 
 We use a github [project board](https://github.com/artsy/palette/projects/1) to
 keep track of the process of shipping a new component. The following section
@@ -68,7 +68,7 @@ Board columns
    new component
 7. **Done**: Pr has been merged and new component is now available for use
 
-### Sizes and naming
+## Sizes and naming
 
 We only use the following variables to describe sizes: x-small (xs), small (sm),
 medium (md), large (lg), x-large (xl).
@@ -77,7 +77,7 @@ If a similar component comes in more than one size, the components should be
 named as explicitly as possible to it's use and function, so that people will
 understand when and how to use it. (e.g. `Input`, `QuickInput`).
 
-### States
+## States
 
 We use the following terminology to describe common states: `default`, `hover`,
 `active`, `disabled`, `error`.

--- a/packages/palette-docs/content/docs/tokens/Color.mdx
+++ b/packages/palette-docs/content/docs/tokens/Color.mdx
@@ -69,7 +69,3 @@ backgrounds.
 Red is used to indicate an error, either as the text color of for backgrounds.
 
 <Spacer m={4} />
-
-## Secondary colors
-
-## Depreciated colors

--- a/packages/palette-docs/content/docs/tokens/Spacing.mdx
+++ b/packages/palette-docs/content/docs/tokens/Spacing.mdx
@@ -3,11 +3,11 @@ name: Spacing
 subNavOrder: 1
 ---
 
-### Theme
+## Theme
 
 https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx#L116
 
-### API
+## API
 
 https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space
 
@@ -15,13 +15,13 @@ See
 [Notion](https://www.notion.so/artsy/Spacing-93eeaed9fdf9480099fec7094fd1b9f3)
 for complete spec.
 
-### Base grid
+## Base grid
 
 We employ a base-10px grid for consistent vertical rhythm.
 
 <img width="100%" src="/assets/spacing-base-10.png" />
 
-### Spacing units
+## Spacing units
 
 Spacing units are set in multiples of 10px.
 
@@ -47,7 +47,7 @@ This means that in practice one should rarely use concrete pixel values:
   </Box>
 </Flex>
 
-### Avoid this
+### Avoid this spacing pattern
 
 <Playground layout="horizontal">
   <BorderBox mt="10px" p="20px">
@@ -55,7 +55,7 @@ This means that in practice one should rarely use concrete pixel values:
   </BorderBox>
 </Playground>
 
-### Good
+### Apply this spacing pattern
 
 <Playground layout="horizontal">
   <BorderBox mt={1} p={2}>

--- a/packages/palette-docs/gatsby-config.js
+++ b/packages/palette-docs/gatsby-config.js
@@ -12,6 +12,7 @@ module.exports = {
     description: "Artsy's design system",
     author: "Artsy",
     changelog: {},
+    siteUrl: "https://palette.artsy.net",
   },
   plugins: [
     {
@@ -69,5 +70,6 @@ module.exports = {
     "gatsby-plugin-react-helmet",
     "gatsby-plugin-styled-components",
     "gatsby-plugin-typescript",
+    "gatsby-plugin-sitemap",
   ],
 }

--- a/packages/palette-docs/package.json
+++ b/packages/palette-docs/package.json
@@ -86,6 +86,7 @@
     "gatsby-plugin-offline": "^2.0.16",
     "gatsby-plugin-react-helmet": "^3.0.5",
     "gatsby-plugin-sharp": "^2.0.14",
+    "gatsby-plugin-sitemap": "^2.2.16",
     "gatsby-plugin-styled-components": "^3.0.4",
     "gatsby-remark-prismjs": "^3.2.4",
     "gatsby-source-filesystem": "^2.0.16",

--- a/packages/palette-docs/src/components/GlobalComponents.jsx
+++ b/packages/palette-docs/src/components/GlobalComponents.jsx
@@ -101,28 +101,40 @@ export const MarkdownComponents = {
   },
   h1: props => (
     <Box mb={5}>
-      <Serif size="8" color="black100">
+      <Serif element="h1" size="8" color="black100" className="DocSearch-lvl1">
         {props.children}
       </Serif>
     </Box>
   ),
   h2: props => (
     <Box mb={1}>
-      <Sans size="5" weight="medium" color="black100">
+      <Sans
+        element="h2"
+        size="5"
+        weight="medium"
+        color="black100"
+        className="DocSearch-lvl2"
+      >
         {props.children}
       </Sans>
     </Box>
   ),
   h3: props => (
     <Box mb={1}>
-      <Sans size="4" weight="medium" color="black100">
+      <Sans
+        element="h3"
+        size="4"
+        weight="medium"
+        color="black100"
+        className="DocSearch-lvl3"
+      >
         {props.children}
       </Sans>
     </Box>
   ),
   h4: props => (
     <Box mb={1}>
-      <Serif size="4" color="black100">
+      <Serif element="h4" size="4" color="black100" className="DocSearch-lvl4">
         {props.children}
       </Serif>
     </Box>
@@ -138,7 +150,7 @@ export const MarkdownComponents = {
 
   p: props => (
     // @ts-ignore
-    <Sans size="3" color="black100" className="contentDiv">
+    <Sans element="p" size="3" color="black100" className="contentDiv">
       {props.children}
     </Sans>
   ),

--- a/packages/palette-docs/src/layouts/DefaultLayout.tsx
+++ b/packages/palette-docs/src/layouts/DefaultLayout.tsx
@@ -30,12 +30,25 @@ export default function DocsLayout(props) {
             rel="stylesheet"
             type="text/css"
           />
+          <meta name="docsearch:language" content="en" />
+          <meta name="docsearch:version" content="1.0.0" />
         </Helmet>
         <Sidebar />
-        <ContentArea flexDirection="column" pt={4} px={6}>
+        <ContentArea
+          className="DocSearch-content"
+          flexDirection="column"
+          pt={4}
+          px={6}
+        >
           {type !== "page" && (
             <Box mb={0.5}>
-              <Serif size="8" color="black100" mb={2}>
+              <Serif
+                element="h1"
+                size="8"
+                color="black100"
+                mb={2}
+                className="DocSearch-lvl1"
+              >
                 {name} {status && <StatusBadge status={status} />}
               </Serif>
             </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,6 +1797,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -10368,6 +10375,16 @@ gatsby-plugin-sharp@^2.0.14:
     progress "^1.1.8"
     sharp "^0.21.3"
     svgo "^0.7.2"
+
+gatsby-plugin-sitemap@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.2.16.tgz#1d8054ce8c78d91618707284d82c1e92782fd68b"
+  integrity sha512-Khs7uZg8bRJZ9OrO1p5yiHyuzhMx0OtSR6wPPMlqOjR9ag9qpRfDwbMG9lEjNxKyl0MGDSEnRWOnZteGcPzq5Q==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    minimatch "^3.0.4"
+    pify "^3.0.0"
+    sitemap "^1.13.0"
 
 gatsby-plugin-styled-components@^3.0.4:
   version "3.0.7"
@@ -20382,6 +20399,14 @@ sisteransi@^1.0.0:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
   integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
 
+sitemap@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-1.13.0.tgz#569cbe2180202926a62a266cd3de09c9ceb43f83"
+  integrity sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=
+  dependencies:
+    underscore "^1.7.0"
+    url-join "^1.1.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -22167,6 +22192,11 @@ underscore.string@^3.3.4, underscore.string@^3.3.5:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+underscore@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
 unescape-js@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unescape-js/-/unescape-js-1.1.1.tgz#a4345e654b857c29fa66469e311ccaf2e93063bd"
@@ -22496,6 +22526,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
+  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
 
 url-loader@^1.0.1, url-loader@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This update makes a series of changes requested by an algolia rep to enable docsearch. 

It includes
- making headings consistent
- ensuring headings use the right elements
- adding a sitemap
- add custom classes that algolia can hook into

Once we have this live they can start indexing us. Afterwards, the next big step will be to add the ui. 