### PR TITLE
Update menu component style props

### DIFF
--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -14,6 +14,7 @@ import { Sans } from "../Typography"
 interface MenuProps {
   children?: React.ReactNode
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
+  margin?: SpaceProps["m"]
   title?: string
   width?: number | string
 }
@@ -21,12 +22,13 @@ interface MenuProps {
 /** Menu */
 export const Menu: React.FC<MenuProps> = ({
   children,
+  margin = "2px",
   title,
   width = 230,
   ...props
 }) => {
   return (
-    <MenuContainer width={width} m="2px" {...props}>
+    <MenuContainer width={width} m={margin} {...props}>
       <BorderBox p={0} pb={1} background="white">
         <Flex flexDirection="column" width="100%">
           {title && (

--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -15,6 +15,7 @@ interface MenuProps {
   children?: React.ReactNode
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
   margin?: SpaceProps["m"]
+  padding?: SpaceProps["p"]
   title?: string
   width?: number | string
 }
@@ -23,13 +24,14 @@ interface MenuProps {
 export const Menu: React.FC<MenuProps> = ({
   children,
   margin = "2px",
+  padding = 1,
   title,
   width = 230,
   ...props
 }) => {
   return (
     <MenuContainer width={width} m={margin} {...props}>
-      <BorderBox p={0} pb={1} background="white">
+      <BorderBox p={0} pb={padding} background="white">
         <Flex flexDirection="column" width="100%">
           {title && (
             <Box px={2} pt={2} pb={1}>
@@ -41,7 +43,7 @@ export const Menu: React.FC<MenuProps> = ({
             </Box>
           )}
 
-          <Flex flexDirection="column" pt={title ? 0 : 1}>
+          <Flex flexDirection="column" pt={title ? 0 : padding}>
             {children}
           </Flex>
         </Flex>

--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -14,8 +14,8 @@ import { Sans } from "../Typography"
 interface MenuProps {
   children?: React.ReactNode
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  margin?: SpaceProps["m"]
-  padding?: SpaceProps["p"]
+  m?: SpaceProps["m"]
+  py?: SpaceProps["p"]
   title?: string
   width?: number | string
 }
@@ -23,18 +23,18 @@ interface MenuProps {
 /** Menu */
 export const Menu: React.FC<MenuProps> = ({
   children,
-  margin = "2px",
-  padding = 1,
+  m = "2px",
+  py = 1,
   title,
   width = 230,
   ...props
 }) => {
   return (
-    <MenuContainer width={width} m={margin} {...props}>
-      <BorderBox p={0} pb={padding} background="white">
+    <MenuContainer width={width} m={m} {...props}>
+      <BorderBox p={0} py={py} background="white">
         <Flex flexDirection="column" width="100%">
           {title && (
-            <Box px={2} pt={2} pb={1}>
+            <Box px={2} pt={1} pb={1}>
               <Sans size="3" weight="medium">
                 {title}
               </Sans>
@@ -43,9 +43,7 @@ export const Menu: React.FC<MenuProps> = ({
             </Box>
           )}
 
-          <Flex flexDirection="column" pt={title ? 0 : padding}>
-            {children}
-          </Flex>
+          <Flex flexDirection="column">{children}</Flex>
         </Flex>
       </BorderBox>
     </MenuContainer>


### PR DESCRIPTION
This addresses some minor style issues with the drop down menu:
- Ensure menu extends to the fullwidth of the screen.
- Remove top and bottom padding for fullwidth drop down menu.

**Before:**
<img width="1242" alt="Screen Shot 2020-04-17 at 2 57 19 PM" src="https://user-images.githubusercontent.com/5201004/79605119-574c1680-80bd-11ea-9b59-fed8187954bc.png">

**After:**
<img width="1611" alt="Screen Shot 2020-04-17 at 3 20 30 PM" src="https://user-images.githubusercontent.com/5201004/79606055-fe7d7d80-80be-11ea-848a-080fb5323381.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.3-canary.671.10374.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@8.1.3-canary.671.10374.0
  # or 
  yarn add @artsy/palette@8.1.3-canary.671.10374.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
