### PR TITLE
Upgrade `react-lazy-load-image-component` off of beta

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -119,7 +119,7 @@
     "d3-shape": "^1.3.5",
     "luxon": "^1.15",
     "rc-slider": "^8.6.2",
-    "react-lazy-load-image-component": "^1.4.0-beta.1",
+    "react-lazy-load-image-component": "^1.4.0",
     "react-live": "^1.12.0",
     "react-powerplug": "^1.0.0",
     "react-spring": "^8.0.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18459,10 +18459,10 @@ react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-lazy-load-image-component@^1.4.0-beta.1:
-  version "1.4.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.0-beta.1.tgz#9728b2de583cfee2146f4e81db60562b63fe866f"
-  integrity sha512-0hsmYC1aVbs2FiPaGli/kLBy/adrZWVDAond/vYZZA1i1pfA+pltT6TrIOmV1hzGhVwNHohkSzDqXvlgVelciQ==
+react-lazy-load-image-component@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.0.tgz#10c73ca46afc039864b395191d6b54a46a673b60"
+  integrity sha512-o/L93CyJVvXPuA2P/ouUZI7ZXJRrdE/eqP45AH5/SakOU0bzAk2ZP6qNT/WaaXhf+JtE7hhjXxMr7KGsLNX64w==
   dependencies:
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"


### PR DESCRIPTION
bumping react-lazy-load-image-component dependency to latest version update (from the current beta it's on)