### PR TITLE
Upgrades styled-bootstrap-grid; removes overflow: hidden

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -130,7 +130,7 @@
     "react-powerplug": "^1.0.0",
     "react-remove-scroll": "^2.3.0",
     "react-spring": "^8.0.27",
-    "styled-bootstrap-grid": "1.0.4",
+    "styled-bootstrap-grid": "3.1.0",
     "styled-system": "^5.1.5",
     "trunc-html": "^1.1.2",
     "use-cursor": "^1.2.0"

--- a/packages/palette/src/elements/Grid/Grid.tsx
+++ b/packages/palette/src/elements/Grid/Grid.tsx
@@ -8,12 +8,7 @@ import {
 
 import styled from "styled-components"
 
-/**
- * TODO: v2 of `styled-bootstrap-grid` contains TS typings, but we need to
- * upgrade to styled-components 4 before it's possible to upgrade to v2.
- */
-
-/** Outter wrapper when using a grid */
+/** Outer wrapper when using a grid */
 export const Grid: any = styled(_Container)`
   overflow: hidden;
   max-width: ${props => props.theme.grid.breakpoints.xl};

--- a/packages/palette/src/elements/Grid/Grid.tsx
+++ b/packages/palette/src/elements/Grid/Grid.tsx
@@ -1,17 +1,14 @@
-import { color, flex, maxWidth, space, textAlign, width } from "styled-system"
-
 import {
   Col as _Col,
   Container as _Container,
   Row as _Row,
 } from "styled-bootstrap-grid"
-
 import styled from "styled-components"
+import { color, flex, maxWidth, space, textAlign, width } from "styled-system"
 
 /** Outer wrapper when using a grid */
 export const Grid: any = styled(_Container)`
-  overflow: hidden;
-  max-width: ${props => props.theme.grid.breakpoints.xl};
+  max-width: ${props => props.theme.grid.breakpoints.xl}px;
   ${space};
   ${maxWidth};
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -24652,10 +24652,10 @@ style-to-object@^0.2.1:
   dependencies:
     css "2.2.4"
 
-styled-bootstrap-grid@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/styled-bootstrap-grid/-/styled-bootstrap-grid-1.0.4.tgz#43417a43097ab00a8f644829f0d11ca226f16455"
-  integrity sha512-4zky8nfXzxzJ9laPTd6kpdYgfdffzk+N5kTjeDCCvnIb4qfSjJ3QfWa9Qf+UdHMA0EPAl4fFjA6keLEq8M2yhA==
+styled-bootstrap-grid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/styled-bootstrap-grid/-/styled-bootstrap-grid-3.1.0.tgz#955991a7f5a7210c5933dddfcc83707d733737a3"
+  integrity sha512-ouKxAS/WNv7B1NgjX6AVmPytjHNYP56u6qyHXzKFSIkXoSCV9xuCAzD5g4mHikl4q7E4vkTqjqIAd33BWXH5yw==
 
 styled-components@4.3.2, styled-components@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
So I'd like to use a vanilla `position: sticky` on an element that happens to be contained within a grid container and you can't actually stick anything if the parent container is `overflow: hidden`.

I can see that this property was introduced here: https://github.com/artsy/reaction/pull/1031 with the foreshadowing "It'll never be scrollable because of that (for better or worse)" 😈  but I'm not entirely sure why this was necessary?

Setting the `overflow` to `auto` on the artist page seems fine? If we *do* need it to be hidden then we can either wrap or mix in a system function for it.

@zephraph I know this was a while ago so I know the memory of this change is hazy but let me know if I'm missing something obvious here.

----

Also I upgraded styled-bootstrap-grid — that said, I have zero idea what the breaking changes in those versions might actually be: there's no changelog and https://github.com/dragma/styled-bootstrap-grid/issues/85 🤷  — the grid demo within the palette docs looks good.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.8.1-canary.716.12006.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@11.8.1-canary.716.12006.0
  # or 
  yarn add @artsy/palette@11.8.1-canary.716.12006.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
