### PR TITLE
Re-add acl permissions to avoid publishing private assets

### DIFF
--- a/packages/palette-docs/gatsby-config.js
+++ b/packages/palette-docs/gatsby-config.js
@@ -62,7 +62,6 @@ module.exports = {
       resolve: `gatsby-plugin-s3`,
       options: {
         bucketName: "artsy-palette",
-        acl: null,
       },
     },
     {


### PR DESCRIPTION
This is technically a revert of #644. When the publish was successful files in the bucket were private. I manually set them to public, but I'm not certain they wouldn't default to private on the next publish. 

I've updated the permissions for this set to be able to control the ACL rules for its bucket, just to ensure the proper permissions are provided on deployments.  

At least now we know it's deploying correctly though!

cc @eessex 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.1.2-canary.645.9773.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.1.2-canary.645.9773.0
  # or 
  yarn add @artsy/palette@7.1.2-canary.645.9773.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
