### PR TITLE
Updates Palette to use new Eigen repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ $ yarn start
 $ open http://localhost:8000/
 ```
 
-## Link with Emission
+## Link with Eigen
 
-When developing components for [Emission](https://github.com/artsy/emission), boot the Simulator and from the Palette project root run:
+When developing components for [our iOS codebase](https://github.com/artsy/eigen), boot the Simulator and from the Palette project root run:
 
 ```
-$ yarn workspace @artsy/palette watch:emission
+$ yarn workspace @artsy/palette watch:eigen
 ```
 
-Since React Native doesn't support symlinks, this will copy changes directly to the Emission folder and hot-reload the app.
+Since React Native doesn't support symlinks, this will copy changes directly to the Eigen folder and hot-reload the app.
 
 ## Linking and Unlinking with Reaction
 
@@ -62,7 +62,7 @@ $ yarn start
 
 ### ⚠️ Don't Forget About iOS!
 
-When adding a new component to Palette, it's important to be aware that this library is used on the web as well as in React Native, via Emission, and therefore must follow a few rules in terms of structure, namely:
+When adding a new component to Palette, it's important to be aware that this library is used on the web as well as in React Native, via Eigen, and therefore must follow a few rules in terms of structure, namely:
 
 > If a mobile component has platform-specific features, that code has to live in a `Component.ios.tsx` file. Or if a web component has browser-only features, then a `Component.ios.tsx` file must be created, or React Native will error out. If the code between a web and native component is identical, a `.ios.tx` file isn’t needed. If some code can be shared between platforms, then that shared code should live in a `Component.shared.tsx` file.
 
@@ -118,7 +118,7 @@ Artsy uses [Zeplin](https://app.zeplin.io/) and we have developed [a plugin](htt
   <img align="left" src="https://avatars2.githubusercontent.com/u/546231?s=200&v=4"/>
 </a>
 
-This project is the work of designers and engineers at [Artsy][footer_website], the 
+This project is the work of designers and engineers at [Artsy][footer_website], the
 world's leading and largest online art marketplace and platform for discovering art.
 One of our core [Engineering Principles][footer_principles] is being [Open
 Source by Default][footer_open] which means we strive to share as many details

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -10,9 +10,9 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist",
-    "clean:emission": "rm -rf ../../../emission/node_modules/@artsy/palette/dist",
+    "clean:eigen": "rm -rf ../../../eigen/node_modules/@artsy/palette/dist",
     "compile": "babel src -s --source-map --extensions '.ts,.tsx' --ignore src/**/__tests__,src/**/__stories__ --out-dir dist",
-    "compile:emission": "yarn compile --out-dir ../../../emission/node_modules/@artsy/palette/dist",
+    "compile:eigen": "yarn compile --out-dir ../../../eigen/node_modules/@artsy/palette/dist",
     "prepack": "yarn generate-tokens && yarn generate-styles",
     "generate-tokens": "ts-node scripts/generate-tokens.ts",
     "generate-styles": "ts-node scripts/generate-styles.ts",
@@ -28,7 +28,7 @@
     "type-check-scripts": "tsc -p tsconfig.scripts.json --noEmit --pretty",
     "type-declarations": "tsc --emitDeclarationOnly",
     "watch": "concurrently --raw --kill-others 'yarn compile -w' 'yarn type-declarations -w'",
-    "watch:emission": "yarn clean:emission && concurrently --raw --kill-others 'yarn compile:emission -w' 'yarn type-declarations -w --outDir ../../../emission/node_modules/@artsy/palette/dist'",
+    "watch:eigen": "yarn clean:eigen && concurrently --raw --kill-others 'yarn compile:eigen -w' 'yarn type-declarations -w --outDir ../../../eigen/node_modules/@artsy/palette/dist'",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "visual-test": "chromatic test --exit-zero-on-changes --app-code n02zjqmdqq"


### PR DESCRIPTION
React Native doesn't support symlinks, so a typical `yarn link` approach won't work. For this reason, we have scripts in Palette to target the React Native codebase's `node_modules` folder. However, we [recently combined Emission into Eigen](https://github.com/artsy/eigen/pull/3022) so we need to update Palette to match the new expected directory name. I updated the script names and docs, too.

I haven't tried this locally but it should work 🙈 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.2-canary.678.10538.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@8.2.2-canary.678.10538.0
  # or 
  yarn add @artsy/palette@8.2.2-canary.678.10538.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
