### PR TITLE
Fixes mixed-in classnames coming from styled-components

### DIFF
--- a/packages/palette/src/elements/Button/Button.story.tsx
+++ b/packages/palette/src/elements/Button/Button.story.tsx
@@ -1,6 +1,11 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
+import styled from "styled-components"
 import { Button } from "./Button"
+
+const StyledButton = styled(Button)`
+  border: 2px solid red;
+`
 
 storiesOf("Components/Button", module)
   .add("small", () => {
@@ -63,6 +68,27 @@ storiesOf("Components/Button", module)
         <Button size="large" variant="noOutline">
           noOutline
         </Button>
+      </>
+    )
+  })
+  .add("styled(Button)", () => {
+    return (
+      <>
+        <StyledButton size="large" variant="primaryBlack" mr={1}>
+          primaryBlack
+        </StyledButton>
+        <StyledButton size="large" variant="primaryWhite" mr={1}>
+          primaryWhite
+        </StyledButton>
+        <StyledButton size="large" variant="secondaryGray" mr={1}>
+          secondaryGray
+        </StyledButton>
+        <StyledButton size="large" variant="secondaryOutline" mr={1}>
+          secondaryOutline
+        </StyledButton>
+        <StyledButton size="large" variant="noOutline">
+          noOutline
+        </StyledButton>
       </>
     )
   })

--- a/packages/palette/src/elements/Button/Button.test.tsx
+++ b/packages/palette/src/elements/Button/Button.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
+import styled from "styled-components"
 import { Theme } from "../../Theme"
 import { Button } from "../Button"
 
@@ -51,6 +52,7 @@ describe("Button", () => {
       </Theme>
     )
     expect(wrapper.find("Spinner").length).toBe(1)
+    expect(wrapper.html()).toContain('class="loading')
   })
 
   it("does not invoke the onClick callback if loading is true", () => {
@@ -80,5 +82,15 @@ describe("Button", () => {
     )
 
     expect(wrapper.find("button[disabled]")).toHaveLength(1)
+  })
+
+  it("has the styled-components classes on styled(Button)", () => {
+    const StyledButton = styled(Button)`
+      border: 1px solid red;
+    `
+
+    const wrapper = mount(<StyledButton>styled</StyledButton>)
+
+    expect(wrapper.html()).toContain("Buttontest__StyledButton")
   })
 })

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -187,6 +187,7 @@ export class ButtonBase extends Component<ButtonBaseProps & SansProps> {
       longestText,
       weight,
       onClick,
+      className,
       ...rest
     } = this.props
 
@@ -195,10 +196,12 @@ export class ButtonBase extends Component<ButtonBaseProps & SansProps> {
 
     return (
       <Container
-        {...rest}
-        className={[loadingClass, disabledClass].join(" ")}
+        className={[loadingClass, disabledClass, className]
+          .filter(Boolean)
+          .join(" ")}
         onClick={this.onClick}
         disabled={disabled}
+        {...rest}
       >
         {loading && <Spinner size={this.props.buttonSize} />}
 


### PR DESCRIPTION
Closes https://github.com/artsy/palette/issues/696

Weird that this uses class names instead of just props for handling these states?

![](http://static.damonzucconi.com/_capture/IHpRYFCzPgVk.png)