### PR TITLE
Add className type to typography components

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "yarn workspaces run test",
     "lint": "yarn workspaces run lint",
     "compile-palette": "yarn workspace @artsy/palette compile",
-    "type-check": "yarn compile-palette && yarn workspaces run type-check",
+    "type-check": "yarn compile-palette && yarn workespace @artsy/palette run type-declarations && yarn workspaces run type-check",
     "build-docs": "yarn compile-palette && yarn workspace artsy-palette-docs build",
     "storybook": "yarn workspace @artsy/palette storybook",
     "visual-test": "yarn workspace @artsy/palette visual-test"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "yarn workspaces run test",
     "lint": "yarn workspaces run lint",
     "compile-palette": "yarn workspace @artsy/palette compile",
-    "type-check": "yarn compile-palette && yarn workespace @artsy/palette run type-declarations && yarn workspaces run type-check",
+    "type-check": "yarn compile-palette && yarn workspace @artsy/palette run type-declarations && yarn workspaces run type-check",
     "build-docs": "yarn compile-palette && yarn workspace artsy-palette-docs build",
     "storybook": "yarn workspace @artsy/palette storybook",
     "visual-test": "yarn workspace @artsy/palette visual-test"

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -150,6 +150,7 @@ function _selectFontFamilyType(weight?: null | FontWeights, italic?: boolean) {
 }
 
 interface StyledTextProps extends Partial<TextProps> {
+  className?: string
   size: string | string[]
   weight?: null | FontWeights
   italic?: boolean

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -78,6 +78,7 @@ export interface TextProps
     StyledSystemDisplayProps,
     TextAlignProps,
     VerticalAlignProps {
+  className?: string
   fontFamily?: string
   style?: CSSProperties
   /**
@@ -150,7 +151,6 @@ function _selectFontFamilyType(weight?: null | FontWeights, italic?: boolean) {
 }
 
 interface StyledTextProps extends Partial<TextProps> {
-  className?: string
   size: string | string[]
   weight?: null | FontWeights
   italic?: boolean


### PR DESCRIPTION
A minor update to fix some type failures on the docs site. Also I noticed the `type-check` command didn't do everything it needed if the types for palette changed that the docs site relied on.  