### PR TITLE
[FX-2245] Read more styling

### DIFF
--- a/packages/palette/src/elements/Clickable/Clickable.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.tsx
@@ -1,12 +1,19 @@
 import React from "react"
 import styled from "styled-components"
+import { compose, ResponsiveValue, system } from "styled-system"
 import { boxMixin, BoxProps } from "../Box"
+
+const cursor = system({ cursor: true })
+const textDecoration = system({ textDecoration: true })
 
 /**
  * ClickableProps
  */
 export type ClickableProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
-  BoxProps
+  BoxProps & {
+    cursor?: ResponsiveValue<string>
+    textDecoration?: ResponsiveValue<string>
+  }
 
 /**
  * Clickable is a utility component useful for wrapping things like <div>s
@@ -17,5 +24,13 @@ export const Clickable = styled.button<ClickableProps>`
   padding: 0;
   border: 0;
   background-color: transparent;
-  ${boxMixin}
+  ${compose(
+    boxMixin,
+    cursor,
+    textDecoration
+  )}
 `
+
+Clickable.defaultProps = {
+  cursor: "pointer",
+}

--- a/packages/palette/src/elements/HTML/HTML.tsx
+++ b/packages/palette/src/elements/HTML/HTML.tsx
@@ -12,18 +12,21 @@ export type HTMLProps = TextProps &
     html: string
   }
 
-const htmlMixin = css`
-  > h1,
-  > h2,
-  > h3,
-  > h4,
-  > h5,
-  > ul,
-  > ol,
-  > p,
-  > blockquote,
-  > pre,
-  > hr {
+/**
+ * Sets reasonable defaults for tags that we might encounter in Markdown output.
+ */
+export const htmlMixin = css`
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  ul,
+  ol,
+  p,
+  blockquote,
+  pre,
+  hr {
     margin: ${space(1)}px auto;
 
     &:first-child {
@@ -35,22 +38,29 @@ const htmlMixin = css`
     }
   }
 
-  > hr {
+  hr {
     height: 1px;
     border: 0;
     background-color: ${color("black10")};
   }
 `
 
-const Container = styled(Text)`
+/**
+ * Sets reasonable defaults for tags that we might encounter in Markdown output.
+ */
+export const HTMLStyles = styled(Text)`
   ${htmlMixin}
 `
 
+HTMLStyles.defaultProps = {
+  variant: "text",
+}
+
 /**
- * HTML
+ * Sets reasonable defaults for tags that we might encounter in Markdown output.
  */
 export const HTML: React.FC<HTMLProps> = ({ html, ...rest }) => {
-  return <Container dangerouslySetInnerHTML={{ __html: html }} {...rest} />
+  return <HTMLStyles dangerouslySetInnerHTML={{ __html: html }} {...rest} />
 }
 
 HTML.displayName = "HTML"

--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
+import { HTMLStyles } from "../HTML"
 import { ReadMore } from "./ReadMore"
 
 storiesOf("Components/ReadMore", module)
@@ -47,7 +48,15 @@ storiesOf("Components/ReadMore", module)
       <ReadMore
         maxChars={300}
         content={
-          <p>Donald Judd, widely regarded as one of the most significant American artists of <a href="#">the post-war period</a>, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa. Donald Judd, widely regarded as one of the most significant American artists of the post-war period, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa.</p>
+          <p>
+            Donald Judd, widely regarded as one of the most significant American
+            artists of <a href="#">the post-war period</a>, is perhaps
+            best-known for the large-scale outdoor installations and long,
+            spacious interiors he designed in Marfa. Donald Judd, widely
+            regarded as one of the most significant American artists of the
+            post-war period, is perhaps best-known for the large-scale outdoor
+            installations and long, spacious interiors he designed in Marfa.
+          </p>
         }
       />
     )
@@ -69,5 +78,37 @@ storiesOf("Components/ReadMore", module)
           </div>
         }
       />
