### PR TITLE
Remove margin on Toggle component

### DIFF
--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -81,7 +81,7 @@ export class Toggle extends React.Component<ToggleProps> {
           </Flex>
         </Header>
         {expanded && children && (
-          <Flex flexDirection="column" alignItems="left" mt={1}>
+          <Flex flexDirection="column" alignItems="left">
             {children}
           </Flex>
         )}


### PR DESCRIPTION
## Problem

White spacing on artwork filters is too large (https://artsyproduct.atlassian.net/browse/FX-1993).

#### Current behavior

![current](https://user-images.githubusercontent.com/4432348/84921675-ca104880-b092-11ea-97d5-fe0a0b6b921b.png)

#### Intended design

![intended_design](https://user-images.githubusercontent.com/4432348/84921687-ce3c6600-b092-11ea-9a67-10d8413b14cf.png)


## Solution

Remove hardcoded top margin from `Toggle` component. This impacts artwork filters on desktop and mobile web, including filters on the auction results page. (The Auctions FAQ page also uses `Toggle` but these pages will soon be retired in favor of Zendesk pages.) After this change, artwork filters will have consistent whitespacing across desktop and mobile web. Eigen does not use Palette's `Toggle` component.

**Note**: The screenshots here for the artwork filters reflect an additional (to be added) Force PR that also tweaked some margins on the filters themselves.

#### Artwork filters

![Screen Shot 2020-06-17 at 10 31 01 AM](https://user-images.githubusercontent.com/4432348/84922485-e9f43c00-b093-11ea-9cb7-0b673b823c59.png)

![Screen Shot 2020-06-17 at 10 48 43 AM](https://user-images.githubusercontent.com/4432348/84922695-3a6b9980-b094-11ea-86f0-d518840f3605.png)

#### Auction results

![Screen Shot 2020-06-17 at 10 52 31 AM](https://user-images.githubusercontent.com/4432348/84923368-1fe5f000-b095-11ea-9466-d14d24e3f5a5.png)

![Screen Shot 2020-06-17 at 10 53 18 AM](https://user-images.githubusercontent.com/4432348/84923370-1fe5f000-b095-11ea-8ae2-19fa73502be7.png)

---

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.3-canary.712.11453.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@11.0.3-canary.712.11453.0
  # or 
  yarn add @artsy/palette@11.0.3-canary.712.11453.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
