### PR TITLE
Add top to flex

### DIFF
--- a/packages/palette/src/elements/Flex/Flex.tsx
+++ b/packages/palette/src/elements/Flex/Flex.tsx
@@ -34,6 +34,8 @@ import {
   space,
   SpaceProps,
   style,
+  top,
+  TopProps,
   width,
   WidthProps,
   zIndex,
@@ -56,6 +58,7 @@ export interface FlexProps
     AlignContentProps,
     BackgroundProps,
     BottomProps,
+    TopProps,
     BorderRadiusProps,
     DisplayProps,
     FlexBasisProps,
@@ -97,6 +100,7 @@ export const Flex = primitives.View<FlexProps>`
   ${order};
   ${position};
   ${space};
+  ${top};
   ${width};
   ${zIndex};
 `


### PR DESCRIPTION
Small change to allow adding top prop to flex. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.7.0-canary.662.10098.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.7.0-canary.662.10098.0
  # or 
  yarn add @artsy/palette@7.7.0-canary.662.10098.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
