### PR TITLE
Add fallback image support to avatar

### DIFF
--- a/packages/palette-docs/content/docs/elements/images/Avatar.mdx
+++ b/packages/palette-docs/content/docs/elements/images/Avatar.mdx
@@ -1,17 +1,14 @@
 ---
 name: Avatar
 ---
+
 All entities use a circular avatar.
 
 <Playground title="Medium">
   <Flex>
     <Avatar size="md" src="https://picsum.photos/110/110/?random" />
     <Spacer ml={1} />
-    <Avatar
-      size="md"
-      lazyLoad
-      src="https://picsum.photos/110/110/?random"
-    />
+    <Avatar size="md" lazyLoad src="https://picsum.photos/110/110/?random" />
   </Flex>
 </Playground>
 
@@ -25,4 +22,27 @@ All entities use a circular avatar.
 
 <Playground title="With initials">
   <Avatar size="xs" initials="CD" />
+</Playground>
+
+<Playground title="With fallback">
+  <Avatar
+    size="xs"
+    renderFallback={({ diameter }) => (
+      <Flex
+        width={diameter}
+        height={diameter}
+        borderRadius={diameter}
+        background="#E5E5E5"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <UserSingleIcon
+          fill="black60"
+          height={parseInt(diameter) - 10}
+          width={parseInt(diameter) - 10}
+        />
+      </Flex>
+    )}
+    src="https://www.artsy.net/does-not-exist"
+  />
 </Playground>

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -73,6 +73,7 @@
     "@types/luxon": "1.15.1",
     "@types/node": "10.14.6",
     "@types/react": "16.8.7",
+    "@types/react-lazy-load-image-component": "^1.3.0",
     "@types/react-test-renderer": "16.8.1",
     "@types/semver": "5.5.0",
     "@types/styled-components": "4.0.2",

--- a/packages/palette/src/elements/Avatar/Avatar.test.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
+import { act } from "react-test-renderer"
 import { Avatar } from "../Avatar"
 
 describe("Avatar", () => {
@@ -34,5 +35,26 @@ describe("Avatar", () => {
     expect(getWrapper("xs").html()).toContain("45px")
     expect(getWrapper("sm").html()).toContain("70px")
     expect(getWrapper("md").html()).toContain("100px")
+  })
+
+  it("renders a fallback if the image fails to load", () => {
+    const Fallback = () => <div id="fallback" />
+    const err = jest.fn()
+    const wrapper = mount(
+      <Avatar
+        src="https://www.artsy.net/does-not-exist"
+        size="md"
+        onError={err}
+        renderFallback={() => <Fallback />}
+      />
+    )
+    act(() => {
+      wrapper.find("img").simulate("error")
+    })
+    act(() => {
+      wrapper.render()
+    })
+    expect(err).toBeCalled()
+    expect(wrapper.find(Fallback).length).toBe(1)
   })
 })

--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -1,8 +1,9 @@
-import React from "react"
+import React, { useState } from "react"
 import { LazyImage } from "../Image/LazyImage"
 import { AvatarProps, BaseAvatar, sizeValue } from "./Avatar.shared"
 
 interface AvatarWebProps extends AvatarProps {
+  renderFallback?: (props: { diameter: string }) => JSX.Element
   lazyLoad?: boolean
 }
 
@@ -12,23 +13,33 @@ export const Avatar = ({
   initials,
   lazyLoad = false,
   size = "md",
+  renderFallback,
+  onError,
 }: AvatarWebProps) => {
   const { diameter } = sizeValue(size)
+  const [useFallback, setUseFallback] = useState(false)
 
   return (
     <BaseAvatar
       src={src}
       initials={initials}
       size={size}
-      renderAvatar={() => (
-        <LazyImage
-          preload={!lazyLoad}
-          width={diameter}
-          height={diameter}
-          borderRadius={diameter}
-          src={src}
-        />
-      )}
+      renderAvatar={() =>
+        renderFallback && useFallback ? (
+          renderFallback({ diameter })
+        ) : (
+          <LazyImage
+            onError={e => {
+              onError ? onError(e) : setUseFallback(true)
+            }}
+            preload={!lazyLoad}
+            width={diameter}
+            height={diameter}
+            borderRadius={diameter}
+            src={src}
+          />
+        )
+      }
     />
   )
 }

