### PR TITLE
PURCHASE-1518: Update Bell and BellFill Icons in Palette

### DIFF
--- a/packages/palette/src/svgs/BellFillIcon.ios.tsx
+++ b/packages/palette/src/svgs/BellFillIcon.ios.tsx
@@ -6,7 +6,7 @@ import { Icon, IconProps } from "./Icon"
 /** BellFillIcon */
 export const BellFillIcon: React.SFC<IconProps> = props => {
   return (
-    <Icon {...props} viewBox="0 0 18 18">
+    <Icon {...props} width="14px" height="14px" viewBox="0 0 18 18">
       <Path
         d="M15.39 12.69A10.08 10.08 0 0 1 13.5 7V5.5a4.5 4.5 0 0 0-9 0V7a10.08 10.08 0 0 1-1.89 5.69.51.51 0 0 0-.06.53.5.5 0 0 0 .45.28h3.37a2.67 2.67 0 0 0-.12.75 2.75 2.75 0 0 0 5.5 0 2.67 2.67 0 0 0-.12-.75H15a.5.5 0 0 0 .45-.28.51.51 0 0 0-.06-.53zm-4.64 1.56a1.75 1.75 0 0 1-3.5 0 1.73 1.73 0 0 1 .18-.75h3.14c.116.233.177.49.18.75z"
         fill={color(props.fill)}

--- a/packages/palette/src/svgs/BellFillIcon.tsx
+++ b/packages/palette/src/svgs/BellFillIcon.tsx
@@ -5,7 +5,7 @@ import { Icon, IconProps } from "./Icon"
 /** BellFillIcon */
 export const BellFillIcon: React.SFC<IconProps> = props => {
   return (
-    <Icon {...props} viewBox="0 0 18 18">
+    <Icon {...props} width="14px" height="14px" viewBox="0 0 18 18">
       <title>unwatch lot</title>
       <path
         d="M15.39 12.69A10.08 10.08 0 0 1 13.5 7V5.5a4.5 4.5 0 0 0-9 0V7a10.08 10.08 0 0 1-1.89 5.69.51.51 0 0 0-.06.53.5.5 0 0 0 .45.28h3.37a2.67 2.67 0 0 0-.12.75 2.75 2.75 0 0 0 5.5 0 2.67 2.67 0 0 0-.12-.75H15a.5.5 0 0 0 .45-.28.51.51 0 0 0-.06-.53zm-4.64 1.56a1.75 1.75 0 0 1-3.5 0 1.73 1.73 0 0 1 .18-.75h3.14c.116.233.177.49.18.75z"

--- a/packages/palette/src/svgs/BellIcon.ios.tsx
+++ b/packages/palette/src/svgs/BellIcon.ios.tsx
@@ -6,7 +6,7 @@ import { Icon, IconProps } from "./Icon"
 /** BellIcon */
 export const BellIcon: React.SFC<IconProps> = props => {
   return (
-    <Icon {...props} viewBox="0 0 18 18">
+    <Icon {...props} width="14px" height="14px" viewBox="0 0 18 18">
       <Path
         d="M15.39 12.69A10.08 10.08 0 0 1 13.5 7V5.5a4.5 4.5 0 0 0-9 0V7a10.08 10.08 0 0 1-1.89 5.69.51.51 0 0 0-.06.53.5.5 0 0 0 .45.28h3.37a2.67 2.67 0 0 0-.12.75 2.75 2.75 0 0 0 5.5 0 2.67 2.67 0 0 0-.12-.75H15a.5.5 0 0 0 .45-.28.51.51 0 0 0-.06-.53zm-4.64 1.56a1.75 1.75 0 0 1-3.5 0 1.73 1.73 0 0 1 .18-.75h3.14c.116.233.177.49.18.75zM3.94 12.5A11 11 0 0 0 5.5 7V5.5a3.5 3.5 0 0 1 7 0V7a11 11 0 0 0 1.56 5.5H3.94z"
         fill={color(props.fill)}

--- a/packages/palette/src/svgs/BellIcon.tsx
+++ b/packages/palette/src/svgs/BellIcon.tsx
@@ -5,7 +5,7 @@ import { Icon, IconProps } from "./Icon"
 /** BellIcon */
 export const BellIcon: React.SFC<IconProps> = props => {
   return (
-    <Icon {...props} viewBox="0 0 18 18">
+    <Icon {...props} width="14px" height="14px" viewBox="0 0 18 18">
       <title>watch lot</title>
       <path
         d="M15.39 12.69A10.08 10.08 0 0 1 13.5 7V5.5a4.5 4.5 0 0 0-9 0V7a10.08 10.08 0 0 1-1.89 5.69.51.51 0 0 0-.06.53.5.5 0 0 0 .45.28h3.37a2.67 2.67 0 0 0-.12.75 2.75 2.75 0 0 0 5.5 0 2.67 2.67 0 0 0-.12-.75H15a.5.5 0 0 0 .45-.28.51.51 0 0 0-.06-.53zm-4.64 1.56a1.75 1.75 0 0 1-3.5 0 1.73 1.73 0 0 1 .18-.75h3.14c.116.233.177.49.18.75zM3.94 12.5A11 11 0 0 0 5.5 7V5.5a3.5 3.5 0 0 1 7 0V7a11 11 0 0 0 1.56 5.5H3.94z"

--- a/packages/palette/src/svgs/Icon.ios.tsx
+++ b/packages/palette/src/svgs/Icon.ios.tsx
@@ -42,6 +42,6 @@ export const Icon = styled(Svg)<IconProps>`
 
 Icon.defaultProps = {
   fill: "black100",
-  height: "16px",
-  width: "16px",
+  height: "18px",
+  width: "18px",
 }

--- a/packages/palette/src/svgs/Icon.ios.tsx
+++ b/packages/palette/src/svgs/Icon.ios.tsx
@@ -42,6 +42,6 @@ export const Icon = styled(Svg)<IconProps>`
 
 Icon.defaultProps = {
   fill: "black100",
-  height: "18px",
-  width: "18px",
+  height: "16px",
+  width: "16px",
 }


### PR DESCRIPTION
# [PURCHASE-1518] Update Bell and BellFill Icons in Palette

Adjusted the height by a few pixels on the Bell and BellFill icons because they were too tall compared to the other icons on the iOS Artwork Page.

__Before:__
<img width="350" alt="Screen Shot 2019-10-11 at 3 15 04 PM" src="https://user-images.githubusercontent.com/5643895/66678838-c8a49b80-ec3a-11e9-8f88-1c5ba1ea2b60.png">

__After:__
<img width="350" alt="Screen Shot 2019-10-15 at 2 15 28 PM" src="https://user-images.githubusercontent.com/5643895/66860502-4e865680-ef5b-11e9-8123-55818fa57315.png">


[PURCHASE-1518]: https://artsyproduct.atlassian.net/browse/PURCHASE-1518