### PR TITLE
Add missing `flexShrink` to Flex component

### DIFF
--- a/packages/palette/src/elements/Flex/Flex.tsx
+++ b/packages/palette/src/elements/Flex/Flex.tsx
@@ -45,6 +45,10 @@ const flexGrow = style({
   prop: "flexGrow",
 })
 
+const flexShrink = style({
+  prop: "flexShrink",
+})
+
 export interface FlexProps
   extends AlignItemsProps,
     AlignContentProps,
@@ -64,6 +68,7 @@ export interface FlexProps
     WidthProps,
     ZIndexProps {
   flexGrow?: number | string
+  flexShrink?: number | string
 }
 
 /**
@@ -79,6 +84,7 @@ export const Flex = primitives.View<FlexProps>`
   ${flexBasis};
   ${flexDirection};
   ${flexGrow};
+  ${flexShrink};
   ${flexWrap};
   ${height};
   ${justifyContent};


### PR DESCRIPTION
The version of styled-systems we're on is missing the `flexShrink` property. This adds it. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.5.1-canary.659.10038.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.5.1-canary.659.10038.0
  # or 
  yarn add @artsy/palette@7.5.1-canary.659.10038.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
