### PR TITLE
Adds support for `srcSet`

### DIFF
--- a/packages/palette/src/elements/Image/Image.shared.tsx
+++ b/packages/palette/src/elements/Image/Image.shared.tsx
@@ -28,8 +28,10 @@ const ratioPadding = system({
 
 /** Props for web & iOS images */
 export interface BaseImageProps {
-  /** The url for the image */
+  /** The URL for the image */
   src: string
+  /** The URLs for the image */
+  srcSet?: string
   /** Apply additional styles to component */
   style?: object
 }

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -12,6 +12,16 @@ storiesOf("Components/Image", module)
       />
     )
   })
+  .add("Image w/srcSet", () => {
+    return (
+      <Image
+        width="300px"
+        height="200px"
+        src="https://picsum.photos/seed/example/300/200"
+        srcSet="https://picsum.photos/seed/example/300/200 1x, https://picsum.photos/seed/example/600/400 2x"
+      />
+    )
+  })
   .add("LazyImage", () => {
     return (
       <>
@@ -22,6 +32,22 @@ storiesOf("Components/Image", module)
             width="300px"
             height="200px"
             src={`https://picsum.photos/seed/${i}/300/200`}
+          />
+        ))}
+      </>
+    )
+  })
+  .add("LazyImage w/srcSet", () => {
+    return (
+      <>
+        {[...new Array(100)].map((_, i) => (
+          <Image
+            key={i}
+            lazyLoad
+            width="300px"
+            height="200px"
+            src={`https://picsum.photos/seed/${i}/300/200`}
+            srcSet={`https://picsum.photos/seed/${i}/300/200 1x, https://picsum.photos/seed/${i}/600/400 2x`}
           />
         ))}
       </>

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -76,6 +76,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   const [isImageLoaded, setImageLoaded] = useState(false)
   const {
     src,
+    srcSet,
     title,
     alt,
     ["aria-label"]: ariaLabel,
@@ -99,6 +100,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
         omitFromProps={imagePropsToOmit}
         onError={onError}
         src={src}
+        srcSet={srcSet}
         title={title}
         alt={alt}
         aria-label={ariaLabel}


### PR DESCRIPTION
So I had initially intended to refactor this entire component but that got away with me. My intention with simply adding the prop here is that currently because we swap `src` props for `FillwidthItem` on page load, we actually double load images on all 1x devices 😈 