### PR TITLE
Uses native Text and TextProps

### DIFF
--- a/packages/palette/src/elements/Text/Text.ios.tsx
+++ b/packages/palette/src/elements/Text/Text.ios.tsx
@@ -1,6 +1,7 @@
 import React from "react"
+import { Text as NativeText, TextProps as NativeTextProps } from "react-native"
+import { styled } from "styled-components/native"
 import { variant as systemVariant } from "styled-system"
-import { styled as primitives } from "../../platform/primitives"
 import { BaseTextProps, textMixin } from "./Text.shared"
 import {
   calculateLetterSpacing,
@@ -12,9 +13,9 @@ import {
 } from "./tokens.ios"
 
 /** TextProps */
-export type TextProps = BaseTextProps
+export type TextProps = BaseTextProps & NativeTextProps
 
-const InnerText = primitives.Text<TextProps>`
+const InnerText = styled(NativeText)<TextProps>`
   ${systemVariant({ variants: TEXT_VARIANTS })}
   ${textMixin}
 `


### PR DESCRIPTION
@pvinis pointed out we're missing the native props here. I'm not sure if this is the appropriate way to go about this — @damassi? There are type-errors with the `primitives.Text` but it's not needed since this isn't shared anyway.

![](http://static.damonzucconi.com/_capture/ZHMirvVzVLCq.png)