### PR TITLE
Removed spacing, changed font for text area

### DIFF
--- a/packages/palette/src/elements/TextArea/TextArea.story.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.story.tsx
@@ -26,5 +26,12 @@ storiesOf("Components/TextArea", module)
     return <TextArea {...defaultProps} name="my-text-area" />
   })
   .add("TextArea + title + desc", () => {
-    return <TextArea {...defaultProps} name="my-text-area" title="Note" description="This is my description" />
+    return (
+      <TextArea
+        {...defaultProps}
+        name="my-text-area"
+        title="Note"
+        description="This is my description"
+      />
+    )
   })

--- a/packages/palette/src/elements/TextArea/TextArea.story.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.story.tsx
@@ -25,3 +25,6 @@ storiesOf("Components/TextArea", module)
   .add("TextArea + name", () => {
     return <TextArea {...defaultProps} name="my-text-area" />
   })
+  .add("TextArea + title + desc", () => {
+    return <TextArea {...defaultProps} name="my-text-area" title="Note" description="This is my description" />
+  })

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -6,15 +6,15 @@ import { space } from "../../helpers/space"
 import { Collapse } from "../Collapse"
 import { Flex } from "../Flex"
 import { Spacer } from "../Spacer"
-import { Sans, Serif } from "../Typography/Typography"
+import { Sans } from "../Typography/Typography"
 
 const StyledTextArea = styled.textarea`
   transition: border-color 0.25s ease;
   padding: ${space(1)}px;
   min-height: ${space(9)}px;
-  font-family: ${themeGet("fontFamily.serif.regular")};
-  font-size: ${themeGet("typeSizes.serif.3.fontSize")}px;
-  line-height: ${themeGet("typeSizes.serif.3.lineHeight")}px;
+  font-family: ${themeGet("fontFamily.sans.regular")};
+  font-size: ${themeGet("typeSizes.sans.3.fontSize")}px;
+  line-height: ${themeGet("typeSizes.sans.3.lineHeight")}px;
   outline: none;
   ${({ hasError }: { hasError?: boolean }) => css`
     border: 1px solid ${color(hasError ? "red100" : "black10")};
@@ -100,21 +100,22 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
       <Flex flexDirection="column">
         {title && (
           <>
-            <Serif size="3t">
+            <Sans size="3t">
               {title}
               {this.props.required && <Required>*</Required>}
-            </Serif>
-            <Spacer mb={1} />
+            </Sans>
           </>
         )}
         {description && (
           <>
-            <Serif size="2" color="black60">
+            <Sans size="2" color="black60">
               {description}
-            </Serif>
-            <Spacer mb={1} />
+            </Sans>
           </>
         )}
+        {(title || description) &&
+          <Spacer mb={1} />
+        }
         <StyledTextArea
           {...others}
           onChange={this.onChange}

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -113,9 +113,7 @@ export class TextArea extends React.Component<TextAreaProps, TextAreaState> {
             </Sans>
           </>
         )}
-        {(title || description) &&
-          <Spacer mb={1} />
-        }
+        {(title || description) && <Spacer mb={1} />}
         <StyledTextArea
           {...others}
           onChange={this.onChange}


### PR DESCRIPTION
Changes text area title/description to use `Sans`. Updates the spacing to ensure there's not 10px of spacing between the `title` and the `description`. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.1-canary.668.10308.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@8.1.1-canary.668.10308.0
  # or 
  yarn add @artsy/palette@8.1.1-canary.668.10308.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
