### PR TITLE
Style tweaks for text inputs

### DIFF
--- a/packages/palette/src/elements/Input/Input.story.tsx
+++ b/packages/palette/src/elements/Input/Input.story.tsx
@@ -1,0 +1,30 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Input } from "./Input"
+
+const defaultProps = {
+  placeholder: "Start typing…",
+}
+
+storiesOf("Components/Input", module)
+  .add("Input", () => {
+    return <Input {...defaultProps} />
+  })
+  .add("Input + title", () => {
+    return <Input {...defaultProps} title="Your offer" />
+  })
+  .add("Input + title + required", () => {
+    return <Input {...defaultProps} title="Your offer" required />
+  })
+  .add("Input + title + desc", () => {
+    return <Input {...defaultProps} title="Your offer" description="This is my description" />
+  })
+  .add("Input + error", () => {
+    return <Input {...defaultProps} error="Something went wrong." />
+  })
+  .add("Input + disabled", () => {
+    return <Input {...defaultProps} disabled />
+  })
+  .add("Input + specified width", () => {
+    return <Input style={{ width: "50%" }} {...defaultProps} />
+  })

--- a/packages/palette/src/elements/Input/Input.story.tsx
+++ b/packages/palette/src/elements/Input/Input.story.tsx
@@ -17,7 +17,13 @@ storiesOf("Components/Input", module)
     return <Input {...defaultProps} title="Your offer" required />
   })
   .add("Input + title + desc", () => {
-    return <Input {...defaultProps} title="Your offer" description="This is my description" />
+    return (
+      <Input
+        {...defaultProps}
+        title="Your offer"
+        description="This is my description"
+      />
+    )
   })
   .add("Input + error", () => {
     return <Input {...defaultProps} error="Something went wrong." />

--- a/packages/palette/src/elements/Input/Input.test.tsx
+++ b/packages/palette/src/elements/Input/Input.test.tsx
@@ -14,7 +14,6 @@ describe("Input", () => {
       title: "This is the title",
     }
     const wrapper = mount(<Input {...props} />)
-    expect(wrapper.find("Serif").length).toEqual(1)
     expect(wrapper.text()).toEqual(props.title)
   })
 
@@ -33,7 +32,6 @@ describe("Input", () => {
       description: "This is the title",
     }
     const wrapper = mount(<Input {...props} />)
-    expect(wrapper.find("Serif").length).toEqual(1)
     expect(wrapper.text()).toEqual(props.description)
   })
 
@@ -42,7 +40,6 @@ describe("Input", () => {
       error: "This is the title",
     }
     const wrapper = mount(<Input {...props} />)
-    expect(wrapper.find("Sans").length).toEqual(1)
     expect(wrapper.text()).toEqual(props.error)
   })
 })

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -4,7 +4,7 @@ import { themeGet } from "styled-system"
 import { color, space } from "../../helpers"
 import { Color } from "../../Theme"
 import { Box } from "../Box"
-import { Sans, Serif } from "../Typography"
+import { Sans } from "../Typography"
 
 export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   description?: string
@@ -24,15 +24,15 @@ export const Input: React.ForwardRefExoticComponent<
     return (
       <Box width="100%">
         {title && (
-          <Serif mb="0.5" size="3">
+          <Sans mb="0.5" size="3">
             {title}
             {required && <Required>*</Required>}
-          </Serif>
+          </Sans>
         )}
         {description && (
-          <Serif color="black60" mb="1" size="2">
+          <Sans color="black60" mb="1" size="2">
             {description}
-          </Serif>
+          </Sans>
         )}
         <StyledInput
           ref={ref}
@@ -75,9 +75,9 @@ export const computeBorderColor = (inputStatus: InputStatus): Color => {
 }
 
 const StyledInput = styled.input<StyledInputProps>`
-  font-family: ${themeGet("fontFamily.serif.regular")};
-  font-size: ${themeGet("typeSizes.serif.3.fontSize")}px;
-  line-height: ${themeGet("typeSizes.serif.3t.lineHeight")}px;
+  font-family: ${themeGet("fontFamily.sans.regular")};
+  font-size: ${themeGet("typeSizes.sans.3.fontSize")}px;
+  line-height: ${themeGet("typeSizes.sans.3t.lineHeight")}px;
   height: 40px;
   background-color: ${props =>
     props.disabled ? color("black5") : color("white100")};


### PR DESCRIPTION
Changed font family on text inputs from Serif to Sans. Created a storybook file for inputs.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.2-canary.670.10350.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@8.1.2-canary.670.10350.0
  # or 
  yarn add @artsy/palette@8.1.2-canary.670.10350.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
