### PR TITLE
Add the ability to have a secondary action on the toggle

### DIFF
--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -21,7 +21,7 @@ storiesOf("Components/Toggle", module)
   .add("Toggle", () => {
     return (
       <Box width="350px">
-        <Toggle expanded>
+        <Toggle label="Test" expanded>
           <h1>Hello world</h1>
         </Toggle>
       </Box>
@@ -30,7 +30,7 @@ storiesOf("Components/Toggle", module)
   .add("Toggle disabled", () => {
     return (
       <Box width="350px">
-        <Toggle expanded disabled>
+        <Toggle label="Test" expanded disabled>
           <h1>Hello world</h1>
         </Toggle>
       </Box>
@@ -39,7 +39,7 @@ storiesOf("Components/Toggle", module)
   .add("Toggle with secondary action", () => {
     return (
       <Box width="350px">
-        <Toggle expanded renderSecondaryAction={SecondaryAction}>
+        <Toggle label="Test" expanded renderSecondaryAction={SecondaryAction}>
           <h1>Hello world</h1>
         </Toggle>
       </Box>
@@ -48,7 +48,12 @@ storiesOf("Components/Toggle", module)
   .add("Toggle disabled with secondary action", () => {
     return (
       <Box width="350px">
-        <Toggle expanded disabled renderSecondaryAction={SecondaryAction}>
+        <Toggle
+          label="Test"
+          expanded
+          disabled
+          renderSecondaryAction={SecondaryAction}
+        >
           <h1>Hello world</h1>
         </Toggle>
       </Box>

--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -1,0 +1,38 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Box } from "../Box"
+import { Link } from "../Link"
+import { Toggle } from "./Toggle"
+
+const SecondaryAction = () => {
+  return (
+    <Link
+      onClick={e => {
+        alert("hello world!")
+        e.stopPropagation()
+      }}
+    >
+      Alert
+    </Link>
+  )
+}
+
+storiesOf("Components/Toggle", module)
+  .add("Toggle", () => {
+    return (
+      <Box width="350px">
+        <Toggle expanded>
+          <h1>Hello world</h1>
+        </Toggle>
+      </Box>
+    )
+  })
+  .add("Toggle with secondary action", () => {
+    return (
+      <Box width="350px">
+        <Toggle expanded renderSecondaryAction={SecondaryAction}>
+          <h1>Hello world</h1>
+        </Toggle>
+      </Box>
+    )
+  })

--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -27,10 +27,28 @@ storiesOf("Components/Toggle", module)
       </Box>
     )
   })
+  .add("Toggle disabled", () => {
+    return (
+      <Box width="350px">
+        <Toggle expanded disabled>
+          <h1>Hello world</h1>
+        </Toggle>
+      </Box>
+    )
+  })
   .add("Toggle with secondary action", () => {
     return (
       <Box width="350px">
         <Toggle expanded renderSecondaryAction={SecondaryAction}>
+          <h1>Hello world</h1>
+        </Toggle>
+      </Box>
+    )
+  })
+  .add("Toggle disabled with secondary action", () => {
+    return (
+      <Box width="350px">
+        <Toggle expanded disabled renderSecondaryAction={SecondaryAction}>
           <h1>Hello world</h1>
         </Toggle>
       </Box>

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -9,6 +9,13 @@ export interface ToggleProps {
   expanded?: boolean
   label?: string
   textSize?: SansSize
+  /**
+   * Adds the ability to render a set of components by the chevron for
+   * secondary actions such as clearing filters
+   */
+  renderSecondaryAction?: (
+    toggleProps: Pick<ToggleProps, "disabled" | "expanded" | "textSize">
+  ) => JSX.Element
 }
 
 export interface ToggleState {
@@ -45,7 +52,7 @@ export class Toggle extends React.Component<ToggleProps> {
 
   render() {
     const { disabled, expanded } = this.state
-    const { children, label, textSize } = this.props
+    const { children, label, textSize, renderSecondaryAction } = this.props
 
     return (
       <Flex width="100%" flexDirection="column" pb={2}>
@@ -60,15 +67,17 @@ export class Toggle extends React.Component<ToggleProps> {
             >
               {label}
             </Sans>
-            {!disabled && (
-              <Flex justifyContent="right">
-                <ChevronIcon
-                  direction={expanded ? "up" : "down"}
-                  width={12}
-                  height={12}
-                />
-              </Flex>
-            )}
+            <Flex justifyContent="right" alignItems="center">
+              {renderSecondaryAction &&
+                renderSecondaryAction({ disabled, expanded, textSize })}
+              <ChevronIcon
+                style={{ visibility: disabled ? "hidden" : "visible" }}
+                direction={expanded ? "up" : "down"}
+                width={12}
+                height={12}
+                ml={1}
+              />
+            </Flex>
           </Flex>
         </Header>
         {expanded && children && (


### PR DESCRIPTION
This adds the ability to inject secondary action on the toggle. The secondary action is a render function that will render _something_ beside the chevron icon. 

<img width="385" alt="image" src="https://user-images.githubusercontent.com/3087225/77326173-cf5a3300-6cef-11ea-8666-a489ca1d3ce6.png">

This will initially be used for [PURCHASE-1841](https://artsyproduct.atlassian.net/browse/PURCHASE-1841). 

![image](https://user-images.githubusercontent.com/3087225/77326475-3ed02280-6cf0-11ea-9e60-75d2ac609d60.png)

The `clear` link here would be the secondary action. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.4.0-canary.654.9952.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.4.0-canary.654.9952.0
  # or 
  yarn add @artsy/palette@7.4.0-canary.654.9952.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
