### PR TITLE
Updates avatar size and typography for entity header small variant

### DIFF
--- a/packages/palette-docs/content/docs/components/EntityHeader.mdx
+++ b/packages/palette-docs/content/docs/components/EntityHeader.mdx
@@ -10,9 +10,9 @@ name: EntityHeader
     meta="American, b. 1979"
     href="http://www.artsy.net/artist/francesca-dimattio"
     FollowButton={
-      <Sans size="2" weight="medium" color="black">
+      <Text variant="caption" weight="medium" color="black">
         Follow
-      </Sans>
+      </Text>
     }
   />
 </Playground>
@@ -26,9 +26,9 @@ When no `imageURL` is provided it will defer to the `initials` prop:
     meta="American, b. 1979"
     href="http://www.artsy.net/artist/francesca-dimattio"
     FollowButton={
-      <Sans size="2" weight="medium" color="black">
+      <Text variant="caption" weight="medium" color="black">
         Follow
-      </Sans>
+      </Text>
     }
   />
 </Playground>
@@ -44,9 +44,9 @@ When `smallVariant` prop is provided:
     imageUrl="https://picsum.photos/110/110/?random"
     href="http://www.artsy.net/artist/francesca-dimattio"
     FollowButton={
-      <Sans size="3" style={{ textDecoration: "underline" }}>
+      <Text variant="text" style={{ textDecoration: "underline" }}>
         Following
-      </Sans>
+      </Text>
     }
   />
 </Playground>

--- a/packages/palette/src/elements/Avatar/Avatar.shared.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.shared.tsx
@@ -15,6 +15,10 @@ export interface SizeProps {
 
 /** Size */
 export const Size: SizeProps = {
+  xxs: {
+    diameter: "30px",
+    typeSize: "3",
+  },
   xs: {
     diameter: "45px",
     typeSize: "3",
@@ -29,11 +33,13 @@ export const Size: SizeProps = {
   },
 }
 
-type SizeKey = "xs" | "sm" | "md"
+type SizeKey = "xxs" | "xs" | "sm" | "md"
 
 /** sizeValue */
 export const sizeValue = (size: SizeKey) => {
   switch (size) {
+    case "xxs":
+      return Size.xxs
     case "xs":
       return Size.xs
     case "sm":

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -6,7 +6,7 @@ import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { Link } from "../Link"
 import { SpacerProps } from "../Spacer"
-import { Sans } from "../Typography"
+import { Text } from "../Text"
 
 interface EntityHeaderProps extends SpacerProps {
   href?: string
@@ -50,21 +50,25 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
     <ContainerComponent {...remainderProps} {...containerProps}>
       {(imageUrl || initials) && (
         <Flex mr={1}>
-          <Avatar size="xs" src={imageUrl} initials={initials} />
+          <Avatar
+            size={smallVariant ? "xxs" : "xs"}
+            src={imageUrl}
+            initials={initials}
+          />
         </Flex>
       )}
 
       {smallVariant ? (
         <Flex alignItems="center" width="100%">
-          <Sans size="3">{name}</Sans>
+          <Text variant="text">{name}</Text>
 
-          <Sans size="3">
+          <Text variant="text">
             {FollowButton && (
               <>
                 {
-                  <Sans size="3" mx={0.3} display="inline-block">
+                  <Text variant="text" mx={0.3} display="inline-block">
                     •
-                  </Sans>
+                  </Text>
                 }
                 <Box
                   display="inline-block"
@@ -78,28 +82,28 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
                 </Box>
               </>
             )}
-          </Sans>
+          </Text>
         </Flex>
       ) : (
         <Flex flexDirection="column" justifyContent="center" width="100%">
-          <Sans size="3" weight="medium" color="black100">
+          <Text variant="mediumText" color="black100">
             {name}
-          </Sans>
+          </Text>
 
-          <Sans size="2" color="black60">
+          <Text variant="caption" color="black60">
             {!!meta && <span>{meta}</span>}
 
             {FollowButton && (
               <>
                 {meta && (
-                  <Sans
-                    size="2"
+                  <Text
+                    variant="caption"
                     color="black60"
                     mx={0.3}
                     display="inline-block"
                   >
                     •
-                  </Sans>
+                  </Text>
                 )}
                 <Box
                   display="inline-block"
@@ -113,7 +117,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
                 </Box>
               </>
             )}
-          </Sans>
+          </Text>
         </Flex>
       )}
     </ContainerComponent>


### PR DESCRIPTION
The `smallVariant` needs some updates, per https://artsyproduct.atlassian.net/browse/FX-2149.

This PR updates the avatar size to be 30px and uses the new type variants.

![image](https://user-images.githubusercontent.com/2081340/90183997-6f3d5980-dd82-11ea-871e-c2853d4b2495.png)
