### PR TITLE
Fix lazy load double download issue by updating lib

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -119,7 +119,7 @@
     "d3-shape": "^1.3.5",
     "luxon": "^1.15",
     "rc-slider": "^8.6.2",
-    "react-lazy-load-image-component": "^1.4.0",
+    "react-lazy-load-image-component": "^1.4.1-beta.0",
     "react-live": "^1.12.0",
     "react-powerplug": "^1.0.0",
     "react-spring": "^8.0.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18459,10 +18459,10 @@ react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-lazy-load-image-component@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.0.tgz#10c73ca46afc039864b395191d6b54a46a673b60"
-  integrity sha512-o/L93CyJVvXPuA2P/ouUZI7ZXJRrdE/eqP45AH5/SakOU0bzAk2ZP6qNT/WaaXhf+JtE7hhjXxMr7KGsLNX64w==
+react-lazy-load-image-component@^1.4.1-beta.0:
+  version "1.4.1-beta.0"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.4.1-beta.0.tgz#4b47fcda23b40412bc03f66442e419a23e5cae9d"
+  integrity sha512-SFYu44wAMRpN9afyoeerlSprjl3K/aokueZgTW/qbqmxkEbRLUSWubr5dM1cXEAcLxFruqGdjswzB8YI3KaPBQ==
   dependencies:
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"


### PR DESCRIPTION
See https://github.com/Aljullu/react-lazy-load-image-component/issues/50

TL;DR

react-lazy-load-image-component was sometimes double downloading images (especially on chrome) because an optimization that changed the src and retriggered the download.

I thought another changed fixed it, but it was hard to reproduce due to the need to link the library from reaction through force. 