### PR TITLE
Disable acl to bypass requiring the addition of extra permissions

### DIFF
--- a/packages/palette-docs/gatsby-config.js
+++ b/packages/palette-docs/gatsby-config.js
@@ -62,6 +62,7 @@ module.exports = {
       resolve: `gatsby-plugin-s3`,
       options: {
         bucketName: "artsy-palette",
+        acl: null,
       },
     },
     {


### PR DESCRIPTION
Adding `acl: null` to not require a special ACL permissions grant in IAM. 

I also updated the S3 permissions slightly. 

See #643 for more context. 