### PR TITLE
[FX-1936] Implements ModalBase (take II)

### DIFF
--- a/packages/palette/jest.config.ts
+++ b/packages/palette/jest.config.ts
@@ -1,5 +1,6 @@
 import Enzyme from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
+import "regenerator-runtime/runtime"
 
 Enzyme.configure({
   adapter: new Adapter(),

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -73,6 +73,7 @@
     "@types/luxon": "1.15.1",
     "@types/node": "10.14.6",
     "@types/react": "16.8.7",
+    "@types/react-dom": "^16.9.8",
     "@types/react-lazy-load-image-component": "1.3.0",
     "@types/react-test-renderer": "16.8.1",
     "@types/semver": "5.5.0",
@@ -102,7 +103,7 @@
     "react-native": "0.55.4",
     "react-native-svg": "9.6.4",
     "react-test-renderer": "16.8.6",
-    "regenerator-runtime": "0.11.1",
+    "regenerator-runtime": "^0.13.5",
     "simple-progress-webpack-plugin": "1.1.2",
     "static-extend": "0.1.2",
     "storybook-chromatic": "1.3.3",
@@ -123,10 +124,12 @@
     "react-lazy-load-image-component": "^1.4.1-beta.0",
     "react-live": "^1.12.0",
     "react-powerplug": "^1.0.0",
+    "react-remove-scroll": "^2.3.0",
     "react-spring": "^8.0.27",
     "styled-bootstrap-grid": "1.0.4",
     "styled-system": "^3.1.11",
-    "trunc-html": "^1.1.2"
+    "trunc-html": "^1.1.2",
+    "use-cursor": "^1.2.0"
   },
   "husky": {
     "hooks": {

--- a/packages/palette/src/elements/BarChart/BarChart.story.tsx
+++ b/packages/palette/src/elements/BarChart/BarChart.story.tsx
@@ -64,7 +64,7 @@ storiesOf("Components/BarChart", module)
         </Box>
       )
     },
-    { chromatic: { delay: 750 } }
+    { chromatic: { delay: 1000, diffThreshold: 0.75 } }
   )
 
   .add(
@@ -123,7 +123,7 @@ storiesOf("Components/BarChart", module)
         </Box>
       )
     },
-    { chromatic: { delay: 750 } }
+    { chromatic: { delay: 1000, diffThreshold: 0.75 } }
   )
 
   .add(
@@ -182,7 +182,7 @@ storiesOf("Components/BarChart", module)
         </Box>
       )
     },
-    { chromatic: { delay: 750 } }
+    { chromatic: { delay: 1000, diffThreshold: 0.75 } }
   )
 
   .add(
@@ -243,7 +243,7 @@ storiesOf("Components/BarChart", module)
         </Box>
       )
     },
-    { chromatic: { delay: 750 } }
+    { chromatic: { delay: 1000, diffThreshold: 0.75 } }
   )
 
   .add(
@@ -298,7 +298,7 @@ storiesOf("Components/BarChart", module)
         </Box>
       )
     },
-    { chromatic: { delay: 750 } }
+    { chromatic: { delay: 1000, diffThreshold: 0.75 } }
   )
 
   .add(
@@ -342,5 +342,5 @@ storiesOf("Components/BarChart", module)
         </Box>
       )
     },
-    { chromatic: { delay: 750 } }
+    { chromatic: { delay: 1000, diffThreshold: 0.75 } }
   )

