### PR TITLE
Add name prop to TextArea

### DIFF
--- a/packages/palette-docs/content/docs/elements/inputs/TextArea.mdx
+++ b/packages/palette-docs/content/docs/elements/inputs/TextArea.mdx
@@ -5,13 +5,18 @@ name: TextArea
 ## Basic
 
 <Playground>
-  <TextArea placeholder="Start typing..." onChange={console.log} />
+  <TextArea
+    name="basic-text-area"
+    placeholder="Start typing..."
+    onChange={console.log}
+  />
 </Playground>
 
 ## Required
 
 <Playground>
   <TextArea
+    name="required-text-area"
     title="Note"
     placeholder="Start typing..."
     onChange={console.log}
@@ -26,6 +31,7 @@ name: TextArea
     {({ on, toggle }) => (
       <>
         <TextArea
+          name="error-text-area"
           error={on ? "There was an error" : null}
           defaultValue="This is some text"
           onChange={console.log}
@@ -44,6 +50,7 @@ name: TextArea
 
 <Playground title="With title">
   <TextArea
+    name="title-text-area"
     title="Note"
     error="There was an error"
     defaultValue="This is some text"
@@ -55,6 +62,7 @@ name: TextArea
 
 <Playground>
   <TextArea
+    name="description-text-area"
     title="Note"
     description="For your security do not share personal information."
     defaultValue="This is some text"
@@ -66,6 +74,7 @@ name: TextArea
 
 <Playground>
   <TextArea
+    name="limited-text-area"
     title="Note"
     description="For your security do not share personal information."
     defaultValue="This is some text"
@@ -81,6 +90,7 @@ name: TextArea
     {({ on, toggle }) => (
       <>
         <TextArea
+          name="limiting-with-error-text-area"
           error={on ? "There was an error" : null}
           defaultValue="This is some text"
           characterLimit="322"

--- a/packages/palette/src/elements/TextArea/TextArea.story.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.story.tsx
@@ -1,0 +1,27 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { TextArea } from "./TextArea"
+
+const defaultProps = {
+  placeholder: "Start typing...",
+}
+
+storiesOf("Components/TextArea", module)
+  .add("TextArea", () => {
+    return <TextArea {...defaultProps} />
+  })
+  .add("TextArea + title", () => {
+    return <TextArea {...defaultProps} title="Note" />
+  })
+  .add("TextArea + title + required", () => {
+    return <TextArea {...defaultProps} title="Note" required />
+  })
+  .add("TextArea + error", () => {
+    return <TextArea {...defaultProps} error="Something went wrong." />
+  })
+  .add("TextArea + character limit", () => {
+    return <TextArea {...defaultProps} characterLimit={10} />
+  })
+  .add("TextArea + name", () => {
+    return <TextArea {...defaultProps} name="my-text-area" />
+  })

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -39,9 +39,10 @@ export interface TextAreaProps {
   onChange?(result: TextAreaChange): void
 
   // forwarded to the styled.input
+  className?: string
   defaultValue?: string
   innerRef?: React.RefObject<HTMLTextAreaElement>
-  className?: string
+  name?: string
   placeholder?: string
 }
 

--- a/packages/palette/src/elements/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/palette/src/elements/TextArea/__tests__/TextArea.test.tsx
@@ -165,4 +165,9 @@ describe("TextArea", () => {
       exceedsCharacterLimit: false,
     })
   })
+
+  it("renders the name if supplied", () => {
+    const wrapper = getWrapper({ name: "my-input" })
+    expect(wrapper.find("textarea[name='my-input']")).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
This PR adds a `name` prop to the TextArea input. 

If a client wasn't using TypeScript, they would have no problem passing a `name` into a `<TextArea>`. The `name` would be attached to the `textarea` element in the DOM, just as they'd expect. However, if the client was using TypeScript, they would get a compilation error. This PR doesn't change how the name gets emitted in the DOM - it just allows for TypeScript clients to pass it in.

## Why?

Adding the `name` property enables for easier testing. `capybara` tests have an idiom where you fill in fields in a form with `fill_in 'field_name', with: value` - but they expect a `name` attribute on the field. Enzyme tests also become easier, as elements can be targeted via a selector like `.find('textarea[name="my-textarea"])`.

It also enables us to use `<label for="name">` elements to describe a textarea for accessibility - though this PR **does not** include modifying the `title` prop to be emitted as a `label` element. 

## Potential followup items

* Modify the `title` prop to be emitted as a `<label for="` element
* Modify the `TextAreaProps` to `extend React.HTMLProps<HTMLTextAreaElement>` similar to [how the `Input` component is built](https://github.com/artsy/palette/blob/master/packages/palette/src/elements/Input/Input.tsx#L9). This is not totally trivial, as `HTMLTextAreaElement` includes a `title` prop of a different type than ours. 