--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -30,7 +30,10 @@ export const Avatar = ({
         ) : (
           <LazyImage
             onError={e => {
-              onError ? onError(e) : setUseFallback(true)
+              if (onError) {
+                onError(e)
+              }
+              setUseFallback(true)
             }}
             preload={!lazyLoad}
             width={diameter}

--- a/packages/palette/src/elements/Flex/Flex.tsx
+++ b/packages/palette/src/elements/Flex/Flex.tsx
@@ -7,6 +7,8 @@ import {
   AlignItemsProps,
   background,
   BackgroundProps,
+  borderRadius,
+  BorderRadiusProps,
   bottom,
   BottomProps,
   display,
@@ -54,6 +56,7 @@ export interface FlexProps
     AlignContentProps,
     BackgroundProps,
     BottomProps,
+    BorderRadiusProps,
     DisplayProps,
     FlexBasisProps,
     FlexDirectionProps,
@@ -80,6 +83,7 @@ export const Flex = primitives.View<FlexProps>`
   ${alignItems};
   ${background};
   ${bottom};
+  ${borderRadius};
   ${display};
   ${flexBasis};
   ${flexDirection};

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -18,7 +18,10 @@ const imagePropsToOmit = omitProps.filter(
 )
 
 const InnerLazyImage = styled(CleanTag.as(LazyLoadImage))<
-  WebImageProps & { onLoad: () => void }
+  WebImageProps & {
+    onLoad: () => void
+    onError?: (event: React.SyntheticEvent<any, Event>) => void
+  }
 >`
   width: 100%;
   height: 100%;
@@ -61,6 +64,7 @@ interface LazyImageProps
   /** The image component to render when preload is true */
   imageComponent?: any // FunctionComponent<ImageProps>
   onContextMenu?: (e: any) => void
+  onError?: (event: React.SyntheticEvent<any, Event>) => void
 }
 
 /** LazyImage */
@@ -79,6 +83,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
     height,
     borderRadius,
     style,
+    onError,
     ...containerProps
   } = props
   return preload ? (
@@ -92,6 +97,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
     >
       <InnerLazyImage
         omitFromProps={imagePropsToOmit}
+        onError={onError}
         src={src}
         title={title}
         alt={alt}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3694,6 +3694,14 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-lazy-load-image-component@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-lazy-load-image-component/-/react-lazy-load-image-component-1.3.0.tgz#c02b5c94f2776cb726b7d6bdb9507b2583cdc52d"
+  integrity sha512-Wb+VvdKtvitAutq7seLRw84wutA1fm20l+/WLD9UZd3wuPCoog9mmWNFU3uMR42ghk0sMQKPyGbUxvwKnmgctA==
+  dependencies:
+    "@types/react" "*"
+    csstype "^2.2.0"
+
 "@types/react-test-renderer@16.8.1":
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.8.1.tgz#96f3ce45a3a41c94eca532a99103dd3042c9d055"


### PR DESCRIPTION
This adds the ability to specify a fallback when the image doesn't load for an avatar. I updated the palette docs with a realistic example of how we might use it. 

Note that this should still be ported to iOS. 

![image](https://user-images.githubusercontent.com/3087225/77837732-6d0f9100-713a-11ea-8b0a-d2a4b26c830c.png)

This adds two props to avatar:

1. `renderFallback` -- Basically a render method to render a component if the image fails to load
2. `onError` -- The is the same callback that's present on images and is what powers the fallback logic. You can also hook into this to do arbitrary things (like remove the `src` from the props so that it falls back to initials if you have those defined).  

A tiny related article: https://medium.com/@Mdmoin07/image-fallback-for-broken-images-react-react-native-261f35b02f45
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.6.0-canary.660.10068.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.6.0-canary.660.10068.0
  # or 
  yarn add @artsy/palette@7.6.0-canary.660.10068.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
