### PR TITLE
No unstable_trackIn in eigen

### DIFF
--- a/packages/palette/src/elements/Typography/Typography.tsx
+++ b/packages/palette/src/elements/Typography/Typography.tsx
@@ -31,6 +31,7 @@ import {
   TextAlignProps,
 } from "styled-system"
 
+import { isReactNative } from "../../helpers/isReactNative"
 import { determineFontSizes } from "./determineFontSizes"
 
 /**
@@ -195,10 +196,14 @@ function createStyledText<P extends StyledTextProps>(
           fontFamily={
             fontFamilyType && themeProps.fontFamily[fontType][fontFamilyType]
           }
-          style={{
-            ...(unstable_trackIn ? { letterSpacing: "-0.03em" } : {}),
-            ..._style,
-          }}
+          style={
+            isReactNative()
+              ? _style
+              : {
+                  ...(unstable_trackIn ? { letterSpacing: "-0.03em" } : {}),
+                  ..._style,
+                }
+          }
           {...determineFontSizes(fontType, size)}
           // styled-components supports calling the prop `as`, but there are
           //  issues when passing it into this component named `as`. See


### PR DESCRIPTION
@oxaudo this change you made failed in eigen (artsy/eigen#3318) because the `style` prop is allowed to be an array in react-native but this code assumed that it was always an object. In this PR I just turned the `unstable_trackIn` feature off in react-native, since I guess it's a web-only thing?