### PR TITLE
[Carousel/Swiper] Allows structural components to be injected

### DIFF
--- a/packages/palette/src/elements/Carousel/Carousel.story.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.story.tsx
@@ -4,15 +4,21 @@ import React, { useEffect, useState } from "react"
 import { Box } from "../Box"
 import { Clickable } from "../Clickable"
 import { Text } from "../Text"
-import { Carousel, CarouselProps } from "./Carousel"
-import { CarouselNext, CarouselPrevious } from "./CarouselNavigation"
+import {
+  Carousel,
+  CarouselCell,
+  CarouselNext,
+  CarouselPrevious,
+  CarouselProps,
+  CarouselRail,
+} from "./"
 
 const Demo = ({
   widths = [...new Array(25)].map(_ => 300),
   heights = [400],
   ...rest
 }: {
-  widths?: number[]
+  widths?: Array<number | string>
   heights?: number[]
 } & Omit<CarouselProps, "children">) => {
   return (
@@ -132,6 +138,27 @@ storiesOf("Components/Carousel", module)
               zIndex={1}
             />
           )
+        }}
+      />
+    )
+  })
+  .add("Custom rail and cells", () => {
+    return (
+      <Demo
+        widths={["100%", "100%", "100%", "100%"]}
+        Cell={React.forwardRef((props, ref) => {
+          return (
+            <CarouselCell
+              {...props}
+              ref={ref as any}
+              display="inline-flex"
+              width="100%"
+              pr={0}
+            />
+          )
+        })}
+        Rail={props => {
+          return <CarouselRail {...props} transition="none" display="block" />
         }}
       />
     )

--- a/packages/palette/src/elements/Carousel/Carousel.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from "react"
 import styled from "styled-components"
+import { ResponsiveValue, system } from "styled-system"
 import { useCursor } from "use-cursor"
 import { ChevronIcon } from "../../svgs"
 import { SpacingUnit } from "../../Theme"
@@ -15,10 +16,47 @@ import { useUpdateEffect } from "../../utils/useUpdateEffect"
 import { Box, BoxProps } from "../Box"
 import { Skip } from "../Skip"
 import { VisuallyHidden } from "../VisuallyHidden"
-import { CarouselNext, CarouselPrevious } from "./CarouselNavigation"
+import {
+  CarouselNavigationProps,
+  CarouselNext,
+  CarouselPrevious,
+} from "./CarouselNavigation"
 import { paginateCarousel } from "./paginate"
 
 const RAIL_TRANSITION_MS = 500
+
+const transition = system({ transition: true })
+
+/** CarouselRailProps */
+export type CarouselRailProps = BoxProps & {
+  transition?: ResponsiveValue<string>
+}
+
+/** A `CarouselRail` slides back and forth within the viewport */
+export const CarouselRail = styled(Box)<CarouselRailProps>`
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  white-space: nowrap;
+  ${transition}
+`
+
+CarouselRail.defaultProps = {
+  as: "ul",
+  display: "flex",
+  transition: `transform ${RAIL_TRANSITION_MS}ms`,
+}
+
+/** CarouselCellProps */
+export type CarouselCellProps = BoxProps
+
+/** A `CarouselCell` wraps a single child in the carousel */
+export const CarouselCell = styled(Box)``
+
+CarouselCell.defaultProps = {
+  as: "li",
+}
 
 /**
  * We share this spacing value with the `Swiper` component
@@ -35,21 +73,16 @@ const Viewport = styled(Box)`
   overflow: hidden;
 `
 
-const Rail = styled(Box)`
-  display: flex;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  transition: transform ${RAIL_TRANSITION_MS}ms;
-`
-
-const Cell = styled(Box)``
-
 export interface CarouselProps extends BoxProps {
   children: JSX.Element | JSX.Element[]
-  Next?: React.ComponentType<React.ButtonHTMLAttributes<HTMLButtonElement>>
-  Previous?: React.ComponentType<React.ButtonHTMLAttributes<HTMLButtonElement>>
+  Next?: typeof CarouselNext | React.FC<CarouselNavigationProps>
+  Previous?: typeof CarouselPrevious | React.FC<CarouselNavigationProps>
+  Rail?: typeof CarouselRail | React.FC<CarouselRailProps>
+  /**
+   * If providing a custom `Cell` you must forward a ref so
+   * that cell widths can be calculated.
+   */
+  Cell?: React.ForwardRefExoticComponent<CarouselCellProps>
   onChange?(index: number): void
 }
 
@@ -63,6 +96,8 @@ export const Carousel: React.FC<CarouselProps> = ({
   children,
   Previous = CarouselPrevious,
   Next = CarouselNext,
+  Rail = CarouselRail,
+  Cell = CarouselCell,
   onChange,
   ...rest
 }) => {
@@ -168,17 +203,12 @@ export const Carousel: React.FC<CarouselProps> = ({
       </nav>
 
       <Viewport ref={viewportRef as any}>
-        <Rail as="ul" style={{ transform: `translateX(${offset})` }}>
+        <Rail style={{ transform: `translateX(${offset})` }}>
           {cells.map(({ child, ref }, i) => {
             const isLast = i === cells.length - 1
 
             return (
-              <Cell
-                as="li"
-                key={i}
-                ref={ref as any}
-                pr={!isLast && CELL_GAP_PADDING_AMOUNT}
-              >
+              <Cell key={i} ref={ref} pr={!isLast && CELL_GAP_PADDING_AMOUNT}>
                 {child}
               </Cell>
             )

--- a/packages/palette/src/elements/Carousel/CarouselNavigation.tsx
+++ b/packages/palette/src/elements/Carousel/CarouselNavigation.tsx
@@ -1,10 +1,13 @@
 import styled from "styled-components"
 import { color, space } from "../../helpers"
 import { SpacingUnit } from "../../Theme"
-import { Clickable } from "../Clickable"
+import { Clickable, ClickableProps } from "../Clickable"
 
 const ARROW_WIDTH: SpacingUnit[] = [2, 4]
 const ARROW_TRANSITION_MS = 250
+
+/** CarouselNavigationProps */
+export type CarouselNavigationProps = ClickableProps
 
 const Arrow = styled(Clickable)`
   position: absolute;

--- a/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
+++ b/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
@@ -75,4 +75,56 @@ describe("Carousel", () => {
     await tick()
     expect(onChange).lastCalledWith(0)
   })
+
+  it("accepts a customizable Rail", () => {
+    const wrapper = mount(
+      <Carousel
+        Rail={({ children, ...rest }) => {
+          return (
+            <Box {...rest}>
+              <div>
+                I have {React.Children.toArray(children).length} beautiful
+                children
+              </div>
+
+              {children}
+            </Box>
+          )
+        }}
+      >
+        <Box>1</Box>
+        <Box>2</Box>
+        <Box>3</Box>
+      </Carousel>
+    )
+
+    const html = wrapper.html()
+
+    expect(html).toContain("I have 3 beautiful children")
+    expect(html.match(/\<li\s/g).length).toBe(3)
+  })
+
+  it("accepts a customizable Cell", () => {
+    const wrapper = mount(
+      <Carousel
+        Cell={React.forwardRef(({ children, ...rest }, ref) => {
+          return (
+            <Box ref={ref as any} {...rest}>
+              beautiful number {children}
+            </Box>
+          )
+        })}
+      >
+        <>1</>
+        <>2</>
+        <>3</>
+      </Carousel>
+    )
+
+    const html = wrapper.html()
+
+    expect(html).toContain("beautiful number 1")
+    expect(html).toContain("beautiful number 2")
+    expect(html).toContain("beautiful number 3")
+  })
 })

--- a/packages/palette/src/elements/Swiper/Swiper.story.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.story.tsx
@@ -1,11 +1,11 @@
 import { storiesOf } from "@storybook/react"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import styled from "styled-components"
 import { Box } from "../Box"
 import { Clickable } from "../Clickable"
 import { ProgressDots } from "../ProgressDots"
 import { Text } from "../Text"
-import { Swiper, SwiperProps } from "./Swiper"
+import { Swiper, SwiperCell, SwiperProps, SwiperRail } from "./"
 
 const Demo = ({
   widths,
@@ -67,7 +67,7 @@ const ProgressBarDemo = () => {
 
   return (
     <>
-      <Demo widths={widths} onChange={setIndex} snap="center" />
+      <Demo widths={widths} onChange={setIndex} snap="start" />
       <ProgressBar progress={progress} />
     </>
   )
@@ -79,7 +79,25 @@ const ProgressDotsDemo = () => {
 
   return (
     <>
-      <Demo widths={widths} onChange={setIndex} snap="center" />
+      <Demo widths={widths} onChange={setIndex} />
+      <ProgressDots amount={widths.length} activeIndex={index} />
+    </>
+  )
+}
+
+const Dynamic = () => {
+  const [index, setIndex] = useState(0)
+  const [widths, setWidths] = useState([300])
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setWidths(prevWidths => [...prevWidths, 300])
+    }, 500)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <>
+      <Demo widths={widths} onChange={setIndex} />
       <ProgressDots amount={widths.length} activeIndex={index} />
     </>
   )
@@ -99,4 +117,29 @@ storiesOf("Components/Swiper", module)
   })
   .add("Progress dots example", () => {
     return <ProgressDotsDemo />
+  })
+  .add("Custom rail and cells", () => {
+    return (
+      <Demo
+        snap="start"
+        widths={["100%", "100%", "100%", "100%"]}
+        Cell={React.forwardRef((props, ref) => {
+          return (
+            <SwiperCell
+              {...props}
+              ref={ref as any}
+              display="inline-flex"
+              width="100%"
+              pr={0}
+            />
+          )
+        })}
+        Rail={props => {
+          return <SwiperRail {...props} display="block" />
+        }}
+      />
+    )
+  })
+  .add("Dynamic items", () => {
+    return <Dynamic />
   })

--- a/packages/palette/src/elements/Swiper/__tests__/Swiper.test.tsx
+++ b/packages/palette/src/elements/Swiper/__tests__/Swiper.test.tsx
@@ -17,4 +17,56 @@ describe("Swiper", () => {
     expect(wrapper.find(Box).length).toBe(3)
     expect(wrapper.html()).toContain("scroll-snap-align: center")
   })
+
+  it("accepts a customizable Rail", () => {
+    const wrapper = mount(
+      <Swiper
+        Rail={({ children, ...rest }) => {
+          return (
+            <Box {...rest}>
+              <div>
+                I have {React.Children.toArray(children).length} beautiful
+                children
+              </div>
+
+              {children}
+            </Box>
+          )
+        }}
+      >
+        <Box>1</Box>
+        <Box>2</Box>
+        <Box>3</Box>
+      </Swiper>
+    )
+
+    const html = wrapper.html()
+
+    expect(html).toContain("I have 3 beautiful children")
+    expect(html.match(/\<li\s/g).length).toBe(3)
+  })
+
+  it("accepts a customizable Cell", () => {
+    const wrapper = mount(
+      <Swiper
+        Cell={React.forwardRef(({ children, ...rest }, ref) => {
+          return (
+            <Box ref={ref as any} {...rest}>
+              beautiful number {children}
+            </Box>
+          )
+        })}
+      >
+        <>1</>
+        <>2</>
+        <>3</>
+      </Swiper>
+    )
+
+    const html = wrapper.html()
+
+    expect(html).toContain("beautiful number 1")
+    expect(html).toContain("beautiful number 2")
+    expect(html).toContain("beautiful number 3")
+  })
 })


### PR DESCRIPTION
[Hide diff whitespace changes](https://github.com/artsy/palette/pull/767/files?diff=unified&w=1)

Ultimately the goal here was to add support for 100% width cells & disabling carousel animated transitions without resorting to adding a number of additional and inconsistent props. These are essentially stylistic changes and so rather than exposing options which toggle them, allowing fully customizable sub-components both discourages out-of-design-system inconsistencies but makes complex behaviors that are well thought out possible none-the-less.

![](http://static.damonzucconi.com/_capture/rrEs6Vk0895K.gif)

![](http://static.damonzucconi.com/_capture/tWgEkmqtZ07W.gif)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.0.1-canary.767.12960.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.0.1-canary.767.12960.0
  # or 
  yarn add @artsy/palette@13.0.1-canary.767.12960.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
