### PR TITLE
[FX-1907] make background color darker for legibility with light text colors

### DIFF
--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -80,7 +80,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   ...props
 }) => {
   return (
-    <MenuLink href={href} {...props}>
+    <MenuLink href={href} {...props} hasLighterColor={Boolean(textColor)}>
       <Box px={px} py={py}>
         <MenuLinkText size={fontSize} weight={textWeight} color={textColor}>
           {children}
@@ -90,7 +90,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   )
 }
 
-const MenuLink = styled.a`
+const MenuLink = styled.a<{ hasLighterColor: boolean }>`
   cursor: pointer;
   display: flex;
   text-decoration: none;
@@ -101,7 +101,8 @@ const MenuLink = styled.a`
   ${display};
 
   &:hover {
-    background-color: ${color("black5")};
+    background-color: ${p =>
+      p.hasLighterColor ? color("black10") : color("black5")};
   }
 
   ${Sans} {

--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -66,6 +66,7 @@ interface MenuItemProps extends BoxProps {
   py?: SpaceProps["py"]
   textColor?: string
   textWeight?: "medium" | "regular"
+  hasLighterTextColor?: boolean
 }
 
 /** MenuItem */
@@ -77,10 +78,11 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   py = 1,
   textWeight = "medium",
   textColor,
+  hasLighterTextColor,
   ...props
 }) => {
   return (
-    <MenuLink href={href} {...props} hasLighterColor={Boolean(textColor)}>
+    <MenuLink href={href} {...props} hasLighterTextColor={hasLighterTextColor}>
       <Box px={px} py={py}>
         <MenuLinkText size={fontSize} weight={textWeight} color={textColor}>
           {children}
@@ -90,7 +92,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   )
 }
 
-const MenuLink = styled.a<{ hasLighterColor: boolean }>`
+const MenuLink = styled.a<{ hasLighterTextColor: boolean }>`
   cursor: pointer;
   display: flex;
   text-decoration: none;
@@ -102,7 +104,7 @@ const MenuLink = styled.a<{ hasLighterColor: boolean }>`
 
   &:hover {
     background-color: ${p =>
-      p.hasLighterColor ? color("black10") : color("black5")};
+      p.hasLighterTextColor ? color("black10") : color("black5")};
   }
 
   ${Sans} {


### PR DESCRIPTION
Addresses: [FX-1907](https://artsyproduct.atlassian.net/browse/FX-1907)

![image](https://user-images.githubusercontent.com/5201004/80155169-28d3ad00-858f-11ea-9c1c-fe0317c263f2.png)


Adjusts the back-ground color to be more legible when we use lighter colors.

<img width="1678" alt="Screen Shot 2020-04-23 at 5 55 30 PM" src="https://user-images.githubusercontent.com/5201004/80155193-39842300-858f-11ea-9c89-11a32b379999.png">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.1-canary.673.10444.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@8.2.1-canary.673.10444.0
  # or 
  yarn add @artsy/palette@8.2.1-canary.673.10444.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
