### PR TITLE
Add new context w/ proper permissions to upload to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ workflows:
       - yarn/run:
           name: deploy-docs
           script: deploy-docs
-          context: hokusai
+          context: palette-docs-upload
           requires:
             - auto/publish
           filters:


### PR DESCRIPTION
cc @eessex, @damassi 

I created a new IAM role w/ write-only permissions to palette's S3 bucket. This should fix our problem w/ master failing to upload site artifacts.  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.1.2-canary.643.9742.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.1.2-canary.643.9742.0
  # or 
  yarn add @artsy/palette@7.1.2-canary.643.9742.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
