### PR TITLE
Use Sans Instead of Serif in EntityHeader component

### DIFF
--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -2,7 +2,7 @@ import React, { SFC } from "react"
 import { Avatar } from "../Avatar"
 import { Flex } from "../Flex"
 import { SpacerProps } from "../Spacer"
-import { Sans, Serif } from "../Typography"
+import { Sans } from "../Typography"
 
 interface EntityHeaderProps extends SpacerProps {
   href?: string
@@ -39,14 +39,9 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
         </Flex>
       )}
       <Flex justifyContent="center" width={0} flexGrow={1}>
-        <Serif
-          ellipsizeMode="tail"
-          numberOfLines={1}
-          size="3t"
-          color="black100"
-        >
+        <Sans ellipsizeMode="tail" numberOfLines={1} size="3" color="black100">
           {name}
-        </Serif>
+        </Sans>
         {!!meta && (
           <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60">
             {meta}

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -6,7 +6,7 @@ import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { Link } from "../Link"
 import { SpacerProps } from "../Spacer"
-import { Sans, Serif } from "../Typography"
+import { Sans } from "../Typography"
 
 interface EntityHeaderProps extends SpacerProps {
   href?: string
@@ -53,9 +53,9 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
       )}
 
       <Flex flexDirection="column" justifyContent="center" width="100%">
-        <Serif size="3" weight="semibold" color="black100">
+        <Sans size="3" weight="medium" color="black100">
           {name}
-        </Serif>
+        </Sans>
 
         <Sans size="2" color="black60">
           {!!meta && <span>{meta}</span>}


### PR DESCRIPTION
Before (iOS):
![Screen Shot 2020-05-26 at 12 11 36 PM](https://user-images.githubusercontent.com/10385964/82924268-15c74a80-9f4a-11ea-98c7-f96eb7148950.png)


After (iOS):
![Screen Shot 2020-05-26 at 12 00 46 PM](https://user-images.githubusercontent.com/10385964/82924155-f2040480-9f49-11ea-8a6e-864a60410018.png)


Before (web):
![Screen Shot 2020-05-22 at 7 27 38 PM](https://user-images.githubusercontent.com/10385964/82715704-639a3500-9c62-11ea-83c8-b41d6a2bf1e1.png)
![Screen Shot 2020-05-22 at 7 27 41 PM](https://user-images.githubusercontent.com/10385964/82715705-6432cb80-9c62-11ea-9194-81cf29b67055.png)
![Screen Shot 2020-05-22 at 7 27 45 PM](https://user-images.githubusercontent.com/10385964/82715706-6432cb80-9c62-11ea-9030-eda3ea647dc1.png)
![Screen Shot 2020-05-22 at 7 27 48 PM](https://user-images.githubusercontent.com/10385964/82715707-6432cb80-9c62-11ea-8f0f-6b414cc2b5c0.png)


After (web):
![Screen Shot 2020-05-22 at 6 53 06 PM](https://user-images.githubusercontent.com/10385964/82715666-35b4f080-9c62-11ea-815b-c0f5a45999bf.png)
![Screen Shot 2020-05-22 at 6 53 13 PM](https://user-images.githubusercontent.com/10385964/82715668-364d8700-9c62-11ea-8047-0e80fafb6926.png)
![Screen Shot 2020-05-22 at 6 53 19 PM](https://user-images.githubusercontent.com/10385964/82715670-364d8700-9c62-11ea-9b13-2241bb812c39.png)
![Screen Shot 2020-05-22 at 6 53 25 PM](https://user-images.githubusercontent.com/10385964/82715672-364d8700-9c62-11ea-81ab-9f8d7ef67f57.png)





https://artsyproduct.atlassian.net/browse/FX-1901