### PR TITLE
[FX-1889] expand menu component to work with new nav DropDownMenu in reaction

### DIFF
--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 
-import { display } from "styled-system"
+import { display, SpaceProps } from "styled-system"
 import { color } from "../../helpers/color"
 import { SansSize } from "../../Theme"
 import { BorderBox } from "../BorderBox"
@@ -10,6 +10,7 @@ import { Flex } from "../Flex"
 import { Separator } from "../Separator"
 import { Spacer } from "../Spacer"
 import { Sans } from "../Typography"
+import { themeProps } from "../../Theme"
 
 interface MenuProps {
   children?: React.ReactNode
@@ -60,8 +61,8 @@ interface MenuItemProps extends BoxProps {
   href?: string
   textColor?: string // TODO:  Look into type conflict with styled-system
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  paddingX?: number
-  paddingY?: number
+  px?: SpaceProps["px"]
+  py?: SpaceProps["py"]
   textWeight?: "medium" | "regular"
 }
 
@@ -70,15 +71,15 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   children,
   fontSize = "2",
   href,
-  paddingX = 2,
-  paddingY = 1,
+  px = 2,
+  py = 1,
   textWeight = "medium",
   textColor,
   ...props
 }) => {
   return (
     <MenuLink href={href} {...props}>
-      <Box px={paddingX} py={paddingY}>
+      <Box px={px} py={py}>
         <MenuLinkText size={fontSize} weight={textWeight} color={textColor}>
           {children}
         </MenuLinkText>
@@ -107,5 +108,5 @@ const MenuLink = styled.a`
   }
 `
 const MenuLinkText = styled(Sans)<{ color: string }>`
-  color: ${p => (p.color ? p.color : color("black100"))};
+  color: ${p => p.color || color("black100")};
 `

--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -10,7 +10,6 @@ import { Flex } from "../Flex"
 import { Separator } from "../Separator"
 import { Spacer } from "../Spacer"
 import { Sans } from "../Typography"
-import { themeProps } from "../../Theme"
 
 interface MenuProps {
   children?: React.ReactNode
@@ -59,10 +58,11 @@ interface MenuItemProps extends BoxProps {
   children: React.ReactNode
   fontSize?: SansSize
   href?: string
-  textColor?: string // TODO:  Look into type conflict with styled-system
+  color?: string // TODO:  Look into type conflict with styled-system
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
   px?: SpaceProps["px"]
   py?: SpaceProps["py"]
+  textColor?: string
   textWeight?: "medium" | "regular"
 }
 

--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 
 import { display } from "styled-system"
 import { color } from "../../helpers/color"
+import { SansSize } from "../../Theme"
 import { BorderBox } from "../BorderBox"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
@@ -14,7 +15,7 @@ interface MenuProps {
   children?: React.ReactNode
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
   title?: string
-  width?: number
+  width?: number | string
 }
 
 /** Menu */
@@ -38,7 +39,9 @@ export const Menu: React.FC<MenuProps> = ({
             </Box>
           )}
 
-          <Box pt={title ? 0 : 1}>{children}</Box>
+          <Flex flexDirection="column" pt={title ? 0 : 1}>
+            {children}
+          </Flex>
         </Flex>
       </BorderBox>
     </MenuContainer>
@@ -53,23 +56,32 @@ const MenuContainer = styled(Box)`
 
 interface MenuItemProps extends BoxProps {
   children: React.ReactNode
+  fontSize?: SansSize
   href?: string
-  color?: string // TODO:  Look into type conflict with styled-system
+  textColor?: string // TODO:  Look into type conflict with styled-system
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
+  paddingX?: number
+  paddingY?: number
+  textWeight?: "medium" | "regular"
 }
 
 /** MenuItem */
 export const MenuItem: React.FC<MenuItemProps> = ({
   children,
+  fontSize = "2",
   href,
+  paddingX = 2,
+  paddingY = 1,
+  textWeight = "medium",
+  textColor,
   ...props
 }) => {
   return (
     <MenuLink href={href} {...props}>
-      <Box px={2} py={1}>
-        <Sans size="2" weight="medium">
+      <Box px={paddingX} py={paddingY}>
+        <MenuLinkText size={fontSize} weight={textWeight} color={textColor}>
           {children}
-        </Sans>
+        </MenuLinkText>
       </Box>
     </MenuLink>
   )
@@ -93,4 +105,7 @@ const MenuLink = styled.a`
     display: flex;
     align-items: center;
   }
+`
+const MenuLinkText = styled(Sans)<{ color: string }>`
+  color: ${p => (p.color ? p.color : color("black100"))};
 `


### PR DESCRIPTION
Addresses: [FX-1889](https://artsyproduct.atlassian.net/browse/FX-1889)

This expands the Menu and MenuItem components to support the new DropDownMenu component in reaction. It adds a few new props in order to adjust the menu styling.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.8.1-canary.664.10164.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@7.8.1-canary.664.10164.0
  # or 
  yarn add @artsy/palette@7.8.1-canary.664.10164.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
