### PR TITLE
allow customizing border color for BorderBox

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/BorderBox.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/BorderBox.mdx
@@ -13,6 +13,7 @@ name: BorderBox
 <Playground title="BorderBox">
   <>
     <BorderBox mb={2}>One box...</BorderBox>
-    <BorderBox>Pushes down another</BorderBox>
+    <BorderBox mb={2}>Pushes down another</BorderBox>
+    <BorderBox mb={2} borderColor="red100">And another with border color</BorderBox> 
   </>
 </Playground>

--- a/packages/palette/src/elements/BorderBox/BorderBoxBase.tsx
+++ b/packages/palette/src/elements/BorderBox/BorderBoxBase.tsx
@@ -8,6 +8,8 @@ import { Flex, FlexProps } from "../Flex"
 import {
   background,
   BackgroundProps,
+  border,
+  BorderProps,
   height,
   HeightProps,
   maxWidth,
@@ -20,6 +22,7 @@ import {
 
 export interface BorderBoxProps
   extends BackgroundProps,
+    BorderProps,
     FlexProps,
     HeightProps,
     MaxWidthProps,
@@ -37,6 +40,7 @@ export const BorderBoxBase = styledWrapper(Flex)<BorderBoxProps>`
   border-radius: 2px;
   padding: ${space(2)}px;
   ${background};
+  ${border};
   ${height};
   ${maxWidth};
   ${styledSpace};


### PR DESCRIPTION
This might be controversial since allows to expand the variation on boxes, but we do already have a way to do it by extending with Styled components and we do allow to customize spacing. So seems logical to allow to customize `borderColor` as well.

This is for the https://github.com/artsy/volt/pull/4357