### PR TITLE
Chore - Cleanup Dependency Cycles

### DIFF
--- a/packages/palette/src/elements/LabeledRange/LabeledRange.tsx
+++ b/packages/palette/src/elements/LabeledRange/LabeledRange.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import styled from "styled-components"
 import { space, SpaceProps } from "styled-system"
-import { Flex, Sans, Slider, SliderProps } from "../"
+import { Flex } from "../Flex"
+import { Slider, SliderProps } from "../Slider"
+import { Sans } from "../Typography"
 
 interface LabeledRangeProps extends SliderProps {
   label: string
@@ -20,7 +22,7 @@ interface LabeledRangeState {
 export class LabeledRange extends React.Component<
   LabeledRangeProps,
   LabeledRangeState
-> {
+  > {
   static defaultProps = {
     disabled: false,
   }
@@ -69,17 +71,17 @@ export class LabeledRange extends React.Component<
               {disabledText}
             </Sans>
           ) : (
-            <Flex justifyContent="space-between">
-              <Sans size="2" color="black100" mt={0.3}>
-                {label}
-              </Sans>
-              <Sans size="2" color="black60" mt={0.3}>
-                {formatter
-                  ? formatter(min, max, this.maxIndicator())
-                  : this.toString()}
-              </Sans>
-            </Flex>
-          )}
+              <Flex justifyContent="space-between">
+                <Sans size="2" color="black100" mt={0.3}>
+                  {label}
+                </Sans>
+                <Sans size="2" color="black60" mt={0.3}>
+                  {formatter
+                    ? formatter(min, max, this.maxIndicator())
+                    : this.toString()}
+                </Sans>
+              </Flex>
+            )}
         </Header>
 
         <Flex flexDirection="column" alignItems="left" mt={-1} mb={1}>

--- a/packages/palette/src/elements/Pagination/Pagination.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.tsx
@@ -1,9 +1,12 @@
 import React from "react"
 import styled, { css } from "styled-components"
 
