### PR TITLE
Export the Option interface

### DIFF
--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -28,7 +28,7 @@ const computeOptionTags = (options: Option[], name?: string): JSX.Element[] => {
   return optionTags
 }
 
-interface Option {
+export interface Option {
   value: string
   text: string
 }


### PR DESCRIPTION
Users of this component are going to want to use this interface, so we might as well export it.