### PR TITLE
Implements utility for breaking apart layout props

### DIFF
--- a/packages/palette/src/elements/Box/Box.tsx
+++ b/packages/palette/src/elements/Box/Box.tsx
@@ -1,5 +1,3 @@
-// @ts-ignore
-import React from "react"
 import { styled as primitives } from "../../platform/primitives"
 
 import {
@@ -55,3 +53,28 @@ export const Box = primitives.View<BoxProps>`
 `
 
 Box.displayName = "Box"
+
+/** RegExp for filtering BoxProps */
+export const BOX_PROP_REGEX = new RegExp(`^(${boxMixin.propNames.join("|")})$`)
+
+/** Splits out props into valid and invalid BoxProps */
+export const splitBoxProps = <
+  T extends BoxProps,
+  U extends Omit<T, keyof BoxProps>
+>(
+  props: T
+): [BoxProps, U] => {
+  const boxProps = {} as T
+  const notBoxProps = {} as U
+
+  for (const key of Object.keys(props)) {
+    if (BOX_PROP_REGEX.test(key)) {
+      boxProps[key] = props[key]
+      continue
+    }
+
+    notBoxProps[key] = props[key]
+  }
+
+  return [boxProps, notBoxProps]
+}

--- a/packages/palette/src/elements/Box/__tests__/Box.test.tsx
+++ b/packages/palette/src/elements/Box/__tests__/Box.test.tsx
@@ -1,0 +1,23 @@
+import { splitBoxProps } from "../index"
+
+describe("splitBoxProps", () => {
+  it("splits props into valid and invalid BoxProps", () => {
+    const [boxProps, nonBoxProps] = splitBoxProps({
+      position: "absolute",
+      foo: "bar",
+      bar: { baz: "qux" },
+      m: 1,
+      px: 4,
+      textAlign: "center",
+    })
+
+    expect(boxProps).toStrictEqual({
+      m: 1,
+      position: "absolute",
+      px: 4,
+      textAlign: "center",
+    })
+
+    expect(nonBoxProps).toStrictEqual({ bar: { baz: "qux" }, foo: "bar" })
+  })
+})


### PR DESCRIPTION
OK, so I'd like to break apart https://github.com/artsy/palette/pull/730 into some more manageable pieces.

This gives us a typesafe utility that we can use when you have compound components where you've got an outer Box container that is being used to manage layout but would like to spread native rest props on the inner component (think img, input, etc).

![](https://static.damonzucconi.com/_capture/ULXilKck9oH7.png)