-import { Box, Flex, Sans } from "../"
-import { color, space } from "../../helpers"
-import { ChevronIcon } from "../../svgs"
+import { color } from "../../helpers/color"
+import { space } from "../../helpers/space"
+import { ChevronIcon } from "../../svgs/ChevronIcon"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
+import { Sans } from "../Typography"
 
 interface Props {
   onClick?: (cursor: string, page: number) => void

--- a/packages/palette/src/elements/PriceRange/PriceRange.tsx
+++ b/packages/palette/src/elements/PriceRange/PriceRange.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { LabeledRange, SliderProps } from "../"
+import { LabeledRange } from "../LabeledRange"
+import { SliderProps } from "../Slider"
 
 interface PriceRangeProps extends SliderProps {
   currency?: string

--- a/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
@@ -1,15 +1,13 @@
 import { DateTime } from "luxon"
 import React from "react"
-import {
-  Flex,
-  ProgressBarTimer,
-  Sans,
-  Spacer,
-  StackableBorderBox,
-  TimeRemaining,
-} from "../"
-import { TimerIcon } from "../../svgs"
+import { TimerIcon } from "../../svgs/TimerIcon"
 import { useCurrentTime } from "../../utils/useCurrentTime"
+import { Flex } from "../Flex"
+import { ProgressBarTimer } from "../ProgressBarTimer"
+import { Spacer } from "../Spacer"
+import { StackableBorderBox } from "../StackableBorderBox"
+import { TimeRemaining } from "../TimeRemaining"
+import { Sans } from "../Typography"
 
 const FIVE_HOURS_IN_SECONDS = 60 * 60 * 5
 
@@ -37,7 +35,7 @@ export const StaticCountdownTimer: React.SFC<{
   const time = `${hour}:${minutes}${amPm}`
   const actionDeadline = `${endDateTime.monthShort} ${
     endDateTime.day
-  }, ${time} ${endDateTime.offsetNameShort}`
+    }, ${time} ${endDateTime.offsetNameShort}`
 
   const highlight =
     endDateTime.diff(

--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -1,10 +1,13 @@
 import React from "react"
 import styled from "styled-components"
 
-import { Flex, Sans, Tab, Tabs, TabsProps } from "../"
-import { space } from "../../helpers"
-import { CheckIcon, ChevronIcon } from "../../svgs"
+import { space } from "../../helpers/space"
+import { CheckIcon } from "../../svgs/CheckIcon"
+import { ChevronIcon } from "../../svgs/ChevronIcon"
+import { Flex } from "../Flex"
+import { Tab, Tabs, TabsProps } from "../Tabs"
 import { sharedTabsStyles } from "../Tabs"
+import { Sans } from "../Typography"
 
 interface StepperProps extends TabsProps {
   /** The initial step stepper renders */

--- a/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
+++ b/packages/palette/src/elements/TimeRemaining/TimeRemaining.tsx
@@ -1,9 +1,10 @@
 import { DateTime, Duration } from "luxon"
 import React from "react"
-import { Flex, Sans } from "../"
-import { color } from "../../helpers"
+import { color } from "../../helpers/color"
 import { SansSize } from "../../Theme"
 import { useCurrentTime } from "../../utils/useCurrentTime"
+import { Flex } from "../Flex"
+import { Sans } from "../Typography"
 
 function padWithZero(num: number) {
   return num.toString().padStart(2, "0")
@@ -31,45 +32,45 @@ export const TimeRemaining: React.SFC<{
   timerFontSize = "3",
   trailingText,
 }) => {
-  const duration = Duration.fromISO(
-    DateTime.fromISO(countdownEnd)
-      .diff(useCurrentTime(currentTime))
-      .toString()
-  )
+    const duration = Duration.fromISO(
+      DateTime.fromISO(countdownEnd)
+        .diff(useCurrentTime(currentTime))
+        .toString()
+    )
 
-  const hasEnded = Math.floor(duration.seconds) <= 0
+    const hasEnded = Math.floor(duration.seconds) <= 0
 
-  const days = `${padWithZero(Math.max(0, Math.floor(duration.as("days"))))}d `
-  const hours = `${padWithZero(
-    Math.max(0, Math.floor(duration.as("hours") % 24))
-  )}h `
-  const minutes = `${padWithZero(
-    Math.max(0, Math.floor(duration.as("minutes") % 60))
-  )}m `
-  const seconds = `${padWithZero(
-    Math.max(0, Math.floor(duration.as("seconds") % 60))
-  )}s`
+    const days = `${padWithZero(Math.max(0, Math.floor(duration.as("days"))))}d `
+    const hours = `${padWithZero(
+      Math.max(0, Math.floor(duration.as("hours") % 24))
+    )}h `
+    const minutes = `${padWithZero(
+      Math.max(0, Math.floor(duration.as("minutes") % 60))
+    )}m `
+    const seconds = `${padWithZero(
+      Math.max(0, Math.floor(duration.as("seconds") % 60))
+    )}s`
 
-  return (
-    <Flex flexDirection="column" alignItems="center">
-      <Sans size={timerFontSize} color={highlight} weight="medium">
-        {hasEnded && timeEndedDisplayText ? (
-          timeEndedDisplayText
-        ) : (
-          <>
-            {days}
-            {hours}
-            {minutes}
-            {seconds}
-            {trailingText && ` ${trailingText}`}
-          </>
-        )}
-      </Sans>
-      {(labelWithTimeRemaining || labelWithoutTimeRemaining) && (
-        <Sans size={labelFontSize} weight="medium">
-          {hasEnded ? labelWithoutTimeRemaining : labelWithTimeRemaining}
+    return (
+      <Flex flexDirection="column" alignItems="center">
+        <Sans size={timerFontSize} color={highlight} weight="medium">
+          {hasEnded && timeEndedDisplayText ? (
+            timeEndedDisplayText
+          ) : (
+              <>
+                {days}
+                {hours}
+                {minutes}
+                {seconds}
+                {trailingText && ` ${trailingText}`}
+              </>
+            )}
         </Sans>
-      )}
-    </Flex>
-  )
-}
+        {(labelWithTimeRemaining || labelWithoutTimeRemaining) && (
+          <Sans size={labelFontSize} weight="medium">
+            {hasEnded ? labelWithoutTimeRemaining : labelWithTimeRemaining}
+          </Sans>
+        )}
+      </Flex>
+    )
+  }

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -1,8 +1,11 @@
 import React from "react"
 import styled from "styled-components"
 import { space, SpaceProps } from "styled-system"
-import { ChevronIcon, Flex, Sans, Separator } from "../../"
+import { ChevronIcon } from "../../svgs/ChevronIcon"
 import { SansSize } from "../../Theme"
+import { Flex } from "../Flex"
+import { Separator } from "../Separator"
+import { Sans } from "../Typography"
 
 export interface ToggleProps {
   disabled?: boolean


### PR DESCRIPTION
There are several dependency cycles in Palette that under certain
circumstances such as loading a component using its canonical path
which will create partially loaded modules that lead to undefined objects at
runtime.

The solution is to import the files directly rather than relying on the global
index.