### PR TITLE
Move paginateCarousel Rename to Original File

### DIFF
--- a/packages/palette/src/elements/Carousel/Carousel.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.tsx
@@ -16,7 +16,7 @@ import { Box, BoxProps } from "../Box"
 import { Skip } from "../Skip"
 import { VisuallyHidden } from "../VisuallyHidden"
 import { CarouselNext, CarouselPrevious } from "./CarouselNavigation"
-import { paginate } from "./paginate"
+import { paginateCarousel } from "./paginate"
 
 const RAIL_TRANSITION_MS = 500
 
@@ -89,7 +89,7 @@ export const Carousel: React.FC<CarouselProps> = ({
     const { current: viewport } = viewportRef
     const els = cells.map(({ ref }) => ref.current)
     const values = els.map(node => node.clientWidth)
-    setPages(paginate({ viewport: viewport.clientWidth, values }))
+    setPages(paginateCarousel({ viewport: viewport.clientWidth, values }))
   }
 
   useEffect(() => {

--- a/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
+++ b/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
@@ -4,7 +4,7 @@ import { Box } from "../../Box"
 import { Carousel } from "../Carousel"
 
 jest.mock("../paginate", () => ({
-  paginate: () => [0, 100],
+  paginateCarousel: () => [0, 100],
 }))
 
 const tick = () => new Promise(resolve => setTimeout(resolve, 0))

--- a/packages/palette/src/elements/Carousel/__tests__/paginate.test.ts
+++ b/packages/palette/src/elements/Carousel/__tests__/paginate.test.ts
@@ -1,4 +1,4 @@
-import { chunk, compound, paginate } from "../paginate"
+import { chunk, compound, paginateCarousel } from "../paginate"
 
 describe("compound", () => {
   it("sums correctly (1)", () => {
@@ -61,13 +61,13 @@ describe("chunk", () => {
 describe("paginate", () => {
   it("returns a single page of 0 when the widths fit within the viewport", () => {
     expect(
-      paginate({ viewport: 1000, values: [100, 100, 100, 100, 100] })
+      paginateCarousel({ viewport: 1000, values: [100, 100, 100, 100, 100] })
     ).toStrictEqual([0])
   })
 
   it("returns multiple pages (1)", () => {
     expect(
-      paginate({
+      paginateCarousel({
         viewport: 1000,
         values: [
           // 0
@@ -81,7 +81,7 @@ describe("paginate", () => {
 
   it("returns multiple pages (2)", () => {
     expect(
-      paginate({
+      paginateCarousel({
         viewport: 1000,
         values: [
           // 0
@@ -97,7 +97,7 @@ describe("paginate", () => {
 
   it("returns multiple pages (3)", () => {
     expect(
-      paginate({
+      paginateCarousel({
         viewport: 1000,
         values: [
           // 0
@@ -116,7 +116,7 @@ describe("paginate", () => {
 
   it("returns multiple pages (4)", () => {
     expect(
-      paginate({
+      paginateCarousel({
         viewport: 1000,
         values: [
           // 0
@@ -136,7 +136,7 @@ describe("paginate", () => {
 
   it("handles the last page remainder (1)", () => {
     expect(
-      paginate({
+      paginateCarousel({
         viewport: 1000,
         values: [
           // 0
@@ -150,7 +150,7 @@ describe("paginate", () => {
 
   it("handles the last page remainder (2)", () => {
     expect(
-      paginate({ viewport: 880, values: [333, 333, 333, 333, 333] })
+      paginateCarousel({ viewport: 880, values: [333, 333, 333, 333, 333] })
     ).toStrictEqual([0, 666, 785])
   })
 })

--- a/packages/palette/src/elements/Carousel/index.ts
+++ b/packages/palette/src/elements/Carousel/index.ts
@@ -1,3 +1,3 @@
 export * from "./Carousel"
 export * from "./CarouselNavigation"
-export { paginate as paginateCarousel } from "./paginate"
+export * from "./paginate"

--- a/packages/palette/src/elements/Carousel/paginate.ts
+++ b/packages/palette/src/elements/Carousel/paginate.ts
@@ -40,7 +40,7 @@ export type CarouselPaginationAlignment = "left" | "right"
  * @param values array of cell widths
  * @param alignment align last page to the left or right
  */
-export const paginate = ({
+export const paginateCarousel = ({
   viewport,
   values,
   alignment = "right",


### PR DESCRIPTION
Moves the renaming of the paginateCarousel function into the file where
it is create rather then renaming it in the `index.ts`.