### PR TITLE
Export BorderBoxProps in top-level package

### DIFF
--- a/packages/palette/src/elements/BorderBox/index.tsx
+++ b/packages/palette/src/elements/BorderBox/index.tsx
@@ -1,1 +1,2 @@
 export * from "./BorderBox"
+export { BorderBoxProps } from "./BorderBoxBase"


### PR DESCRIPTION
`BorderBoxProps` is exported within `BorderBoxBase` which wasn't included in the `index.tsx` exports.

Addresses [this comment](https://github.com/artsy/reaction/pull/3398#discussion_r408897421) in a previous PR and allows us to update the artsy/reaction imports which reach all the way through `dist/elements/BorderBox/BorderBoxBase`.