### PR TITLE
Improve selects

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/Input.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Input.mdx
@@ -46,7 +46,7 @@ Inputs should be used in instances where we require users to enter information t
   </BorderBox>
 </Playground>
 
-## Disabled
+## Disabled Input
 
 <Playground>
   <BorderBox>

--- a/packages/palette-docs/content/docs/elements/inputs/Select.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/Select.mdx
@@ -9,65 +9,74 @@ therefore require structured inputs with a variety of contextual info. For
 light-weight applications we recommend using the
 [mini-dropdown](https://palette.artsy.net/elements/inputs/select/).
 
-import { Value } from "react-powerplug"
-
 Our default dropdown style. When dropdown is active, display system dropdown
 list. When possible, dropdowns should default to a placeholder as to not force
 users into decisions. Occasionally, we default users to a selection for the sake
 of user-benefitting product strategy.
 
-<Box>
-  <Serif size="3">Title</Serif>
-  <LargeSelect
-    options={[
-      {
-        text: "Most Recent",
-        value: "mostRecent",
-      },
-    ]}
-  />
-</Box>
-
-<Spacer my={2} />
-
-<Box>
-  <Serif size="3">Title</Serif>
-  <Serif size="2">Short description</Serif>
-  <LargeSelect
-    options={[
-      {
-        text: "Most Recent",
-        value: "mostRecent",
-      },
-    ]}
-  />
-</Box>
-
-<Spacer my={6} />
-
-## Error state
+## Select only
 
 <Playground>
-  <Value>
-    {({ value = "badValue", set }) => {
-      const error = value === "goodValue" ? "" : "Error Message"
-      return (
-        <LargeSelect
-          error={error}
-          options={[
-            {
-              text: "Good",
-              value: "goodValue",
-            },
-            {
-              text: "Bad",
-              value: "badValue",
-            },
-          ]}
-          selected={value}
-          onSelect={value => set(value)}
-        />
-      )
-    }}
-  </Value>
+  <BorderBox>
+    <LargeSelect
+      options={[{ text: "Most Recent", value: "mostRecent" }]}
+    />
+  </BorderBox>
+</Playground>
+
+## Select + Title
+
+<Playground>
+  <BorderBox>
+    <LargeSelect
+      options={[{ text: "Most Recent", value: "mostRecent" }]}
+      title="Pick something"
+    />
+  </BorderBox>
+</Playground>
+
+## Select + Title + Required
+
+<Playground>
+  <BorderBox>
+    <LargeSelect
+      options={[{ text: "Most Recent", value: "mostRecent" }]}
+      required
+      title="Pick something"
+    />
+  </BorderBox>
+</Playground>
+
+## Select + Title + Description
+
+<Playground>
+  <BorderBox>
+    <LargeSelect
+      description="This matters a lot."
+      options={[{ text: "Most Recent", value: "mostRecent" }]}
+      title="Pick something"
+    />
+  </BorderBox>
+</Playground>
+
+## Select with error
+
+<Playground>
+  <BorderBox>
+    <LargeSelect
+      error="Something went wrong."
+      options={[{ text: "Most Recent", value: "mostRecent" }]}
+    />
+  </BorderBox>
+</Playground>
+
+## Disabled Select
+
+<Playground>
+  <BorderBox>
+    <LargeSelect
+      disabled
+      options={[{ text: "Most Recent", value: "mostRecent" }]}
+    />
+  </BorderBox>
 </Playground>

--- a/packages/palette/src/elements/Input/Input.test.tsx
+++ b/packages/palette/src/elements/Input/Input.test.tsx
@@ -49,98 +49,52 @@ describe("Input", () => {
 
 describe("computeBorderColor", () => {
   it("defaults to returning black 10", () => {
-    const props = {
-      disabled: null,
-      error: null,
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(null,  null)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled", () => {
-    const props = {
-      disabled: true,
-      error: false,
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(true, false)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled and error", () => {
-    const props = {
-      disabled: true,
-      error: true,
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(true, true)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled and hover", () => {
-    const props = {
-      disabled: true,
-      error: false,
-      pseudo: "hover",
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(true, false, "hover")
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled and focus", () => {
-    const props = {
-      disabled: true,
-      error: false,
-      pseudo: "focus",
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(true, false, "focus")
     expect(color).toEqual("black10")
   })
 
   it("returns red100 when error", () => {
-    const props = {
-      disabled: false,
-      error: true,
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(false, true)
     expect(color).toEqual("red100")
   })
 
   it("returns red100 when error and hover", () => {
-    const props = {
-      disabled: false,
-      error: true,
-      pseudo: "hover",
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(false, true, "hover")
     expect(color).toEqual("red100")
   })
 
   it("returns red100 when disabled and focus", () => {
-    const props = {
-      disabled: false,
-      error: true,
-      pseudo: "focus",
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(false, true, "focus")
     expect(color).toEqual("red100")
   })
 
   it("returns black60 on hover", () => {
-    const props = {
-      disabled: false,
-      error: false,
-      pseudo: "hover",
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(false, false, "hover")
     expect(color).toEqual("black60")
   })
 
   it("returns purple100 on focus", () => {
-    const props = {
-      disabled: false,
-      error: false,
-      pseudo: "focus",
-    }
-    const color = computeBorderColor(props)
+    const color = computeBorderColor(false, false, "focus")
     expect(color).toEqual("purple100")
   })
 })

--- a/packages/palette/src/elements/Input/Input.test.tsx
+++ b/packages/palette/src/elements/Input/Input.test.tsx
@@ -49,52 +49,98 @@ describe("Input", () => {
 
 describe("computeBorderColor", () => {
   it("defaults to returning black 10", () => {
-    const color = computeBorderColor(null, null)
+    const props = {
+      disabled: null,
+      error: null,
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled", () => {
-    const color = computeBorderColor(true, false)
+    const props = {
+      disabled: true,
+      error: false,
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled and error", () => {
-    const color = computeBorderColor(true, true)
+    const props = {
+      disabled: true,
+      error: true,
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled and hover", () => {
-    const color = computeBorderColor(true, false, "hover")
+    const props = {
+      disabled: true,
+      error: false,
+      pseudo: "hover",
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("black10")
   })
 
   it("returns black10 when disabled and focus", () => {
-    const color = computeBorderColor(true, false, "focus")
+    const props = {
+      disabled: true,
+      error: false,
+      pseudo: "focus",
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("black10")
   })
 
   it("returns red100 when error", () => {
-    const color = computeBorderColor(false, true)
+    const props = {
+      disabled: false,
+      error: true,
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("red100")
   })
 
   it("returns red100 when error and hover", () => {
-    const color = computeBorderColor(false, true, "hover")
+    const props = {
+      disabled: false,
+      error: true,
+      pseudo: "hover",
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("red100")
   })
 
   it("returns red100 when disabled and focus", () => {
-    const color = computeBorderColor(false, true, "focus")
+    const props = {
+      disabled: false,
+      error: true,
+      pseudo: "focus",
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("red100")
   })
 
   it("returns black60 on hover", () => {
-    const color = computeBorderColor(false, false, "hover")
+    const props = {
+      disabled: false,
+      error: false,
+      pseudo: "hover",
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("black60")
   })
 
   it("returns purple100 on focus", () => {
-    const color = computeBorderColor(false, false, "focus")
+    const props = {
+      disabled: false,
+      error: false,
+      pseudo: "focus",
+    }
+    const color = computeBorderColor(props)
     expect(color).toEqual("purple100")
   })
 })

--- a/packages/palette/src/elements/Input/Input.test.tsx
+++ b/packages/palette/src/elements/Input/Input.test.tsx
@@ -49,7 +49,7 @@ describe("Input", () => {
 
 describe("computeBorderColor", () => {
   it("defaults to returning black 10", () => {
-    const color = computeBorderColor(null,  null)
+    const color = computeBorderColor(null, null)
     expect(color).toEqual("black10")
   })
 

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { themeGet } from "styled-system"
 import { color, space } from "../../helpers"
+import { Color } from "../../Theme"
 import { Box } from "../Box"
 import { Sans, Serif } from "../Typography"
 
@@ -55,7 +56,11 @@ interface StyledInputProps extends React.HTMLProps<HTMLInputElement> {
 /**
  * func to compute border color
  */
-export const computeBorderColor = ({ disabled, error, pseudo = null }) => {
+export const computeBorderColor = (
+  disabled: boolean,
+  error: boolean,
+  pseudo?: string
+): Color => {
   if (disabled) return "black10"
   if (error) return "red100"
   if (pseudo === "hover") return "black60"
@@ -70,7 +75,8 @@ const StyledInput = styled.input<StyledInputProps>`
   height: 40px;
   background-color: ${props =>
     props.disabled ? color("black5") : color("white100")};
-  border: 1px solid ${props => color(computeBorderColor(props))};
+  border: 1px solid
+    ${({ disabled, error }) => color(computeBorderColor(disabled, error))};
   border-radius: 0;
   transition: border-color 0.25s;
   padding: ${space(1)}px;
@@ -79,12 +85,12 @@ const StyledInput = styled.input<StyledInputProps>`
 
   &:hover {
     border-color: ${({ disabled, error }) =>
-      color(computeBorderColor({ disabled, error, pseudo: "hover" }))};
+      color(computeBorderColor(disabled, error, "hover"))};
   }
 
   &:focus {
     border-color: ${({ disabled, error }) =>
-      color(computeBorderColor({ disabled, error, pseudo: "focus" }))};
+      color(computeBorderColor(disabled, error, "focus"))};
   }
 `
 StyledInput.displayName = "StyledInput"

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -89,7 +89,10 @@ const StyledInput = styled.input<StyledInputProps>`
 `
 StyledInput.displayName = "StyledInput"
 
-const Required = styled.span`
+/**
+ * Required
+ */
+export const Required = styled.span`
   color: ${color("purple100")};
 `
 Required.displayName = "Required"

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -53,14 +53,18 @@ interface StyledInputProps extends React.HTMLProps<HTMLInputElement> {
   error: boolean
 }
 
+interface InputStatus {
+  disabled: boolean
+  error: boolean
+  pseudo?: string
+}
+
 /**
  * func to compute border color
  */
-export const computeBorderColor = (
-  disabled: boolean,
-  error: boolean,
-  pseudo?: string
-): Color => {
+export const computeBorderColor = (inputStatus: InputStatus): Color => {
+  const { disabled, error, pseudo } = inputStatus
+
   if (disabled) return "black10"
   if (error) return "red100"
   if (pseudo === "hover") return "black60"
@@ -76,7 +80,7 @@ const StyledInput = styled.input<StyledInputProps>`
   background-color: ${props =>
     props.disabled ? color("black5") : color("white100")};
   border: 1px solid
-    ${({ disabled, error }) => color(computeBorderColor(disabled, error))};
+    ${({ disabled, error }) => color(computeBorderColor({ disabled, error }))};
   border-radius: 0;
   transition: border-color 0.25s;
   padding: ${space(1)}px;
@@ -85,12 +89,12 @@ const StyledInput = styled.input<StyledInputProps>`
 
   &:hover {
     border-color: ${({ disabled, error }) =>
-      color(computeBorderColor(disabled, error, "hover"))};
+      color(computeBorderColor({ disabled, error, pseudo: "hover" }))};
   }
 
   &:focus {
     border-color: ${({ disabled, error }) =>
-      color(computeBorderColor(disabled, error, "focus"))};
+      color(computeBorderColor({ disabled, error, pseudo: "focus" }))};
   }
 `
 StyledInput.displayName = "StyledInput"

--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -2,23 +2,44 @@ import { storiesOf } from "@storybook/react"
 import React from "react"
 import { LargeSelect, SelectSmall } from "./Select"
 
+const options = [
+  {
+    text: "First",
+    value: "firstValue",
+  },
+  {
+    text: "Last",
+    value: "lastValue",
+  },
+]
+
 storiesOf("Components/Select", module)
   .add("LargeSelect", () => {
+    return <LargeSelect options={options} selected="lastValue" />
+  })
+  .add("Select only", () => {
+    return <LargeSelect options={options} />
+  })
+  .add("Select + Title", () => {
+    return <LargeSelect options={options} title="Pick something" />
+  })
+  .add("Select + Title + Required", () => {
+    return <LargeSelect options={options} required title="Pick something" />
+  })
+  .add("Select + Title + Description", () => {
     return (
       <LargeSelect
-        options={[
-          {
-            text: "First",
-            value: "firstValue",
-          },
-          {
-            text: "Last",
-            value: "lastValue",
-          },
-        ]}
-        selected="lastValue"
+        description="This matters a lot."
+        options={options}
+        title="Pick something"
       />
     )
+  })
+  .add("Select with error", () => {
+    return <LargeSelect error="Something went wrong." options={options} />
+  })
+  .add("Disabled Select", () => {
+    return <LargeSelect disabled options={options} />
   })
   .add("SelectSmall with title", () => {
     return (

--- a/packages/palette/src/elements/Select/Select.test.tsx
+++ b/packages/palette/src/elements/Select/Select.test.tsx
@@ -1,19 +1,58 @@
 import { mount } from "enzyme"
 import React from "react"
-import { SelectSmall } from "../Select"
+import { LargeSelect, SelectSmall } from "../Select"
+
+const options = [
+  {
+    text: "First option",
+    value: "firstOption",
+  },
+  {
+    text: "Second option that is really long",
+    value: "secondOption",
+  },
+]
 
 describe("Select", () => {
+  describe("LargeSelect", () => {
+    it("renders the options provided", () => {
+      const props = { options }
+      const wrapper = mount(<LargeSelect {...props} />)
+      expect(wrapper.find("option").length).toEqual(2)
+    })
+
+    it("renders some optional info", () => {
+      const props = {
+        description: "This is the description",
+        error: "This is the error",
+        options,
+        title: "This is the title",
+      }
+      const wrapper = mount(<LargeSelect {...props} />)
+      expect(wrapper.text()).toContain("This is the description")
+      expect(wrapper.text()).toContain("This is the error")
+      expect(wrapper.text()).toContain("This is the title")
+    })
+
+    it("can be marked required", () => {
+      const props = {
+        options,
+        required: true,
+        title: "This is the title",
+      }
+      const wrapper = mount(<LargeSelect {...props} />)
+      expect(wrapper.find("Required").length).toEqual(1)
+    })
+
+    it("passes the name attr down to the raw node", () => {
+      const name = "some_rails_thing"
+      const props = { name, options }
+      const wrapper = mount(<LargeSelect {...props} />)
+      expect(wrapper.find("select").prop("name")).toEqual(name)
+    })
+  })
+
   describe("SelectSmall", () => {
-    const options = [
-      {
-        text: "First option",
-        value: "firstOption",
-      },
-      {
-        text: "Second option that is really long",
-        value: "secondOption",
-      },
-    ]
     it("renders proper options with correct selected one", () => {
       const wrapper = mount(
         <SelectSmall options={options} selected="secondOption" />

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -12,12 +12,13 @@ import { color, space } from "../../helpers"
 import { computeBorderColor, Required } from "../Input"
 import { Sans, Serif } from "../Typography"
 
-const computeOptionTags = (options: Option[]): JSX.Element[] => {
-  const optionTags = options.map(option => {
+const computeOptionTags = (options: Option[], name?: string): JSX.Element[] => {
+  const optionTags = options.map((option, index) => {
     const { text, value } = option
+    const key = [name || "", value || index].join("-")
 
     return (
-      <option value={value} key={value}>
+      <option value={value} key={key}>
         {text}
       </option>
     )
@@ -48,7 +49,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  */
 export const LargeSelect: SFC<SelectProps> = props => {
   const { description, disabled, error, name, onSelect, options, required, selected, title } = props
-  const optionTags = computeOptionTags(options)
+  const optionTags = computeOptionTags(options, name)
 
   return (
     <LargeSelectContainer {...props} p={1}>

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -1,8 +1,5 @@
 import React, { SFC } from "react"
 import styled, { css } from "styled-components"
-import { color, space } from "../../helpers"
-import { Sans } from "../Typography"
-
 import {
   PositionProps,
   space as styledSpace,
@@ -11,18 +8,21 @@ import {
   width,
   WidthProps,
 } from "styled-system"
+import { color, space } from "../../helpers"
+import { Sans } from "../Typography"
 
 interface Option {
   value: string
   text: string
 }
+
 export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
-  options: Option[]
-  selected?: string
   disabled?: boolean
   error?: string
-  title?: string
   onSelect?: (value) => void
+  options: Option[]
+  selected?: string
+  title?: string
 }
 
 /**
@@ -32,9 +32,9 @@ export const LargeSelect: SFC<SelectProps> = props => {
   return (
     <LargeSelectContainer {...props} p={1}>
       <select
-        value={props.selected}
         disabled={props.disabled}
         onChange={event => props.onSelect && props.onSelect(event.target.value)}
+        value={props.selected}
       >
         {props.options.map(({ value, text }) => (
           <option value={value} key={value}>
@@ -58,12 +58,11 @@ export const SelectSmall: SFC<SelectProps> = props => {
             {props.title}:
           </Sans>
         )}
-
         <select
-          value={props.selected}
           onChange={event =>
             props.onSelect && props.onSelect(event.target.value)
           }
+          value={props.selected}
         >
           {props.options.map(({ value, text }) => (
             <option value={value} key={value}>

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -35,6 +35,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
   description?: string
   disabled?: boolean
   error?: string
+  name?: string
   onSelect?: (value) => void
   options: Option[]
   required?: boolean
@@ -46,7 +47,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
-  const { description, disabled, error, onSelect, options, required, selected, title } = props
+  const { description, disabled, error, name, onSelect, options, required, selected, title } = props
   const optionTags = computeOptionTags(options)
 
   return (
@@ -64,6 +65,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
       )}
       <select
         disabled={disabled}
+        name={name}
         onChange={event => onSelect && onSelect(event.target.value)}
         value={selected}
       >

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -63,7 +63,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
  * A small version of drop-down select menu
  */
 export const SelectSmall: SFC<SelectProps> = props => {
-  const { onSelect, selected, options, title } = props
+  const { disabled, onSelect, selected, options, title } = props
   const optionTags = computeOptionTags(options)
 
   return (
@@ -75,6 +75,7 @@ export const SelectSmall: SFC<SelectProps> = props => {
           </Sans>
         )}
         <select
+          disabled={disabled}
           onChange={event => onSelect && onSelect(event.target.value)}
           value={selected}
         >

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -9,6 +9,7 @@ import {
   WidthProps,
 } from "styled-system"
 import { color, space } from "../../helpers"
+import { Box } from "../Box"
 import { computeBorderColor, Required } from "../Input"
 import { Sans, Serif } from "../Typography"
 
@@ -62,7 +63,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
   const optionTags = computeOptionTags(options, name)
 
   return (
-    <LargeSelectContainer {...props} p={1}>
+    <Box width="100%">
       {title && (
         <Serif mb="0.5" size="3">
           {title}
@@ -74,20 +75,22 @@ export const LargeSelect: SFC<SelectProps> = props => {
           {description}
         </Serif>
       )}
-      <select
-        disabled={disabled}
-        name={name}
-        onChange={event => onSelect && onSelect(event.target.value)}
-        value={selected}
-      >
-        {optionTags}
-      </select>
+      <LargeSelectContainer {...props} p={1}>
+        <select
+          disabled={disabled}
+          name={name}
+          onChange={event => onSelect && onSelect(event.target.value)}
+          value={selected}
+        >
+          {optionTags}
+        </select>
+      </LargeSelectContainer>
       {error && (
         <Sans color="red100" mt="1" size="2">
           {error}
         </Sans>
       )}
-    </LargeSelectContainer>
+    </Box>
   )
 }
 

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -31,6 +31,16 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
 export const LargeSelect: SFC<SelectProps> = props => {
   const { disabled, onSelect, selected, options } = props
 
+  const optionTags = options.map(option => {
+    const { text, value } = option
+
+    return (
+      <option value={value} key={value}>
+        {text}
+      </option>
+    )
+  })
+
   return (
     <LargeSelectContainer {...props} p={1}>
       <select
@@ -38,11 +48,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
         onChange={event => onSelect && onSelect(event.target.value)}
         value={selected}
       >
-        {options.map(({ value, text }) => (
-          <option value={value} key={value}>
-            {text}
-          </option>
-        ))}
+        {optionTags}
       </select>
     </LargeSelectContainer>
   )
@@ -53,6 +59,16 @@ export const LargeSelect: SFC<SelectProps> = props => {
  */
 export const SelectSmall: SFC<SelectProps> = props => {
   const { onSelect, selected, options, title } = props
+
+  const optionTags = options.map(option => {
+    const { text, value } = option
+
+    return (
+      <option value={value} key={value}>
+        {text}
+      </option>
+    )
+  })
 
   return (
     <SelectSmallContainer {...props}>
@@ -66,11 +82,7 @@ export const SelectSmall: SFC<SelectProps> = props => {
           onChange={event => onSelect && onSelect(event.target.value)}
           value={selected}
         >
-          {options.map(({ value, text }) => (
-            <option value={value} key={value}>
-              {text}
-            </option>
-          ))}
+          {optionTags}
         </select>
       </label>
     </SelectSmallContainer>

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -48,7 +48,17 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
-  const { description, disabled, error, name, onSelect, options, required, selected, title } = props
+  const {
+    description,
+    disabled,
+    error,
+    name,
+    onSelect,
+    options,
+    required,
+    selected,
+    title,
+  } = props
   const optionTags = computeOptionTags(options, name)
 
   return (

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -9,7 +9,7 @@ import {
   WidthProps,
 } from "styled-system"
 import { color, space } from "../../helpers"
-import { computeBorderColor } from "../Input"
+import { computeBorderColor, Required } from "../Input"
 import { Sans, Serif } from "../Typography"
 
 const computeOptionTags = (options: Option[]): JSX.Element[] => {
@@ -37,6 +37,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
   error?: string
   onSelect?: (value) => void
   options: Option[]
+  required?: boolean
   selected?: string
   title?: string
 }
@@ -45,7 +46,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
-  const { description, disabled, error, onSelect, options, selected, title } = props
+  const { description, disabled, error, onSelect, options, required, selected, title } = props
   const optionTags = computeOptionTags(options)
 
   return (
@@ -53,6 +54,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
       {title && (
         <Serif mb="0.5" size="3">
           {title}
+          {required && <Required>*</Required>}
         </Serif>
       )}
       {description && (

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -29,14 +29,16 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
+  const { disabled, onSelect, selected, options } = props
+
   return (
     <LargeSelectContainer {...props} p={1}>
       <select
-        disabled={props.disabled}
-        onChange={event => props.onSelect && props.onSelect(event.target.value)}
-        value={props.selected}
+        disabled={disabled}
+        onChange={event => onSelect && onSelect(event.target.value)}
+        value={selected}
       >
-        {props.options.map(({ value, text }) => (
+        {options.map(({ value, text }) => (
           <option value={value} key={value}>
             {text}
           </option>
@@ -50,21 +52,21 @@ export const LargeSelect: SFC<SelectProps> = props => {
  * A small version of drop-down select menu
  */
 export const SelectSmall: SFC<SelectProps> = props => {
+  const { onSelect, selected, options, title } = props
+
   return (
     <SelectSmallContainer {...props}>
       <label>
         {props.title && (
           <Sans size="2" display="inline" mr={0.5}>
-            {props.title}:
+            {title}:
           </Sans>
         )}
         <select
-          onChange={event =>
-            props.onSelect && props.onSelect(event.target.value)
-          }
-          value={props.selected}
+          onChange={event => onSelect && onSelect(event.target.value)}
+          value={selected}
         >
-          {props.options.map(({ value, text }) => (
+          {options.map(({ value, text }) => (
             <option value={value} key={value}>
               {text}
             </option>

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -32,6 +32,7 @@ interface Option {
 }
 
 export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
+  description?: string
   disabled?: boolean
   error?: string
   onSelect?: (value) => void
@@ -44,7 +45,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
-  const { disabled, onSelect, options, selected, title } = props
+  const { description, disabled, onSelect, options, selected, title } = props
   const optionTags = computeOptionTags(options)
 
   return (
@@ -52,6 +53,11 @@ export const LargeSelect: SFC<SelectProps> = props => {
       {title && (
         <Serif mb="0.5" size="3">
           {title}
+        </Serif>
+      )}
+      {description && (
+        <Serif color="black60" mb="1" size="2">
+          {description}
         </Serif>
       )}
       <select

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -9,6 +9,7 @@ import {
   WidthProps,
 } from "styled-system"
 import { color, space } from "../../helpers"
+import { computeBorderColor } from "../Input"
 import { Sans } from "../Typography"
 
 const computeOptionTags = (options: Option[]): JSX.Element[] => {
@@ -128,15 +129,20 @@ const LargeSelectContainer = styled.div<SelectProps>`
     height: 40px;
     ${hideDefaultSkin};
     border: 1px solid
-      ${({ error }) => (error && color("red100")) || color("black10")};
+      ${({ disabled, error }) => color(computeBorderColor(disabled, !!error))};
     border-radius: 0;
     transition: border-color 0.25s;
     padding-right: ${space(1)}px;
     cursor: ${props => (props.disabled ? "default" : "pointer")};
     ${styledSpace};
-    &:hover,
+    &:hover {
+      border-color: ${({ disabled, error }) =>
+        color(computeBorderColor(disabled, !!error, "hover"))};
+    }
+
     &:focus {
-      border-color: ${color("purple100")};
+      border-color: ${({ disabled, error }) =>
+        color(computeBorderColor(disabled, !!error, "focus"))};
     }
   }
 

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -11,6 +11,20 @@ import {
 import { color, space } from "../../helpers"
 import { Sans } from "../Typography"
 
+const computeOptionTags = (options: Option[]): JSX.Element[] => {
+  const optionTags = options.map(option => {
+    const { text, value } = option
+
+    return (
+      <option value={value} key={value}>
+        {text}
+      </option>
+    )
+  })
+
+  return optionTags
+}
+
 interface Option {
   value: string
   text: string
@@ -30,16 +44,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  */
 export const LargeSelect: SFC<SelectProps> = props => {
   const { disabled, onSelect, selected, options } = props
-
-  const optionTags = options.map(option => {
-    const { text, value } = option
-
-    return (
-      <option value={value} key={value}>
-        {text}
-      </option>
-    )
-  })
+  const optionTags = computeOptionTags(options)
 
   return (
     <LargeSelectContainer {...props} p={1}>
@@ -59,16 +64,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
  */
 export const SelectSmall: SFC<SelectProps> = props => {
   const { onSelect, selected, options, title } = props
-
-  const optionTags = options.map(option => {
-    const { text, value } = option
-
-    return (
-      <option value={value} key={value}>
-        {text}
-      </option>
-    )
-  })
+  const optionTags = computeOptionTags(options)
 
   return (
     <SelectSmallContainer {...props}>

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -160,7 +160,8 @@ const LargeSelectContainer = styled.div<SelectProps>`
     height: 40px;
     ${hideDefaultSkin};
     border: 1px solid
-      ${({ disabled, error }) => color(computeBorderColor(disabled, !!error))};
+      ${({ disabled, error }) =>
+        color(computeBorderColor({ disabled, error: !!error }))};
     border-radius: 0;
     transition: border-color 0.25s;
     padding-right: ${space(1)}px;
@@ -168,12 +169,16 @@ const LargeSelectContainer = styled.div<SelectProps>`
     ${styledSpace};
     &:hover {
       border-color: ${({ disabled, error }) =>
-        color(computeBorderColor(disabled, !!error, "hover"))};
+        color(
+          computeBorderColor({ disabled, error: !!error, pseudo: "hover" })
+        )};
     }
 
     &:focus {
       border-color: ${({ disabled, error }) =>
-        color(computeBorderColor(disabled, !!error, "focus"))};
+        color(
+          computeBorderColor({ disabled, error: !!error, pseudo: "focus" })
+        )};
     }
   }
 

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -45,7 +45,7 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
-  const { description, disabled, onSelect, options, selected, title } = props
+  const { description, disabled, error, onSelect, options, selected, title } = props
   const optionTags = computeOptionTags(options)
 
   return (
@@ -67,6 +67,11 @@ export const LargeSelect: SFC<SelectProps> = props => {
       >
         {optionTags}
       </select>
+      {error && (
+        <Sans color="red100" mt="1" size="2">
+          {error}
+        </Sans>
+      )}
     </LargeSelectContainer>
   )
 }

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -10,7 +10,7 @@ import {
 } from "styled-system"
 import { color, space } from "../../helpers"
 import { computeBorderColor } from "../Input"
-import { Sans } from "../Typography"
+import { Sans, Serif } from "../Typography"
 
 const computeOptionTags = (options: Option[]): JSX.Element[] => {
   const optionTags = options.map(option => {
@@ -44,11 +44,16 @@ export interface SelectProps extends PositionProps, SpaceProps, WidthProps {
  * A large drop-down select menu
  */
 export const LargeSelect: SFC<SelectProps> = props => {
-  const { disabled, onSelect, selected, options } = props
+  const { disabled, onSelect, options, selected, title } = props
   const optionTags = computeOptionTags(options)
 
   return (
     <LargeSelectContainer {...props} p={1}>
+      {title && (
+        <Serif mb="0.5" size="3">
+          {title}
+        </Serif>
+      )}
       <select
         disabled={disabled}
         onChange={event => onSelect && onSelect(event.target.value)}
@@ -64,7 +69,7 @@ export const LargeSelect: SFC<SelectProps> = props => {
  * A small version of drop-down select menu
  */
 export const SelectSmall: SFC<SelectProps> = props => {
-  const { disabled, onSelect, selected, options, title } = props
+  const { disabled, onSelect, options, selected, title } = props
   const optionTags = computeOptionTags(options)
 
   return (


### PR DESCRIPTION
While working on something unrelated over on Volt, I had a chance to compare the `Select` component here with what we made before Palette even existed! I found that there was some work to do, so this PR is me taking a crack at it. The result of this PR would be me able to migrate code from Volt's select to Palette's.

So with this LargeSelect learns all sorts of cool new tricks:

* it supports title, description and error messages like Input
* it correctly computes it's border color the same way as Input
* it can be marked as required
* a name attribute can be supplied to the underlying select element
* the keys for the options try a little harder to be unique on the page

I've also updated the docs to more closely match Input so that all the various states can be played around with.

Here's some pretty pictures:

<img width="1611" alt="Screen Shot 2019-10-03 at 3 58 37 PM" src="https://user-images.githubusercontent.com/79799/66163794-bef5b500-e5f6-11e9-88d4-4ce2a56e3e49.png">
<img width="1611" alt="Screen Shot 2019-10-03 at 3 58 40 PM" src="https://user-images.githubusercontent.com/79799/66163795-bf8e4b80-e5f6-11e9-8749-9fc79b53aa3b.png">

