### PR TITLE
[Spinner] Adds delay prop for visibility

### DIFF
--- a/packages/palette/src/elements/Spinner/Spinner.shared.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.shared.tsx
@@ -1,6 +1,8 @@
 import { Color } from "../../Theme"
 
 export interface SpinnerProps {
+  /** Delay before spinner appears */
+  delay?: number
   /** Width of the spinner */
   width?: number
   /** Height of the spinner */

--- a/packages/palette/src/elements/Spinner/Spinner.story.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.story.tsx
@@ -1,0 +1,12 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Spinner } from "./Spinner"
+
+storiesOf("Components/Spinner", module)
+  .add("Default Spinner", () => {
+    return <Spinner />
+  })
+
+  .add("Spinner with delayed show", () => {
+    return <Spinner delay={1000} />
+  })

--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -10,15 +10,22 @@ const spin = keyframes`
   }
 `
 
+const fadeIn = keyframes`
+    from { opacity: 0; }
+    to   { opacity: 1; }
+`
+
 /** Generic Spinner component */
 export const Spinner: React.FC<SpinnerProps> = props => {
   const [show, setShow] = useState(props.delay === 0)
 
   useEffect(() => {
-    if (props.delay > 0) {
-      setTimeout(() => {
-        setShow(true)
-      }, props.delay)
+    const timeout = setTimeout(() => {
+      setShow(true)
+    }, props.delay)
+
+    return () => {
+      clearTimeout(timeout)
     }
   }, [])
 
@@ -30,7 +37,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
 }
 
 const SpinnerBar = styled.div<SpinnerProps>`
-  animation: ${spin} 1s infinite linear;
+  animation: ${spin} 1s infinite linear, ${fadeIn} 0.4s linear;
   position: absolute;
 
   ${props => {

--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -1,5 +1,5 @@
 // @ts-ignore
-import React from "react"
+import React, { useEffect, useState } from "react"
 import styled, { keyframes } from "styled-components"
 import { color } from "../../helpers"
 import { getSize, SpinnerProps } from "./Spinner.shared"
@@ -11,7 +11,25 @@ const spin = keyframes`
 `
 
 /** Generic Spinner component */
-export const Spinner = styled.div<SpinnerProps>`
+export const Spinner: React.FC<SpinnerProps> = props => {
+  const [show, setShow] = useState(props.delay === 0)
+
+  useEffect(() => {
+    if (props.delay > 0) {
+      setTimeout(() => {
+        setShow(true)
+      }, props.delay)
+    }
+  }, [])
+
+  if (!show) {
+    return null
+  }
+
+  return <SpinnerBar {...props} />
+}
+
+const SpinnerBar = styled.div<SpinnerProps>`
   animation: ${spin} 1s infinite linear;
   position: absolute;
 
@@ -29,6 +47,7 @@ export const Spinner = styled.div<SpinnerProps>`
 `
 
 Spinner.defaultProps = {
+  delay: 0,
   width: 25,
   height: 6,
   color: "black100",


### PR DESCRIPTION
There's a lot of content around Artsy.net right now that is rendered by a QueryRender, which by default uses a spinner. However, often we make a request to MP but then decide _not_ to render the content, leaving the UI jumpy as the spinner shows and hides. 

Also added a quick 400ms fade in to make the transition less jarring. 

This adds a new `delay` prop which will delay the rendering until `x` milliseconds. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.0.1-canary.640.9679.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.0.1-canary.640.9679.0
  # or 
  yarn add @artsy/palette@7.0.1-canary.640.9679.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
