### PR TITLE
Adds remaining block-level elements that can come from rendered Markdown

### DIFF
--- a/packages/palette/src/elements/HTML/HTML.story.tsx
+++ b/packages/palette/src/elements/HTML/HTML.story.tsx
@@ -26,6 +26,12 @@ const HTML_EXAMPLE = `
   <li>second</li>
   <li>third</li>
 </ul>
+
+<hr />
+
+<pre><code>this is a code block</code></pre>
+
+<blockquote>This is a block quote</blockquote>
 `
 
 storiesOf("Components/HTML", module).add("HTML", () => {

--- a/packages/palette/src/elements/HTML/HTML.tsx
+++ b/packages/palette/src/elements/HTML/HTML.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes } from "react"
 import styled, { css } from "styled-components"
+import { color } from "../../helpers"
 import { space } from "../../helpers/space"
 import { Text, TextProps } from "../Text"
 
@@ -19,7 +20,10 @@ const htmlMixin = css`
   > h5,
   > ul,
   > ol,
-  > p {
+  > p,
+  > blockquote,
+  > pre,
+  > hr {
     margin: ${space(1)}px auto;
 
     &:first-child {
@@ -29,6 +33,12 @@ const htmlMixin = css`
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  > hr {
+    height: 1px;
+    border: 0;
+    background-color: ${color("black10")};
   }
 `
 


### PR DESCRIPTION
Minor thing, normalizing the remaining block-level elements that might come out of Markdown.

Not trying to be super comprehensive with how these are styled (for instance we're targeting `blockquote` specifically on Features) — but rather just give everything a normalized reasonable default.