### PR TITLE
Adjust left/right padding on small buttons for mWeb (to match iOS styling)

### DIFF
--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -39,7 +39,7 @@ export class Button extends Component<WebButtonProps> {
         return {
           height: inline ? "17px" : "26px",
           size: "2",
-          px: inline ? 0 : 1.5,
+          px: inline ? 0 : ("15px" as any),
         }
       case "medium":
         return {

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -39,7 +39,7 @@ export class Button extends Component<WebButtonProps> {
         return {
           height: inline ? "17px" : "26px",
           size: "2",
-          px: inline ? 0 : 2,
+          px: inline ? 0 : 1.5,
         }
       case "medium":
         return {


### PR DESCRIPTION
[PURCHASE-1781]

The Small button size: I know we built all btns with extra padding on right/left, but it feels unresolved/buggy or something in these smaller screen sizes. Possible to consider eliminating this extra 20px of east-west padding? 

https://files.slack.com/files-pri/T02531TU5-FTNEPUDFA/image.png

we adjusted the left/right padding for small buttons in palette for iOS with the new artwork page, so we should be able to change it on web too

__Before:__
<img width="89" alt="Screen Shot 2020-03-25 at 12 43 15 PM" src="https://user-images.githubusercontent.com/5643895/77562327-403b4f80-6e96-11ea-91c7-35ded01c9452.png">

__After:__
<img width="84" alt="Screen Shot 2020-03-25 at 12 43 23 PM" src="https://user-images.githubusercontent.com/5643895/77562340-44676d00-6e96-11ea-8dab-c2fd40be6f10.png">


[PURCHASE-1781]: https://artsyproduct.atlassian.net/browse/PURCHASE-1781