### PR TITLE
Allow the Artsy logo to be scaled

### DIFF
--- a/packages/palette/src/svgs/ArtsyLogoBlackIcon.tsx
+++ b/packages/palette/src/svgs/ArtsyLogoBlackIcon.tsx
@@ -2,14 +2,22 @@ import React from "react"
 import { color } from "../helpers"
 import { G, Icon, IconProps, Path, Title } from "./Icon"
 
+interface ArtsyLogoBlackIconProps extends Omit<IconProps, "width" | "height"> {
+  scale?: number
+}
+
 /** ArtsyLogoBlackIcon */
-export const ArtsyLogoBlackIcon: React.SFC<IconProps> = ({
-  width = "94px",
-  height = "32px",
+export const ArtsyLogoBlackIcon: React.SFC<ArtsyLogoBlackIconProps> = ({
+  scale = 1,
   ...props
 }) => {
   return (
-    <Icon viewBox="0 0 94 32" width={width} height={height} {...props}>
+    <Icon
+      {...props}
+      viewBox="0 0 94 32"
+      width={`${scale * 94}px`}
+      height={`${scale * 32}px`}
+    >
       <Title>Artsy</Title>
       <G fill={color(props.fill)} fillRule="evenodd">
         <Path d="M2.355 2.173h89.323v27.613H53.872v-4.55h-2.119v4.55H2.355V2.173zM.162 31.953h93.71V.006H.161v31.945z" />

--- a/packages/palette/src/svgs/ArtsyLogoBlackIcon.tsx
+++ b/packages/palette/src/svgs/ArtsyLogoBlackIcon.tsx
@@ -3,9 +3,13 @@ import { color } from "../helpers"
 import { G, Icon, IconProps, Path, Title } from "./Icon"
 
 /** ArtsyLogoBlackIcon */
-export const ArtsyLogoBlackIcon: React.SFC<IconProps> = props => {
+export const ArtsyLogoBlackIcon: React.SFC<IconProps> = ({
+  width = "94px",
+  height = "32px",
+  ...props
+}) => {
   return (
-    <Icon {...props} viewBox="0 0 94 32" width="94px" height="32px">
+    <Icon viewBox="0 0 94 32" width={width} height={height} {...props}>
       <Title>Artsy</Title>
       <G fill={color(props.fill)} fillRule="evenodd">
         <Path d="M2.355 2.173h89.323v27.613H53.872v-4.55h-2.119v4.55H2.355V2.173zM.162 31.953h93.71V.006H.161v31.945z" />


### PR DESCRIPTION
Currently we're unable to change the size of the full, black artsy logo. Given that it really needs to keep it's ratio, I've added a scale property that we can use to scale it up down depending on context. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.5.0-canary.658.10022.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.5.0-canary.658.10022.0
  # or 
  yarn add @artsy/palette@7.5.0-canary.658.10022.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
