### PR TITLE
Removes shadow on iOS

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -75,6 +75,7 @@ export const computeBorderColor = (inputStatus: InputStatus): Color => {
 }
 
 const StyledInput = styled.input<StyledInputProps>`
+  appearance: none;
   font-family: ${themeGet("fontFamily.sans.regular")};
   font-size: ${themeGet("typeSizes.sans.3.fontSize")};
   line-height: ${themeGet("typeSizes.sans.3t.lineHeight")};


### PR DESCRIPTION
Thing that was bothering me when I was debugging just now:

Before:
![](https://static.damonzucconi.com/_capture/kMw6TJlB4DA3.png)

After:
![](https://static.damonzucconi.com/_capture/aNlHRAfE9vOU.png)