### PR TITLE
Move docsearch CSS to beginning of head so that our custom styles override it

### DIFF
--- a/packages/palette-docs/plugins/gatsby-plugin-local-algolia-docsearch/gatsby-ssr.js
+++ b/packages/palette-docs/plugins/gatsby-plugin-local-algolia-docsearch/gatsby-ssr.js
@@ -28,3 +28,17 @@ exports.onRenderBody = (
     />,
   ])
 }
+
+exports.onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) => {
+  const headComponents = getHeadComponents()
+  // Move `docsearch-css` to the top so that our custom styles override it.
+  headComponents.sort((x, y) => {
+    if (x.key === "docsearch-css") {
+      return -1
+    } else if (y.key === "docsearch-css") {
+      return 1
+    }
+    return 0
+  })
+  replaceHeadComponents(headComponents)
+}


### PR DESCRIPTION
In #633, I overrode some styles to make the search results look more on-brand. Unfortunately, they only worked locally, as the production build placed the docsearch CSS *after* the overrides. 😢 

This PR adds an `onPreRenderHTML` handler to our custom plugin, to bubble the `docsearch-css` styles to the beginning of the `head` element. Thanks to [the Gatsby docs](https://www.gatsbyjs.org/docs/ssr-apis/#onPreRenderHTML) for a clear example on how to do this!

The search results before these changes (note the algolia-blue underline):

![image](https://user-images.githubusercontent.com/1627089/76250109-a11a2500-6212-11ea-8b1d-d6487d585d0b.png)

The search results after these changes (note the artsy-purple underline):

![image](https://user-images.githubusercontent.com/1627089/76250049-834cc000-6212-11ea-8534-5880511ea6db.png)