--- a/packages/palette/src/elements/Modal/ModalBase.story.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.story.tsx
@@ -1,0 +1,85 @@
+import { storiesOf } from "@storybook/react"
+import React, { useState } from "react"
+import { Box } from "../Box"
+import { Button } from "../Button"
+import { Input } from "../Input"
+import { Join } from "../Join"
+import { Spacer } from "../Spacer"
+import { Sans } from "../Typography"
+import { ModalBase, ModalBaseProps } from "./ModalBase"
+
+const Example: React.FC<
+  ModalBaseProps & { dialogChildren?: JSX.Element; bodyChildren?: JSX.Element }
+> = ({ bodyChildren, dialogChildren, ...rest } = {}) => {
+  const [open, setOpen] = useState(false)
+  const label = open ? 'opened' : 'open'
+  const handleClose = () => setOpen(false)
+
+  return (
+    <>
+      <Button variant="secondaryGray" onClick={() => setOpen(true)}>
+        {label}
+      </Button>
+
+      {bodyChildren}
+
+      {open && (
+        <ModalBase onClose={handleClose} {...rest}>
+          <Box
+            background="black"
+            p={4}
+            width="100%"
+            height="100%"
+            style={{ border: "2px solid red" }}
+          >
+            <Box textAlign="center">
+              <Sans size="6" color="white100">
+                <Join separator={<Spacer my={1} />}>
+                  <>Some example content. Click outside to close.</>
+                  <Button variant="primaryWhite" onClick={handleClose}>
+                    Or click here to close.
+                  </Button>
+                  <Input placeholder="Just an example for focusing" />
+                  <Input placeholder="Just an example for focusing" />
+                  {dialogChildren}
+                </Join>
+              </Sans>
+            </Box>
+          </Box>
+        </ModalBase>
+      )}
+    </>
+  )
+}
+
+storiesOf("Components/ModalBase", module)
+  .add("Default", () => <Example />)
+  .add("Fullscreen", () => (
+    <Example
+      dialogProps={{
+        width: "100%",
+        height: "100%",
+        background: "black",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    />
+  ))
+  .add("Scrolling", () => (
+    <Example
+      bodyChildren={
+        <>
+          {[...new Array(100)].map((_, i) => (
+            <div key={i}>content should not scroll when modal is open</div>
+          ))}
+        </>
+      }
+      dialogChildren={
+        <>
+          {[...new Array(100)].map((_, i) => (
+            <div key={i}>content should be scrollable</div>
+          ))}
+        </>
+      }
+    />
+  ))

--- a/packages/palette/src/elements/Modal/ModalBase.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import { RemoveScroll } from "react-remove-scroll"
+import styled from "styled-components"
+import { zIndex as systemZIndex, ZIndexProps } from "styled-system"
+import { useCursor } from "use-cursor"
+import { Flex, FlexProps } from "../Flex"
+
+// TODO: Update TypeScript definitions for this library
+// https://github.com/theKashey/react-remove-scroll
+const ScrollIsolation = styled(RemoveScroll as any)`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+const Container = styled(Flex)`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  align-items: center;
+  justify-content: center;
+  ${systemZIndex}
+`
+
+const Dialog = styled(Flex).attrs({ role: "dialog" })`
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  > * {
+    max-height: 100%;
+  }
+`
+
+/**
+ * BaseModal
+ */
+export type ModalBaseProps = FlexProps &
+  ZIndexProps & {
+    children?: React.ReactNode
+    dialogProps?: FlexProps
+    onClose?(): void
+  }
+
+/**
+ * It seems we've landed on this value as the 'top'
+ */
+export const DEFAULT_MODAL_Z_INDEX = 9999
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "button:not([disabled])",
+  '[tabindex="0"]',
+].join(", ")
+
+/**
+ * BaseModal
+ * Low-level modal that has no opinions about layout/overlay
+ * Modals content using a portal, locks scroll.
+ */
+export const ModalBase: React.FC<ModalBaseProps> = ({
+  children,
+  zIndex = DEFAULT_MODAL_Z_INDEX,
+  dialogProps = {},
+  onClose = () => null,
+  ...rest
+}) => {
+  const appendEl = useRef(document.createElement("div"))
+  const containerEl = useRef<HTMLDivElement | null>(null)
+  const scrollIsolationEl = useRef<HTMLDivElement | null>(null)
+
+  const [focusableEls, setFocusableEls] = useState<HTMLElement[]>([])
+  const { index: focusableIndex, handlePrev, handleNext } = useCursor({
+    max: focusableEls.length,
+  })
+
+  useEffect(() => {
+    if (!focusableEls.length) return
+    focusableEls[focusableIndex].focus()
+  }, [focusableEls, focusableIndex])
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (event.target === scrollIsolationEl.current) {
+      onClose()
+    }
+  }
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case "Escape":
+        // Prevent <esc> from interfering with the returned focus
+        event.preventDefault()
+        event.stopPropagation()
+
+        // Handle close
+        return onClose()
+
+      case "Tab":
+        // Lock focus within modal
+        event.preventDefault()
+        event.stopPropagation()
+
+        // Move focus up or down
+        event.shiftKey ? handlePrev() : handleNext()
+        break
+      default:
+        break
+    }
+  }
+
+  useEffect(() => {
+    const { current } = appendEl
+
+    const focusedElBeforeOpen = document.activeElement as HTMLElement
+
+    // Append the dialog
+    document.body.appendChild(current)
+
+    // Gets the focusable elements
+    const _focusableEls = Array.from(
+      containerEl.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    )
+    setFocusableEls(_focusableEls)
+
+    // Switches focus to the first focusable element
+    _focusableEls.length && _focusableEls[0].focus()
+
+    document.addEventListener("keydown", handleKeydown)
+
+    return () => {
+      // Remove the dialog
+      document.body.removeChild(current)
+
+      // Return the focus
+      focusedElBeforeOpen.focus()
+
+      document.removeEventListener("keydown", handleKeydown)
+    }
+  }, [])
+
+  return createPortal(
+    <Container ref={containerEl as any} zIndex={zIndex} {...rest}>
+      <ScrollIsolation ref={scrollIsolationEl as any} onClick={handleClick}>
+        <Dialog
+          maxHeight={
+            // Sets to `innerHeight` so as to simulate `100vh` on iOS
+            window.innerHeight
+          }
+          {...dialogProps}
+        >
+          {children}
+        </Dialog>
+      </ScrollIsolation>
+    </Container>,
+    appendEl.current
+  )
+}
+
+ModalBase.displayName = "ModalBase"

--- a/packages/palette/src/elements/Modal/__tests__/ModalBase.test.tsx
+++ b/packages/palette/src/elements/Modal/__tests__/ModalBase.test.tsx
@@ -1,0 +1,83 @@
+import { mount } from "enzyme"
+import React, { useState } from "react"
+import { act } from "react-test-renderer"
+import { ModalBase } from "../ModalBase"
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe("ModalBase", () => {
+  it("renders the children", () => {
+    const wrapper = mount(<ModalBase>content</ModalBase>)
+    expect(wrapper.html()).toContain("content")
+  })
+
+  describe("focus management", () => {
+    const Example = () => {
+      const [open, setOpen] = useState(true)
+      return (
+        <>
+          <input id="qux" autoFocus />
+
+          <button id="open" onClick={() => setOpen(prevOpen => !prevOpen)}>
+            toggle
+          </button>
+
+          {open && (
+            <ModalBase>
+              <input id="foo" />
+              <input id="bar" />
+              <input id="baz" />
+            </ModalBase>
+          )}
+        </>
+      )
+    }
+
+    const keydown = async (key: string, shift: boolean) => {
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key, shiftKey: shift })
+        )
+      })
+      await tick()
+    }
+
+    it("focuses the initial input", () => {
+      const wrapper = mount(<Example />)
+      const input = wrapper.find("#foo")
+      expect(input.getElement().props.id).toEqual("foo")
+      expect(document.activeElement.id).toEqual("foo")
+    })
+
+    it("manages the focus", async () => {
+      mount(<Example />)
+
+      // Tabbing through
+      expect(document.activeElement.id).toEqual("foo")
+      await keydown("Tab", false)
+      expect(document.activeElement.id).toEqual("bar")
+      await keydown("Tab", false)
+      expect(document.activeElement.id).toEqual("baz")
+      // Wraps around
+      await keydown("Tab", false)
+      expect(document.activeElement.id).toEqual("foo")
+      // Shift+tab backwards
+      await keydown("Tab", true)
+      expect(document.activeElement.id).toEqual("baz")
+      await keydown("Tab", true)
+      expect(document.activeElement.id).toEqual("bar")
+      await keydown("Tab", true)
+      expect(document.activeElement.id).toEqual("foo")
+      await keydown("Tab", true)
+      // Wraps around
+      expect(document.activeElement.id).toEqual("baz")
+    })
+
+    it("returns focus to the previous element when closed", () => {
+      const wrapper = mount(<Example />)
+      expect(document.activeElement.id).toEqual("foo")
+      act(() => wrapper.find("#open").simulate("click"))
+      expect(document.activeElement.id).toEqual("qux")
+    })
+  })
+})

--- a/packages/palette/src/elements/Modal/index.tsx
+++ b/packages/palette/src/elements/Modal/index.tsx
@@ -1,1 +1,2 @@
 export * from "./Modal"
+export * from "./ModalBase"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,6 +3721,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-dom@^16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-lazy-load-image-component@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-lazy-load-image-component/-/react-lazy-load-image-component-1.3.0.tgz#c02b5c94f2776cb726b7d6bdb9507b2583cdc52d"
@@ -11172,6 +11179,11 @@ get-document@1:
   resolved "https://registry.yarnpkg.com/get-document/-/get-document-1.0.0.tgz#4821bce66f1c24cb0331602be6cb6b12c4f01c4b"
   integrity sha1-SCG85m8cJMsDMWAr5strEsTwHEs=
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
@@ -15164,6 +15176,11 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
+
+map-cursor-to-max@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-cursor-to-max/-/map-cursor-to-max-1.0.0.tgz#d46fbab9429094ae586d5995f0a1d06dd3999f15"
+  integrity sha512-BBuyrvO7X3eyQGC9GJKeNeGUnF/69OAjfI4OfroIQF0CqC3cf/vnmGJyxb2oWjwasC3eEtW4JGaO/XcArp03ig==
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -19556,6 +19573,25 @@ react-redux@^5.1.1:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
+react-remove-scroll-bar@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.1.0.tgz#edafe9b42a42c0dad9bdd10712772a1f9a39d7b9"
+  integrity sha512-5X5Y5YIPjIPrAoMJxf6Pfa7RLNGCgwZ95TdnVPgPuMftRfO8DaC7F4KP1b5eiO8hHbe7u+wZNDbYN5WUTpv7+g==
+  dependencies:
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+
+react-remove-scroll@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.3.0.tgz#3af06fe2f7130500704b676cdef94452c08fe593"
+  integrity sha512-UqVimLeAe+5EHXKfsca081hAkzg3WuDmoT9cayjBegd6UZVhlTEchleNp9J4TMGkb/ftLve7ARB5Wph+HJ7A5g==
+  dependencies:
+    react-remove-scroll-bar "^2.1.0"
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+    use-callback-ref "^1.2.3"
+    use-sidecar "^1.0.1"
+
 react-resize-detector@^3.2.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-3.4.0.tgz#2ccd399958a0efe9b7c52c5db5a13d87e47cd585"
@@ -19661,6 +19697,15 @@ react-style-proptype@^3.0.0:
   integrity sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==
   dependencies:
     prop-types "^15.5.4"
+
+react-style-singleton@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.1.0.tgz#7396885332e9729957f9df51f08cadbfc164e1c4"
+  integrity sha512-DH4ED+YABC1dhvSDYGGreAHmfuTXj6+ezT3CmHoqIEfxNgEYfIMoOtmbRp42JsUst3IPqBTDL+8r4TF7EWhIHw==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^1.0.0"
 
 react-syntax-highlighter@^8.0.1:
   version "8.1.0"
@@ -20101,15 +20146,15 @@ regenerate@^1.2.1, regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@0.11.1, regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
   integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
+
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.12.0, regenerator-runtime@^0.12.1:
   version "0.12.1"
@@ -20120,6 +20165,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
   integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
+regenerator-runtime@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -23322,6 +23372,11 @@ tslib@^1, tslib@^1.10.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
+tslib@^1.0.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 tslint-config-prettier@1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
@@ -23924,6 +23979,26 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.3.tgz#9f939dfb5740807bbf9dd79cdd4e99d27e827756"
+  integrity sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA==
+
+use-cursor@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-cursor/-/use-cursor-1.2.0.tgz#41f4bd0c99dc8c4b7c5b49973ca9c3c6f4bffaee"
+  integrity sha512-oljIxk/VFhTHrnrrY4nhHGMjVrQm0P7K1zsqRP3m3Oe9lNtikruMiyF98PE0tCDAD3LRPENrp7rwPDwfWyciIA==
+  dependencies:
+    map-cursor-to-max "^1.0.0"
+
+use-sidecar@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"
+  integrity sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==
+  dependencies:
+    detect-node "^2.0.4"
+    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
So here I'm re-implementing the lower-level modal but without forcing it onto the existing one. The intent is to use this for the mobile action sheets in Force (!), and implement any newer modally behavior on top of this. I intend to migrate the existing modal to use this as well, but I'm going to punt on that migration for the time being.

Took a slightly lighter touch here as well with only using a library for the scroll-locking, and implemented the focus management stuff myself.

Keyboard navigation demo (we really need focus rings on Buttons!):
![](http://static.damonzucconi.com/_capture/i1t1O8pVYhzs.gif)

---

I'm gonna yalc this over to Force before converting to a real PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.8.2-canary.693.11035.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@9.8.2-canary.693.11035.0
  # or 
  yarn add @artsy/palette@9.8.2-canary.693.11035.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
