### PR TITLE
BorderBox should support custom padding

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/BorderBox.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/BorderBox.mdx
@@ -14,6 +14,6 @@ name: BorderBox
   <>
     <BorderBox mb={2}>One box...</BorderBox>
     <BorderBox mb={2}>Pushes down another</BorderBox>
-    <BorderBox mb={2} borderColor="red100">And another with border color</BorderBox> 
+    <BorderBox mb={2} px={3} py={1} borderColor="red100">And another with border color and irregular padding</BorderBox> 
   </>
 </Playground>

--- a/packages/palette/src/elements/BorderBox/BorderBoxBase.tsx
+++ b/packages/palette/src/elements/BorderBox/BorderBoxBase.tsx
@@ -1,11 +1,16 @@
 // @ts-ignore
 import React from "react"
-import { border, BorderProps } from "styled-system"
+import {
+  border,
+  BorderProps,
+  space as styledSpace,
+  SpaceProps,
+} from "styled-system"
 import { color, space } from "../../helpers"
 import { styledWrapper } from "../../platform/primitives"
 import { Flex, FlexProps } from "../Flex"
 
-export interface BorderBoxProps extends FlexProps, BorderProps {
+export interface BorderBoxProps extends FlexProps, BorderProps, SpaceProps {
   hover?: boolean
 }
 
@@ -18,4 +23,5 @@ export const BorderBoxBase = styledWrapper(Flex)<BorderBoxProps>`
   border-radius: 2px;
   padding: ${space(2)}px;
   ${border}
+  ${styledSpace}
 `


### PR DESCRIPTION
I think somewhere through refactor the space prop for BorderBox was lost. And seems logical to me that it should be supported for BorderBox.

In fact arguably we should support all the properties there that Box supports + border props. But I only needed spacing for now. So adding it here to fix this view:


![](https://files.slack.com/files-pri/T02531TU5-F015FHVCCAH/screen_shot_2020-06-16_at_9.35.52_am.png)