+    )
+  })
+  .add("HTML styled", () => {
+    return (
+      <HTMLStyles>
+        <ReadMore
+          maxChars={300}
+          content={
+            <>
+              <p>
+                Donald Judd, widely regarded as one of the most significant
+                American artists of <a href="#">the post-war period</a>, is
+                perhaps best-known for the large-scale outdoor installations and
+                long, spacious interiors he designed in Marfa. Donald Judd,
+                widely regarded as one of the most significant American artists
+                of the post-war period, is perhaps best-known for the
+                large-scale outdoor installations and long, spacious interiors
+                he designed in Marfa.
+              </p>
+
+              <hr />
+
+              <p>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit.
+                Provident fuga amet nesciunt atque quam quibusdam? Modi totam
+                commodi illum reprehenderit itaque, molestiae tenetur nisi
+                doloribus recusandae. At sapiente neque minus.
+              </p>
+            </>
+          }
+        />
+      </HTMLStyles>
     )
   })

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -3,6 +3,9 @@ import { renderToStaticMarkup } from "react-dom/server"
 import styled from "styled-components"
 import { DisplayProps } from "styled-system"
 import truncate from "trunc-html"
+import { Clickable, ClickableProps } from "../Clickable"
+import { Text } from "../Text"
+
 export interface ReadMoreProps extends DisplayProps {
   content: string | JSX.Element
   disabled?: boolean
@@ -86,34 +89,21 @@ export class ReadMore extends Component<ReadMoreProps, ReadMoreState> {
   }
 }
 
-const ReadMoreLink = ({ children }) => {
+const ReadMoreLink: React.FC<ClickableProps> = ({ children, ...rest }) => {
   return (
-    <span>
+    <>
       {" "}
-      <ReadMoreLinkContainer>
-        <ReadMoreLinkText>{children}</ReadMoreLinkText>
-      </ReadMoreLinkContainer>
-    </span>
+      <Clickable
+        aria-expanded="false"
+        cursor="pointer"
+        textDecoration="underline"
+        {...rest}
+      >
+        <Text variant="mediumText">{children}</Text>
+      </Clickable>
+    </>
   )
 }
-
-const ReadMoreLinkContainer = styled.span`
-  cursor: pointer;
-  text-decoration: underline;
-  display: inline-block;
-  white-space: nowrap;
-`
-
-// NOTE: Couldn't use @artsy/palette / Sans due to root element being a `div`;
-// as html content from CMS comes through as a p tag, markup is rendered invalid.
-const ReadMoreLinkText = styled.span`
-  display: inline;
-  font-family: Unica77LLWebMedium, "Helvetica Neue", Helvetica, Arial,
-    sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-`
 
 const Container = styled.div<ReadMoreState>`
   cursor: ${p => (p.isExpanded ? "auto" : "pointer")};

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -108,12 +108,6 @@ const ReadMoreLink: React.FC<ClickableProps> = ({ children, ...rest }) => {
 const Container = styled.div<ReadMoreState>`
   cursor: ${p => (p.isExpanded ? "auto" : "pointer")};
 
-  > span > * {
-    margin-block-start: 0;
-    margin-block-end: 0;
-    padding-bottom: 1em;
-  }
-
   > span > *:last-child {
     display: inline;
   }


### PR DESCRIPTION
Re: [FX-2245](https://artsyproduct.atlassian.net/browse/FX-2245)

In order to handle this — the simplest way to go about it is to style  the content from the outside. This PR exposes `HTMLStyles` which is the container from the `HTML` component in order to handle this consistently. Some related updates have also been made.

We can't style from inside the component because the read more link leans on `display: inline` which will cause changes to the line-height. This is also a bit more general as well, avoiding making assumptions about the HTML we are truncating.

Some minor updates have also been made like supporting cursor/textDecoration props in `Clickable` and some light updates in the `ReadMore` component itself.