### PR TITLE
Small dropdown arrow is misaligned

### DIFF
--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -232,6 +232,7 @@ const SelectSmallContainer = styled.div<SelectProps>`
     ${width};
     ${maxWidth};
     ${minWidth};
+    margin: 0;
 
     &:hover {
       background-color: ${color("black30")};


### PR DESCRIPTION
# [PURCHASE-1779]

the Sort: dropdown arrow is displaying oddly/in incorrect placement on Chrome (iPhone X)

https://files.slack.com/files-pri/T02531TU5-FTC9HD19P/image.png

__Before:__
<img width="240" alt="Screen Shot 2020-02-21 at 3 20 04 PM" src="https://user-images.githubusercontent.com/5643895/75068890-102b1600-54be-11ea-8294-5bb3b6faa989.png">

__After:__
<img width="240" alt="Screen Shot 2020-02-21 at 3 19 15 PM" src="https://user-images.githubusercontent.com/5643895/75068920-1f11c880-54be-11ea-9d0e-b6d5e8e6eee0.png">



[PURCHASE-1779]: https://artsyproduct.atlassian.net/browse/PURCHASE-1779