### PR TITLE
Makes alt property required on web images

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -29,6 +29,7 @@ export const Avatar = ({
           renderFallback({ diameter })
         ) : (
           <LazyImage
+            alt={initials}
             onError={e => {
               if (onError) {
                 onError(e)

--- a/packages/palette/src/elements/CSSGrid/CSSGrid.story.tsx
+++ b/packages/palette/src/elements/CSSGrid/CSSGrid.story.tsx
@@ -19,6 +19,7 @@ storiesOf("Components/CSSGrid", module).add(
         {[1, 2, 3, 4, 5, 6, 7, 8].map(i => {
           return (
             <Image
+              alt="Random Example"
               src="https://picsum.photos/id/1025/140/100/"
               width={[100, 120, 140]}
               key={i}

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -6,6 +6,7 @@ storiesOf("Components/Image", module)
   .add("Image", () => {
     return (
       <Image
+        alt="Random Example"
         width="300px"
         height="200px"
         src="https://picsum.photos/seed/example/300/200"
@@ -18,6 +19,7 @@ storiesOf("Components/Image", module)
         {[...new Array(100)].map((_, i) => (
           <Image
             key={i}
+            alt="Random Example"
             lazyLoad
             width="300px"
             height="200px"

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -12,7 +12,7 @@ export interface WebImageProps extends ImageProps {
   /** Flag for if image should be lazy loaded */
   lazyLoad?: boolean
   /** Alternate text for image */
-  alt?: string
+  alt: string
   /** A11y text label */
   ["aria-label"]?: string
   /** The title of the image */
@@ -39,6 +39,7 @@ export const Image = ({
 
 /** Props for a web-only ResponsiveImage component. */
 export interface WebResponsiveImageProps extends ResponsiveImageProps {
+  alt: string
   /** Flag for if image should be lazy loaded */
   lazyLoad?: boolean
 }


### PR DESCRIPTION
Publishing a canary and if it's simple enough to knock down the errors I think we should merge — this is a bit of a no-brainer to enforce.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.4.1-canary.720.11774.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@11.4.1-canary.720.11774.0
  # or 
  yarn add @artsy/palette@11.4.1-canary.720.11774.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
