### PR TITLE
[COM-16] - add unstable_trackIn as a prop to Sans and Serif

### DIFF
--- a/packages/palette-docs/content/docs/tokens/Typography.mdx
+++ b/packages/palette-docs/content/docs/tokens/Typography.mdx
@@ -40,6 +40,37 @@ the design and engineering teams.
 
 <Spacer my={4} />
 
+<Playground showToggle={true} title="Sans with unstable_trackIn (narrow)" expanded={false}>
+  <Flex mt={4} justifyContent="space-between">
+    <Box>
+      <Sans size="16" unstable_trackIn>Sans 16</Sans>
+      <Sans size="14" unstable_trackIn>Sans 14</Sans>
+      <Sans size="12" unstable_trackIn>Sans 12</Sans>
+      <Sans size="10" unstable_trackIn>Sans 10</Sans>
+      <Sans size="8" unstable_trackIn>Sans 8</Sans>
+      <Sans size="6" unstable_trackIn>Sans 6</Sans>
+      <Sans size="5t" unstable_trackIn>Sans 5t</Sans>
+      <Sans size="5" unstable_trackIn>Sans 5</Sans>
+      <Sans size="4t" unstable_trackIn>Sans 4t</Sans>
+      <Sans size="4" unstable_trackIn>Sans 4</Sans>
+      <Sans size="3t" unstable_trackIn>Sans 3t</Sans>
+      <Sans size="3" unstable_trackIn>Sans 3</Sans>
+      <Sans size="2" unstable_trackIn>Sans 2</Sans>
+      <Sans size="1" unstable_trackIn>Sans 1</Sans>
+    </Box>
+    <Flex width="50%" px={2} alignItems="center">
+      <BorderBox>
+        <Sans size="5">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </Sans>
+      </BorderBox>
+    </Flex>
+  </Flex>
+</Playground>
+
+<Spacer my={4} />
+
 <Playground showToggle={true} title="Serif" expanded={true}>
   <Flex justifyContent="space-between">
     <Box>
@@ -55,6 +86,35 @@ the design and engineering teams.
       <Serif size="3">Serif 3</Serif>
       <Serif size="2">Serif 2</Serif>
       <Serif size="1">Serif 1</Serif>
+    </Box>
+    <Flex width="50%" px={2} alignItems="center">
+      <BorderBox>
+        <Serif size="5">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </Serif>
+      </BorderBox>
+    </Flex>
+  </Flex>
+</Playground>
+
+<Spacer my={4} />
+
+<Playground showToggle={true} title="Serif with unstable_trackIn (narrow)" expanded={false}>
+  <Flex justifyContent="space-between">
+    <Box>
+      <Serif size="12" unstable_trackIn>Serif 12</Serif>
+      <Serif size="10" unstable_trackIn>Serif 10</Serif>
+      <Serif size="8" unstable_trackIn>Serif 8</Serif>
+      <Serif size="6" unstable_trackIn>Serif 6</Serif>
+      <Serif size="5t" unstable_trackIn>Serif 5t</Serif>
+      <Serif size="5" unstable_trackIn>Serif 5</Serif>
+      <Serif size="4t" unstable_trackIn>Serif 4t</Serif>
+      <Serif size="4" unstable_trackIn>Serif 4</Serif>
+      <Serif size="3t" unstable_trackIn>Serif 3t</Serif>
+      <Serif size="3" unstable_trackIn>Serif 3</Serif>
+      <Serif size="2" unstable_trackIn>Serif 2</Serif>
+      <Serif size="1" unstable_trackIn>Serif 1</Serif>
     </Box>
     <Flex width="50%" px={2} alignItems="center">
       <BorderBox>

--- a/packages/palette/src/elements/Typography/Typography.test.tsx
+++ b/packages/palette/src/elements/Typography/Typography.test.tsx
@@ -64,6 +64,16 @@ describe("Typography", () => {
           themeProps.fontFamily.sans.mediumItalic
         )
       })
