### PR TITLE
Allow `Input` to accept refs

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -17,36 +17,38 @@ export interface InputProps extends React.HTMLProps<HTMLInputElement> {
 /**
  * Input component
  */
-export const Input: React.SFC<InputProps> = ({
-  description,
-  disabled,
-  error,
-  required,
-  title,
-  ...rest
-}) => {
-  return (
-    <Box width="100%">
-      {title && (
-        <Serif mb="0.5" size="3">
-          {title}
-          {required && <Required>*</Required>}
-        </Serif>
-      )}
-      {description && (
-        <Serif color="black60" mb="1" size="2">
-          {description}
-        </Serif>
-      )}
-      <StyledInput disabled={disabled} error={!!error} {...rest as any} />
-      {error && (
-        <Sans color="red100" mt="1" size="2">
-          {error}
-        </Sans>
-      )}
-    </Box>
-  )
-}
+export const Input: React.ForwardRefExoticComponent<
+  InputProps
+> = React.forwardRef(
+  ({ description, disabled, error, required, title, ...rest }, ref) => {
+    return (
+      <Box width="100%">
+        {title && (
+          <Serif mb="0.5" size="3">
+            {title}
+            {required && <Required>*</Required>}
+          </Serif>
+        )}
+        {description && (
+          <Serif color="black60" mb="1" size="2">
+            {description}
+          </Serif>
+        )}
+        <StyledInput
+          ref={ref}
+          disabled={disabled}
+          error={!!error}
+          {...rest as any}
+        />
+        {error && (
+          <Sans color="red100" mt="1" size="2">
+            {error}
+          </Sans>
+        )}
+      </Box>
+    )
+  }
+)
 
 interface StyledInputProps extends React.HTMLProps<HTMLInputElement> {
   disabled: boolean


### PR DESCRIPTION
This updates the `Input` component to use `React.forwardRef` so that we can actually get the ref of the input component. 

This would be useful for scenarios where we want to clear the input without having to create a wrapping component. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.8.0-canary.663.10121.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.8.0-canary.663.10121.0
  # or 
  yarn add @artsy/palette@7.8.0-canary.663.10121.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
