### PR TITLE
Reverts serif removal, migrates HTML to new typography

### DIFF
--- a/packages/palette/src/elements/HTML/HTML.story.tsx
+++ b/packages/palette/src/elements/HTML/HTML.story.tsx
@@ -11,7 +11,7 @@ const HTML_EXAMPLE = `
 
 <h4>H4 Headline</h4>
 
-<p>I’m of the opinion that they use no inert material. All their equipment and instruments are alive, in some form or other.</p>
+<p>I’m <em>of the opinion</em> that they use <strong>no <em>inert</em> material.</strong> All their equipment and instruments are alive, in some form or other.</p>
 
 <p>They don’t construct or build at all. The idea of making is foreign to them. They utilize existing forms. Even their ships—</p>
 
@@ -31,9 +31,21 @@ const HTML_EXAMPLE = `
 storiesOf("Components/HTML", module).add("HTML", () => {
   return (
     <>
-      <HTML style={{ border: "1px dotted" }} size="6" html={HTML_EXAMPLE} />
-      <HTML style={{ border: "1px dotted" }} size="4" html={HTML_EXAMPLE} />
-      <HTML style={{ border: "1px dotted" }} size="1" html={HTML_EXAMPLE} />
+      <HTML
+        style={{ border: "1px dotted" }}
+        variant="title"
+        html={HTML_EXAMPLE}
+      />
+      <HTML
+        style={{ border: "1px dotted" }}
+        variant="text"
+        html={HTML_EXAMPLE}
+      />
+      <HTML
+        style={{ border: "1px dotted" }}
+        variant="small"
+        html={HTML_EXAMPLE}
+      />
     </>
   )
 })

--- a/packages/palette/src/elements/HTML/HTML.tsx
+++ b/packages/palette/src/elements/HTML/HTML.tsx
@@ -1,62 +1,46 @@
-import React from "react"
+import React, { HTMLAttributes } from "react"
 import styled, { css } from "styled-components"
 import { space } from "../../helpers/space"
-import { Box } from "../Box"
-import { Sans, SansProps, Serif, SerifProps } from "../Typography"
+import { Text, TextProps } from "../Text"
 
 /**
  * HTML
  */
-export type HTMLProps = (SansProps | SerifProps) & {
-  fontFamily?: "sans" | "serif"
-  html: string
-}
+export type HTMLProps = TextProps &
+  HTMLAttributes<HTMLDivElement | HTMLHeadingElement | HTMLParagraphElement> & {
+    html: string
+  }
 
 const htmlMixin = css`
-  > ${Box} {
-    > h1,
-    > h2,
-    > h3,
-    > h4,
-    > h5,
-    > ul,
-    > ol,
-    > p {
-      margin: ${space(1)}px auto;
+  > h1,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > ul,
+  > ol,
+  > p {
+    margin: ${space(1)}px auto;
 
-      &:first-child {
-        margin-top: 0;
-      }
+    &:first-child {
+      margin-top: 0;
+    }
 
-      &:last-child {
-        margin-bottom: 0;
-      }
+    &:last-child {
+      margin-bottom: 0;
     }
   }
 `
 
-const TYPEFACES = {
-  sans: styled(Sans)`
-    ${htmlMixin}
-  `,
-  serif: styled(Serif)`
-    ${htmlMixin}
-  `,
-} as const
-
-type Typeface = keyof typeof TYPEFACES
+const Container = styled(Text)`
+  ${htmlMixin}
+`
 
 /**
  * HTML
  */
-export const HTML = ({ fontFamily = "sans", html, size, ...rest }) => {
-  const Component = TYPEFACES[fontFamily as Typeface]
-
-  return (
-    <Component size={size} {...rest}>
-      <Box dangerouslySetInnerHTML={{ __html: html }} />
-    </Component>
-  )
+export const HTML: React.FC<HTMLProps> = ({ html, ...rest }) => {
+  return <Container dangerouslySetInnerHTML={{ __html: html }} {...rest} />
 }
 
 HTML.displayName = "HTML"

--- a/packages/palette/src/elements/Text/Text.story.tsx
+++ b/packages/palette/src/elements/Text/Text.story.tsx
@@ -131,6 +131,7 @@ storiesOf("Components/Text", module)
         letterSpacing: "tightest",
       },
       {
+        fontFamily: "serif",
         fontSize: "70px",
         lineHeight: "solid",
         letterSpacing: "tight",
@@ -142,14 +143,16 @@ storiesOf("Components/Text", module)
         letterSpacing: "tightest",
       },
       {
+        fontFamily: "serif",
         fontSize: "55px",
         lineHeight: "solid",
         letterSpacing: "tightest",
       },
       {
-        variant: 'text',
-        lineHeight: 'solid'
-      }
+        fontFamily: "serif",
+        variant: "text",
+        lineHeight: "solid",
+      },
     ] as const
 
     return (

--- a/packages/palette/src/elements/Text/tokens.ts
+++ b/packages/palette/src/elements/Text/tokens.ts
@@ -5,4 +5,5 @@ export * from "./tokens.shared"
  */
 export const TEXT_FONTS = {
   sans: '"ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif',
+  serif: '"adobe-garamond-pro", "Times New Roman", Times, serif',
 }


### PR DESCRIPTION
So:

> Garamond will continue to be used in Editorial, and in all B2B web pages and outreach.

So I've reverted its removal here.

Also updating the HTML component to extend Text instead of Sans/Serif. This will constitute a breaking change, though the only call sites currently are on the Feature pages. I'll handle the integration of this as soon as it's released.

One other nice thing about this is now we get proper bold and italic fonts within rendered HTML 🥳 

![](http://static.damonzucconi.com/_capture/xdwPKlPKbhk0.png)