### PR TITLE
GALL-2970 Add web version of medium card

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/Cards.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Cards.mdx
@@ -64,7 +64,7 @@ name: Cards
 <Playground title="Medium Card with tag">
   <Box width="50%" p="2px" backgroundColor="yellow30">
     <MediumCard
-      image="https://www.fillmurray.com/400/300"
+      image="https://www.fillmurray.com/280/370"
       title="Check this out"
       subtitle="It's good"
       tag={{

--- a/packages/palette/src/elements/Cards/MediumCard.tsx
+++ b/packages/palette/src/elements/Cards/MediumCard.tsx
@@ -1,10 +1,49 @@
 import React from "react"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
+import { Image } from "../Image"
+import { Sans } from "../Typography"
+import { CardTag } from "./CardTag"
 import { MediumCardProps } from "./MediumCard.shared"
 
 /**
  * `MediumCard` is a card with one image one tall image, and text for title and subtitle
  * at the bottom.
  */
-export const MediumCard: React.FC<MediumCardProps> = ({}) => {
-  return null
+export const MediumCard: React.FC<MediumCardProps> = ({
+  image,
+  title,
+  subtitle,
+  tag
+}) => {
+  return (
+    <Box width="280px" height="370px" position="relative">
+      <Flex
+        width="100%"
+        height="100%"
+        position="absolute"
+        top="0"
+        borderRadius="4px"
+        overflow="hidden"
+      >
+        <Image src={image} alt={title} height="100%" width="auto" />
+        <Box
+          style={{
+            background: "linear-gradient(rgba(0, 0, 0, 0), rgba(0,0,0,1))",
+            opacity: 0.15
+          }}
+          position="absolute" width="100%" height="100%"
+        />
+        <Box position="absolute" bottom="15px" left="15px">
+          <Sans size="5t" weight="regular" color="white100">
+            {title}
+          </Sans>
+          <Sans size="3t" weight="regular" color="white100">
+            {subtitle}
+          </Sans>
+        </Box>
+        {!!tag && <CardTag {...tag} position="absolute" top="15px" left="15px" />}
+      </Flex>
+    </Box >
+  )
 }


### PR DESCRIPTION
Adds a medium size card to palette. See spec for medium card here: https://www.figma.com/file/GrCeNUJbKpfZtgwHga64cC/Artsy-Viewing-Room-Entry-Points-Components?node-id=78%3A1368

<img width="349" alt=" 2020-07-15 at 3 26 35 PM" src="https://user-images.githubusercontent.com/1389948/87587097-a6e7b180-c6af-11ea-9884-2d16f3082587.png">
