### PR TITLE
SelectSmall updates

### DIFF
--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -8,13 +8,15 @@ import {
   space as styledSpace,
   SpaceProps,
   themeGet,
+  width,
+  WidthProps,
 } from "styled-system"
 
 interface Option {
   value: string
   text: string
 }
-export interface SelectProps extends PositionProps, SpaceProps {
+export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
   options: Option[]
   selected?: string
   disabled?: boolean
@@ -144,6 +146,7 @@ const SelectSmallContainer = styled.div<SelectProps>`
   position: relative;
 
   label {
+    ${width};
     padding: 0;
     margin: 0;
   }
@@ -158,6 +161,7 @@ const SelectSmallContainer = styled.div<SelectProps>`
     padding: ${space(0.5)}px ${space(1) + carretSize * 4}px ${space(0.5)}px
       ${space(1)}px;
     ${styledSpace};
+    ${width};
 
     &:hover {
       background-color: ${color("black30")};

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -157,6 +157,7 @@ const SelectSmallContainer = styled.div<SelectProps>`
     line-height: ${themeGet("typeSizes.sans.2.lineHeight")}px;
     padding: ${space(0.5)}px ${space(1) + carretSize * 4}px ${space(0.5)}px
       ${space(1)}px;
+    ${styledSpace};
 
     &:hover {
       background-color: ${color("black30")};


### PR DESCRIPTION
@sepans and I needed to add some functionality to `<SelectSmall>` - this PR allows it to receive the normal `m`, `mr`, `p`, `pr`...etc. props that other Palette components accept, and it also allows the consumer to pass a `width` prop.

This should not affect existing functionality as nothing we added changes the default behavior.