### PR TITLE
Adds Tags container animation

### DIFF
--- a/packages/palette/src/elements/Tags/Tags.tsx
+++ b/packages/palette/src/elements/Tags/Tags.tsx
@@ -30,9 +30,7 @@ export const Tags: React.FC<TagsProps> = ({
   // after animating AnimatingBox height set back height to auto (to handle screen resize etc.)
   useEffect(() => {
     animatingBox.current.addEventListener("transitionend", e => {
-      const isAnimatingBoxTransition = Array.from(
-        (e.target as HTMLTextAreaElement).classList
-      ).some(elClass => elClass.indexOf("AnimatingBox") > -1)
+      const isAnimatingBoxTransition = e.target === animatingBox.current
       if (isAnimatingBoxTransition) {
         setBoxHeight("auto")
       }

--- a/packages/palette/src/elements/Tags/Tags.tsx
+++ b/packages/palette/src/elements/Tags/Tags.tsx
@@ -51,18 +51,14 @@ export const Tags: React.FC<TagsProps> = ({
    */
   const toggleMore = () => {
     const BORDER_OFFSET = 2
-    const oldHeight = flexContainer.current.offsetHeight
-      ? flexContainer.current.offsetHeight - BORDER_OFFSET
-      : "auto"
+    const oldHeight = flexContainer.current.offsetHeight - BORDER_OFFSET
     setBoxHeight(oldHeight + "px")
 
     setExpanded(!expanded)
 
     // wait for a tick
     setTimeout(() => {
-      const newHeight = flexContainer.current.offsetHeight
-        ? flexContainer.current.offsetHeight - BORDER_OFFSET
-        : "auto"
+      const newHeight = flexContainer.current.offsetHeight - BORDER_OFFSET
       setBoxHeight(`${newHeight}px`)
     }, 10)
   }


### PR DESCRIPTION
Fixes [PURCHASE-1615](https://artsyproduct.atlassian.net/browse/PURCHASE-1615)

Mostly inspired from [Collapse component](https://github.com/artsy/palette/blob/master/packages/palette/src/elements/Collapse/Collapse.tsx) H/T @ds300

I first struggled to find a way to animate the height of a flexbox that has `flex-wrap` to wrap its element using only css but looked at the collapse component and realized that approach is perfectly applicable here but open to other simpler ideas.

Also I don't think this causes any problem with **SSR** since the height is `auto` by default and only changes when there is a user interaction but I might be missing something.

<details>
  <summary>screenshot</summary>

![tags-animation](https://user-images.githubusercontent.com/687513/67714671-c1052680-f99e-11e9-9d5e-c089e1b372eb.gif)


</details>

TODO: 
- [x] Add `.ios.tsx` file (in https://github.com/artsy/palette/commit/ddf783a9bde4f4c6bc650a30f5d95c0534450213)