### PR TITLE
Deploy docs to s3 on master build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ workflows:
       - yarn/run:
           name: deploy-docs
           script: deploy-docs
+          context: hokusai
           requires:
             - yarn/auto-release
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,3 +48,11 @@ workflows:
             - yarn/lint
             - yarn/type-check
             - yarn/update-cache
+      - yarn/run:
+          name: deploy-docs
+          script: deploy-docs
+          requires:
+            - yarn/auto-release
+          filters:
+            branches:
+              only: master

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build-docs": "yarn compile-palette && yarn workspace artsy-palette-docs build",
     "compile-palette": "yarn workspace @artsy/palette compile",
-    "deploy-docs": "yarn workspace artsy-palette-docs deploy",
+    "deploy-docs": "yarn compile-palette && yarn workspace artsy-palette-docs deploy",
     "lint": "yarn workspaces run lint",
     "start": "concurrently --raw --kill-others 'yarn workspace @artsy/palette watch' 'yarn workspace artsy-palette-docs start'",
     "storybook": "yarn workspace @artsy/palette storybook",


### PR DESCRIPTION
This is a follow-up to https://github.com/artsy/palette/pull/629

cc @damassi 

This sets up CI to deploy the docs (assuming that the `auto-release` set succeeds). 

I'm assuming we need to add some env vars to this as well?

## TODO

- [x] Add credentials for pushing to s3