+
+      it("supports unstable_trackIn to adjust letter-spacing", () => {
+        const sans = renderer.create(
+          <Sans size="3t" unstable_trackIn>
+            Hello world
+          </Sans>
+        ).root
+        const text = sans.findByType(Text as React.ComponentClass<any>)
+        expect(text.props.style).toEqual({ letterSpacing: "-0.03em" })
+      })
     })
 
     describe("concerning font-size & line-height", () => {
@@ -138,6 +148,16 @@ describe("Typography", () => {
         expect(text.props.fontFamily).toEqual(
           themeProps.fontFamily.serif.italic
         )
+      })
+
+      it("supports unstable_trackIn to adjust letter-spacing", () => {
+        const sans = renderer.create(
+          <Serif size="3t" unstable_trackIn>
+            Hello world
+          </Serif>
+        ).root
+        const text = sans.findByType(Text as React.ComponentClass<any>)
+        expect(text.props.style).toEqual({ letterSpacing: "-0.03em" })
       })
 
       describe("with invalid options", () => {

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -20,8 +20,6 @@ import {
   DisplayProps as StyledSystemDisplayProps,
   fontSize,
   FontSizeProps,
-  letterSpacing,
-  LetterSpacingProps,
   lineHeight,
   LineHeightProps,
   maxWidth,
@@ -79,7 +77,6 @@ export interface TextProps
     SpaceProps,
     StyledSystemDisplayProps,
     TextAlignProps,
-    LetterSpacingProps,
     VerticalAlignProps {
   className?: string
   fontFamily?: string
@@ -109,7 +106,6 @@ export const Text = primitives.Text<TextProps>`
   ${space};
   ${textAlign};
   ${verticalAlign};
-  ${letterSpacing};
 `
 
 /**
@@ -183,6 +179,7 @@ function createStyledText<P extends StyledTextProps>(
       size,
       weight,
       italic,
+      style: _style,
       unstable_trackIn,
       element,
       ...textProps
@@ -192,13 +189,17 @@ function createStyledText<P extends StyledTextProps>(
       if (fontFamilyType === null) {
         throw new Error("Did not expect `fontType` to be `null`.")
       }
+
       return (
         <Text
           fontFamily={
             fontFamilyType && themeProps.fontFamily[fontType][fontFamilyType]
           }
+          style={{
+            ...(unstable_trackIn ? { letterSpacing: "-0.03em" } : {}),
+            ..._style,
+          }}
           {...determineFontSizes(fontType, size)}
-          {...(unstable_trackIn ? { letterSpacing: "-0.03em" } : {})}
           // styled-components supports calling the prop `as`, but there are
           //  issues when passing it into this component named `as`. See
           //  https://github.com/styled-components/styled-components/issues/2448

--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -20,6 +20,8 @@ import {
   DisplayProps as StyledSystemDisplayProps,
   fontSize,
   FontSizeProps,
+  letterSpacing,
+  LetterSpacingProps,
   lineHeight,
   LineHeightProps,
   maxWidth,
@@ -77,6 +79,7 @@ export interface TextProps
     SpaceProps,
     StyledSystemDisplayProps,
     TextAlignProps,
+    LetterSpacingProps,
     VerticalAlignProps {
   className?: string
   fontFamily?: string
@@ -106,6 +109,7 @@ export const Text = primitives.Text<TextProps>`
   ${space};
   ${textAlign};
   ${verticalAlign};
+  ${letterSpacing};
 `
 
 /**
@@ -154,6 +158,7 @@ interface StyledTextProps extends Partial<TextProps> {
   size: string | string[]
   weight?: null | FontWeights
   italic?: boolean
+  unstable_trackIn?: boolean
 }
 
 /**
@@ -174,7 +179,14 @@ function createStyledText<P extends StyledTextProps>(
   selectFontFamilyType: typeof _selectFontFamilyType = _selectFontFamilyType
 ) {
   return styledWrapper<P>(
-    ({ size, weight, italic, element, ...textProps }: StyledTextProps) => {
+    ({
+      size,
+      weight,
+      italic,
+      unstable_trackIn,
+      element,
+      ...textProps
+    }: StyledTextProps) => {
       const fontFamilyType = selectFontFamilyType(_fontWeight(weight), italic)
       // This is mostly to narrow the type of `fontFamilyType` to remove `null`.
       if (fontFamilyType === null) {
@@ -186,6 +198,7 @@ function createStyledText<P extends StyledTextProps>(
             fontFamilyType && themeProps.fontFamily[fontType][fontFamilyType]
           }
           {...determineFontSizes(fontType, size)}
+          {...(unstable_trackIn ? { letterSpacing: "-0.03em" } : {})}
           // styled-components supports calling the prop `as`, but there are
           //  issues when passing it into this component named `as`. See
           //  https://github.com/styled-components/styled-components/issues/2448
@@ -217,6 +230,8 @@ export interface SansProps extends Partial<TextProps> {
    * to `regular`.
    */
   weight?: null | "regular" | "medium"
+
+  unstable_trackIn?: boolean
 }
 
 /**
@@ -247,6 +262,7 @@ export interface SerifProps extends Partial<TextProps> {
    * to `regular`.
    */
   weight?: null | "regular" | "semibold"
+  unstable_trackIn?: boolean
 }
 
 /**


### PR DESCRIPTION
Not 100% sure that I understand the ask correctly. But that does add `unstable_trackIn` to Sans and Serif and puts a sample in the doc file. It's collapsed by default.

Looks like that:
<img width="966" alt="Screen Shot 2020-05-15 at 2 59 26 PM" src="https://user-images.githubusercontent.com/437156/82087510-4263a280-96be-11ea-97a0-7db95fb0fee1.png">
<img width="971" alt="Screen Shot 2020-05-15 at 2 59 43 PM" src="https://user-images.githubusercontent.com/437156/82087516-455e9300-96be-11ea-82d2-09e802c3c226.png">
