### PR TITLE
Allow attributes to be passed to checkbox for testing

### DIFF
--- a/packages/palette/src/elements/Checkbox/Checkbox.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.tsx
@@ -57,19 +57,26 @@ export class Checkbox extends React.Component<CheckboxProps> {
   }
 
   render() {
-    const { selected, children, error, disabled, hover } = this.props
+    const {
+      selected,
+      children,
+      error,
+      disabled,
+      hover,
+      onSelect,
+      ...other
+    } = this.props
 
     return (
       <Container
         className={hover && "hover"}
         my={0.5}
-        onClick={() =>
-          !disabled && this.props.onSelect && this.props.onSelect(!selected)
-        }
+        onClick={() => !disabled && onSelect && onSelect(!selected)}
         selected={selected}
         hover={hover}
         disabled={disabled}
         alignItems="center"
+        {...other}
       >
         <CheckboxButton
           border={1}


### PR DESCRIPTION
@sweir27 and @ds300 are working on cypress tests and needed a way to target the checkbox in a test. Cypress recommends putting something like `data-test="123"` on an element to enable targeting it for a test, but the checkbox wasn't passing down attributes to the element. 

This adds a spread to pass down unused props to the wrapper element. The same pattern is already used in the radio button.