### PR TITLE
Breakpoints aliasing

### DIFF
--- a/packages/palette/src/Theme.tsx
+++ b/packages/palette/src/Theme.tsx
@@ -49,6 +49,15 @@ export const unitlessBreakpoints = {
 }
 
 /**
+ * We alias breakpoints onto the scale so that styled-system has access
+ * to the named breakpoints as well as the scale
+ */
+const BREAKPOINTS_SCALE = Object.assign(
+  [breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl],
+  breakpoints
+)
+
+/**
  * All of the config for the Artsy theming system, based on the
  * design system from our design team:
  * https://www.notion.so/artsy/Master-Library-810612339f474d0997fe359af4285c56
@@ -60,7 +69,7 @@ export const themeProps = {
   /**
    *  This allows styled-system to hook into our breakpoints
    */
-  breakpoints: [breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl],
+  breakpoints: BREAKPOINTS_SCALE,
 
   /**
    * Artsy's color schemes:

--- a/packages/palette/src/elements/Grid/Grid.story.tsx
+++ b/packages/palette/src/elements/Grid/Grid.story.tsx
@@ -1,0 +1,29 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { BorderBox } from "../BorderBox"
+import { Col, Grid, Row } from "./Grid"
+
+storiesOf("Components/Grid", module).add("Basic", () => {
+  return (
+    <Grid
+      border={{
+        default: "4px solid pink",
+        xs: "4px solid red",
+        sm: "4px solid green",
+        md: "4px solid gold",
+        lg: "4px solid purple",
+        xl: "4px solid blue",
+      }}
+    >
+      <Row>
+        {[...new Array(12)].map((_, i) => {
+          return (
+            <Col sm={1} key={i}>
+              <BorderBox>{i + 1}</BorderBox>
+            </Col>
+          )
+        })}
+      </Row>
+    </Grid>
+  )
+})

--- a/packages/palette/src/elements/Grid/Grid.tsx
+++ b/packages/palette/src/elements/Grid/Grid.tsx
@@ -4,28 +4,55 @@ import {
   Row as _Row,
 } from "styled-bootstrap-grid"
 import styled from "styled-components"
-import { color, flex, maxWidth, space, textAlign, width } from "styled-system"
+import {
+  border,
+  BorderProps,
+  color,
+  ColorProps,
+  compose,
+  flex,
+  FlexProps,
+  maxWidth,
+  MaxWidthProps,
+  space,
+  SpaceProps,
+  textAlign,
+  TextAlignProps,
+  width,
+  WidthProps,
+} from "styled-system"
 
 /** Outer wrapper when using a grid */
-export const Grid: any = styled(_Container)`
+export const Grid = styled(_Container)<
+  SpaceProps & MaxWidthProps & BorderProps
+>`
   max-width: ${props => props.theme.grid.breakpoints.xl}px;
-  ${space};
-  ${maxWidth};
+  ${compose(
+    space,
+    maxWidth,
+    border
+  )};
 `
 
 /** Grid row */
-export const Row: any = styled(_Row)`
-  ${color};
-  ${space};
+export const Row = styled(_Row)<ColorProps & SpaceProps>`
+  ${compose(
+    color,
+    space
+  )};
 `
 
 /** Grid column */
-export const Col: any = styled(_Col)`
-  ${color};
-  ${flex};
-  ${space};
-  ${textAlign};
-  ${width};
+export const Col = styled(_Col)<
+  ColorProps & FlexProps & SpaceProps & TextAlignProps & WidthProps
+>`
+  ${compose(
+    color,
+    flex,
+    space,
+    textAlign,
+    width
+  )}
 `
 
 Grid.displayName = "Grid"


### PR DESCRIPTION
@williardx has an interesting use case where he wants to override the Grid's `maxWidth` and set it to 100% when at or below the small breakpoint.

Initially I had thought you should be able to use the responsive props for this but it turns out that's not useful because in terms of the directionality of the media query, to do this you'd want a max-width, and responsive props create styles using min-width.

Nonetheless, I thought I'd PR support for object style syntax here. Which at least makes this a lot more clear and less mysterious.

![](http://static.damonzucconi.com/_capture/TJtNv1DbBucy.gif)