### PR TITLE
Use a stable image for CSSGrid story.

### DIFF
--- a/packages/palette/src/elements/CSSGrid/CSSGrid.story.tsx
+++ b/packages/palette/src/elements/CSSGrid/CSSGrid.story.tsx
@@ -19,7 +19,7 @@ storiesOf("Components/CSSGrid", module).add(
         {[1, 2, 3, 4, 5, 6, 7, 8].map(i => {
           return (
             <Image
-              src="https://picsum.photos/140/100/?random"
+              src="https://picsum.photos/id/1025/140/100/"
               width={[100, 120, 140]}
               key={i}
             />


### PR DESCRIPTION
Because we were using a random image from picsum.com for the CSS Grid story, every build resulted in visual diffs that we had to approve.

This PR specifies the objectively best image available on picsum instead.

![image](https://user-images.githubusercontent.com/1627089/77436987-245e7d80-6db2-11ea-8330-de3844e30a06.png)

A closer view:

![image](https://user-images.githubusercontent.com/1627089/77437045-34765d00-6db2-11ea-8dde-2432cf26c5e0.png)
