### PR TITLE
Supports a small entity header design via "smallVariant" prop

### DIFF
--- a/packages/palette-docs/content/docs/components/EntityHeader.mdx
+++ b/packages/palette-docs/content/docs/components/EntityHeader.mdx
@@ -34,11 +34,11 @@ When no `imageURL` is provided it will defer to the `initials` prop:
 </Playground>
 
 
-When `small` prop is provided:
+When `smallVariant` prop is provided:
 
 <Playground>
   <EntityHeader
-    small
+    smallVariant
     initials="FD"
     name="Francesca DiMattio"
     imageUrl="https://picsum.photos/110/110/?random"

--- a/packages/palette-docs/content/docs/components/EntityHeader.mdx
+++ b/packages/palette-docs/content/docs/components/EntityHeader.mdx
@@ -33,6 +33,25 @@ When no `imageURL` is provided it will defer to the `initials` prop:
   />
 </Playground>
 
+
+When `small` prop is provided:
+
+<Playground>
+  <EntityHeader
+    small
+    initials="FD"
+    name="Francesca DiMattio"
+    imageUrl="https://picsum.photos/110/110/?random"
+    href="http://www.artsy.net/artist/francesca-dimattio"
+    FollowButton={
+      <Sans size="3" style={{ textDecoration: "underline" }}>
+        Following
+      </Sans>
+    }
+  />
+</Playground>
+
+
 <Playground>
   <EntityHeader
     imageUrl="https://picsum.photos/110/110/?random"

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -5,6 +5,7 @@ import { SpacerProps } from "../Spacer"
 import { Sans } from "../Typography"
 
 interface EntityHeaderProps extends SpacerProps {
+  small?: boolean
   href?: string
   imageUrl?: string
   initials?: string
@@ -18,6 +19,7 @@ interface EntityHeaderProps extends SpacerProps {
  * Spec: zpl.io/aNoYM6d
  */
 export const EntityHeader: SFC<EntityHeaderProps> = ({
+  small,
   href,
   imageUrl,
   initials,
@@ -26,6 +28,23 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   FollowButton,
   ...remainderProps
 }) => {
+  const followButton = FollowButton && (
+    <Flex
+      ml={1}
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="flex-end"
+    >
+      {FollowButton}
+    </Flex>
+  )
+
+  const headerName = (
+    <Sans ellipsizeMode="tail" numberOfLines={1} size="3">
+      {name}
+    </Sans>
+  )
+
   return (
     <Flex
       flexDirection="row"
@@ -38,25 +57,42 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
           <Avatar size="xs" src={imageUrl} initials={initials} />
         </Flex>
       )}
-      <Flex justifyContent="center" width={0} flexGrow={1}>
-        <Sans ellipsizeMode="tail" numberOfLines={1} size="3" color="black100">
-          {name}
-        </Sans>
-        {!!meta && (
-          <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60">
-            {meta}
-          </Sans>
-        )}
-      </Flex>
 
-      {FollowButton && (
+      {small ? (
         <Flex
-          ml={1}
           flexDirection="row"
+          justifyContent="flex-start"
+          flexGrow={1}
           alignItems="center"
-          justifyContent="flex-end"
         >
-          {FollowButton}
+          {headerName}
+
+          <Sans size="3" mx={0.3}>
+            •
+          </Sans>
+
+          {followButton}
+        </Flex>
+      ) : (
+        <Flex
+          justifyContent="space-between"
+          width={0}
+          flexGrow={1}
+          flexDirection="row"
+        >
+          <Flex>
+            {headerName}
+
+            <Sans
+              ellipsizeMode="tail"
+              numberOfLines={1}
+              size="2"
+              color="black60"
+            >
+              {meta ? meta : ""}
+            </Sans>
+          </Flex>
+          {followButton}
         </Flex>
       )}
     </Flex>

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.ios.tsx
@@ -5,7 +5,7 @@ import { SpacerProps } from "../Spacer"
 import { Sans } from "../Typography"
 
 interface EntityHeaderProps extends SpacerProps {
-  small?: boolean
+  smallVariant?: boolean
   href?: string
   imageUrl?: string
   initials?: string
@@ -19,7 +19,7 @@ interface EntityHeaderProps extends SpacerProps {
  * Spec: zpl.io/aNoYM6d
  */
 export const EntityHeader: SFC<EntityHeaderProps> = ({
-  small,
+  smallVariant,
   href,
   imageUrl,
   initials,
@@ -30,7 +30,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
 }) => {
   const followButton = FollowButton && (
     <Flex
-      ml={1}
+      ml={smallVariant ? 0.3 : 1}
       flexDirection="row"
       alignItems="center"
       justifyContent="flex-end"
@@ -58,7 +58,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
         </Flex>
       )}
 
-      {small ? (
+      {smallVariant ? (
         <Flex
           flexDirection="row"
           justifyContent="flex-start"
@@ -67,7 +67,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
         >
           {headerName}
 
-          <Sans size="3" mx={0.3}>
+          <Sans size="3" ml={0.3}>
             •
           </Sans>
 

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -16,6 +16,7 @@ interface EntityHeaderProps extends SpacerProps {
   name: string
   FollowButton?: JSX.Element
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
+  small?: boolean
 }
 
 interface ContainerComponentProps {
@@ -35,6 +36,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   name,
   meta,
   FollowButton,
+  small,
   ...remainderProps
 }) => {
   const ContainerComponent = href ? FlexLink : Flex
@@ -52,35 +54,68 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
         </Flex>
       )}
 
-      <Flex flexDirection="column" justifyContent="center" width="100%">
-        <Sans size="3" weight="medium" color="black100">
-          {name}
-        </Sans>
+      {small ? (
+        <Flex alignItems="center" width="100%">
+          <Sans size="3">{name}</Sans>
 
-        <Sans size="2" color="black60">
-          {!!meta && <span>{meta}</span>}
+          <Sans size="3">
+            {FollowButton && (
+              <>
+                {
+                  <Sans size="3" mx={0.3} display="inline-block">
+                    •
+                  </Sans>
+                }
+                <Box
+                  display="inline-block"
+                  onClick={event => {
+                    // Capture click event so that interacting with Follow doesn't
+                    // trigger Container's link.
+                    event.stopPropagation()
+                  }}
+                >
+                  {FollowButton}
+                </Box>
+              </>
+            )}
+          </Sans>
+        </Flex>
+      ) : (
+        <Flex flexDirection="column" justifyContent="center" width="100%">
+          <Sans size="3" weight="medium" color="black100">
+            {name}
+          </Sans>
 
-          {FollowButton && (
-            <>
-              {meta && (
-                <Sans size="2" color="black60" mx={0.3} display="inline-block">
-                  •
-                </Sans>
-              )}
-              <Box
-                display="inline-block"
-                onClick={event => {
-                  // Capture click event so that interacting with Follow doesn't
-                  // trigger Container's link.
-                  event.stopPropagation()
-                }}
-              >
-                {FollowButton}
-              </Box>
-            </>
-          )}
-        </Sans>
-      </Flex>
+          <Sans size="2" color="black60">
+            {!!meta && <span>{meta}</span>}
+
+            {FollowButton && (
+              <>
+                {meta && (
+                  <Sans
+                    size="2"
+                    color="black60"
+                    mx={0.3}
+                    display="inline-block"
+                  >
+                    •
+                  </Sans>
+                )}
+                <Box
+                  display="inline-block"
+                  onClick={event => {
+                    // Capture click event so that interacting with Follow doesn't
+                    // trigger Container's link.
+                    event.stopPropagation()
+                  }}
+                >
+                  {FollowButton}
+                </Box>
+              </>
+            )}
+          </Sans>
+        </Flex>
+      )}
     </ContainerComponent>
   )
 }

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -16,7 +16,7 @@ interface EntityHeaderProps extends SpacerProps {
   name: string
   FollowButton?: JSX.Element
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  small?: boolean
+  smallVariant?: boolean
 }
 
 interface ContainerComponentProps {
@@ -36,7 +36,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   name,
   meta,
   FollowButton,
-  small,
+  smallVariant,
   ...remainderProps
 }) => {
   const ContainerComponent = href ? FlexLink : Flex
@@ -54,7 +54,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
         </Flex>
       )}
 
-      {small ? (
+      {smallVariant ? (
         <Flex alignItems="center" width="100%">
           <Sans size="3">{name}</Sans>
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2070

The Entity Header Palette component should support receiving a `smallVariant` prop that changes the layout and design of the component. When this prop is passed the component only renders the Entity name and Followed/Unfollowed State.

With the `smallVariant` prop on iOS:
![Screen Shot 2020-07-02 at 3 35 45 PM](https://user-images.githubusercontent.com/10385964/86402537-fe325e80-bc79-11ea-8342-8e004b1fe4e9.png)
![Screen Shot 2020-07-02 at 3 35 51 PM](https://user-images.githubusercontent.com/10385964/86402538-fe325e80-bc79-11ea-856a-81637c9b7cd1.png)


Without the `smallVariant` prop on iOS:
![Screen Shot 2020-07-02 at 1 15 55 PM](https://user-images.githubusercontent.com/10385964/86392333-41380600-bc69-11ea-81f9-8fb848a2245a.png)


With the `smallVariant` prop on web:
![Screen Shot 2020-07-02 at 11 23 31 AM](https://user-images.githubusercontent.com/10385964/86392342-45fcba00-bc69-11ea-961d-2a788d6073d5.png)

Without the `smallVariant` prop on web:
![Screen Shot 2020-07-02 at 1 24 53 PM](https://user-images.githubusercontent.com/10385964/86392349-4bf29b00-bc69-11ea-8008-7566dc164a4b.png)


In the Palette Playground:
![Screen Shot 2020-07-02 at 1 30 38 PM](https://user-images.githubusercontent.com/10385964/86392386-5d3ba780-bc69-11ea-8351-fc317c1f4d38.png)
