### PR TITLE
Update the Banner component to work well with a content that takes more space

### DIFF
--- a/packages/palette-docs/content/docs/elements/dialogs/Banner.mdx
+++ b/packages/palette-docs/content/docs/elements/dialogs/Banner.mdx
@@ -61,3 +61,18 @@ use colored backgrounds with white text.
 </Box>
 
 <Spacer my={6} />
+
+## Dismissable Banner
+
+You can specify the `dismissable` prop when the banner should be dismissable.
+
+<Playground>
+  <Banner dismissable backgroundColor="black100">
+    Please verify your email address
+    <Button ml={2} variant="primaryWhite" size="small">
+      Resend Email
+    </Button>
+  </Banner>
+</Playground>
+
+<Spacer my={6} />

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -5,7 +5,7 @@ import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { Sans } from "../Typography"
 
-const Target = styled.div`
+const Target = styled(Flex)`
   padding-left: 10px;
   cursor: pointer;
 
@@ -28,7 +28,7 @@ const TextWrapper = styled(Flex)`
 
 const CloseButton = ({ onClick }) => {
   return (
-    <Target onClick={onClick}>
+    <Target onClick={onClick} alignItems="center">
       <CloseIcon fill="white100" />
     </Target>
   )

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -36,7 +36,7 @@ const CloseButton = ({ onClick }) => {
 
 export interface BannerProps {
   dismissable: boolean
-  message: string
+  message?: string
   backgroundColor: string
   textColor: string
 }


### PR DESCRIPTION
This PR has a few changes:

 * Make `props.message` for the `<Banner>` component optional. It can take `props.children` so we may not always have to specify `props.message`, so I think it makes sense to make it optional.
 * Fix the close button position when the context of a `<Banner>` expands the height of the component (see the before/after below).
 * Add a new Dismissable Banner section to the doc to clarify the necessity of this update.

## before

<img width="387" alt="Screen Shot 2020-05-18 at 6 11 03 PM" src="https://user-images.githubusercontent.com/386234/82265024-0a659500-9934-11ea-85af-b09530a2c214.png">

## After

<img width="391" alt="Screen Shot 2020-05-18 at 6 10 43 PM" src="https://user-images.githubusercontent.com/386234/82265032-0e91b280-9934-11ea-9ba6-c0071f57a3ca.png">

## Doc

![doc](https://user-images.githubusercontent.com/386234/82265133-4ac51300-9934-11ea-96a5-e1e6636c673c.png)

