### PR TITLE
Update avatar component to use Sans

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.shared.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.shared.tsx
@@ -1,14 +1,14 @@
 import React, { ImgHTMLAttributes } from "react"
 import { color } from "../../helpers/color"
 import { styledWrapper } from "../../platform/primitives"
-import { SerifSize } from "../../Theme"
+import { SansSize } from "../../Theme"
 import { Flex } from "../Flex"
-import { Serif } from "../Typography"
+import { Sans } from "../Typography"
 
 export interface SizeProps {
   [key: string]: {
     diameter: string
-    typeSize: SerifSize
+    typeSize: SansSize
   }
 }
 
@@ -77,14 +77,14 @@ export const BaseAvatar = ({
         alignItems="center"
         size={size}
       >
-        <Serif
+        <Sans
           size={typeSize}
           color="black60"
-          weight="semibold"
+          weight="medium"
           lineHeight={parseInt(diameter, 10)}
         >
           {initials}
-        </Serif>
+        </Sans>
       </InitialsHolder>
     )
   } else {


### PR DESCRIPTION
While working on the Collect Resume header, @jpotts244 and I noticed that the avatar component uses Sans instead Serif (which the component has currently). This PR updates the Avatar component to Sans which we want globally.

More context in this [slack thread](https://artsy.slack.com/archives/C9YNS4X32/p1591042672438200?thread_ts=1591042646.437900&cid=C9YNS4X32).

**Before:**
<img width="882" alt="Screen Shot 2020-06-01 at 5 45 43 PM" src="https://user-images.githubusercontent.com/5201004/83458072-d5773900-a42f-11ea-974b-417433356b0f.png">

**After:**
<img width="886" alt="Screen Shot 2020-06-01 at 5 46 01 PM" src="https://user-images.githubusercontent.com/5201004/83458102-dd36dd80-a42f-11ea-8c76-7e62de43948c.png">
