### PR TITLE
[Spinner] Remove fade

### DIFF
--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -10,11 +10,6 @@ const spin = keyframes`
   }
 `
 
-const fadeIn = keyframes`
-    from { opacity: 0; }
-    to   { opacity: 1; }
-`
-
 /** Generic Spinner component */
 export const Spinner: React.FC<SpinnerProps> = props => {
   const [show, setShow] = useState(props.delay === 0)
@@ -37,7 +32,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
 }
 
 const SpinnerBar = styled.div<SpinnerProps>`
-  animation: ${spin} 1s infinite linear, ${fadeIn} 0.4s linear;
+  animation: ${spin} 1s infinite linear;
   position: absolute;
 
   ${props => {


### PR DESCRIPTION
Added last week to smooth out QueryRenderer appearance in reaction but turns out it's not needed with new delay prop. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.1.2-canary.647.9808.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.1.2-canary.647.9808.0
  # or 
  yarn add @artsy/palette@7.1.2-canary.647.9808.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
