### PR TITLE
Removes blanket focus disable

### DIFF
--- a/packages/palette/src/helpers/injectGlobalStyles.tsx
+++ b/packages/palette/src/helpers/injectGlobalStyles.tsx
@@ -10,11 +10,6 @@ export function injectGlobalStyles<P>(
   additionalStyles?: string | ReturnType<typeof css>
 ) {
   const GlobalStyles = createGlobalStyle<P>`
-
-    *:focus {
-      outline: none;
-    }
-
     html {
       -webkit-box-sizing: border-box;
               box-sizing: border-box;
@@ -136,7 +131,7 @@ export function injectGlobalStyles<P>(
       font-size: inherit;
       margin: 0;
     }
-    
+
     ${additionalStyles};
   `
 


### PR DESCRIPTION
This is a pretty presumptuous rule to have in here and we shouldn't be doing this anyway.

I ran into this because in trying to clean up how we integrate `:focus-visible` — this is sometimes winning in specificity depending on where I insert the CSS.
