### PR TITLE
bug fix for Dialog

### DIFF
--- a/packages/palette/src/elements/Dialog/Dialog.tsx
+++ b/packages/palette/src/elements/Dialog/Dialog.tsx
@@ -14,6 +14,7 @@ interface DialogProps {
   detail?: React.ReactNode
   primaryCta: CtaProps
   secondaryCta?: CtaProps
+  onClose?: () => void
   show?: boolean
   title: string
 }
@@ -28,6 +29,7 @@ export const Dialog: SFC<DialogProps> = ({
   show = true,
   primaryCta,
   secondaryCta,
+  onClose = () => null,
 }) => {
   const StyledSans = styled(Sans)`
     transition: color 0.14s ease;
@@ -45,7 +47,7 @@ export const Dialog: SFC<DialogProps> = ({
   return (
     <Modal
       show={show}
-      onClose={primaryCta.action}
+      onClose={onClose}
       modalWidth={ModalWidth.Narrow}
       hideCloseButton
     >


### PR DESCRIPTION
Realizing that I have a flaw here with the dialog. Because it's a stopping point in the flow that usually used for 'confirm'/'cancel' interactions - with confirm being primary action and cancel secondary - we definitely don't want to call primary action with dialog close and in most cases we would not want to do any additional actions on close.


I should have a spec for that but not sure how to incorporate `State` for show in spec.