### PR TITLE
[FX-2245] ReadMore styling

### DIFF
--- a/packages/palette/src/elements/Clickable/Clickable.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.tsx
@@ -1,12 +1,19 @@
 import React from "react"
 import styled from "styled-components"
+import { compose, ResponsiveValue, system } from "styled-system"
 import { boxMixin, BoxProps } from "../Box"
+
+const cursor = system({ cursor: true })
+const textDecoration = system({ textDecoration: true })
 
 /**
  * ClickableProps
  */
 export type ClickableProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
-  BoxProps
+  BoxProps & {
+    cursor?: ResponsiveValue<string>
+    textDecoration?: ResponsiveValue<string>
+  }
 
 /**
  * Clickable is a utility component useful for wrapping things like <div>s
@@ -17,5 +24,13 @@ export const Clickable = styled.button<ClickableProps>`
   padding: 0;
   border: 0;
   background-color: transparent;
-  ${boxMixin}
+  ${compose(
+    boxMixin,
+    cursor,
+    textDecoration
+  )}
 `
+
+Clickable.defaultProps = {
+  cursor: "pointer",
+}

--- a/packages/palette/src/elements/HTML/HTML.story.tsx
+++ b/packages/palette/src/elements/HTML/HTML.story.tsx
@@ -34,24 +34,71 @@ const HTML_EXAMPLE = `
 <blockquote>This is a block quote</blockquote>
 `
 
-storiesOf("Components/HTML", module).add("HTML", () => {
-  return (
-    <>
-      <HTML
-        style={{ border: "1px dotted" }}
-        variant="title"
-        html={HTML_EXAMPLE}
-      />
-      <HTML
-        style={{ border: "1px dotted" }}
-        variant="text"
-        html={HTML_EXAMPLE}
-      />
-      <HTML
-        style={{ border: "1px dotted" }}
-        variant="small"
-        html={HTML_EXAMPLE}
-      />
-    </>
-  )
-})
+storiesOf("Components/HTML", module)
+  .add("HTML", () => {
+    return (
+      <>
+        <HTML
+          style={{ border: "1px dotted" }}
+          variant="title"
+          html={HTML_EXAMPLE}
+        />
+        <HTML
+          style={{ border: "1px dotted" }}
+          variant="text"
+          html={HTML_EXAMPLE}
+        />
+        <HTML
+          style={{ border: "1px dotted" }}
+          variant="small"
+          html={HTML_EXAMPLE}
+        />
+      </>
+    )
+  })
+  .add("Default HTML styling", () => {
+    return (
+      <HTML>
+        <h1>H1 Headline</h1>
+
+        <h2>H2 Headline</h2>
+
+        <h3>H3 Headline</h3>
+
+        <h4>H4 Headline</h4>
+
+        <p>
+          I’m <em>of the opinion</em> that they use{" "}
+          <strong>
+            no <em>inert</em> material.
+          </strong>{" "}
+          All their equipment and instruments are alive, in some form or other.
+        </p>
+
+        <p>
+          They don’t construct or build at all. The idea of making is foreign to
+          them. They utilize existing forms. Even their ships—
+        </p>
+
+        <ol>
+          <li>first</li>
+          <li>second</li>
+          <li>third</li>
+        </ol>
+
+        <ul>
+          <li>first</li>
+          <li>second</li>
+          <li>third</li>
+        </ul>
+
+        <hr />
+
+        <pre>
+          <code>this is a code block</code>
+        </pre>
+
+        <blockquote>This is a block quote</blockquote>
+      </HTML>
+    )
+  })

--- a/packages/palette/src/elements/HTML/HTML.tsx
+++ b/packages/palette/src/elements/HTML/HTML.tsx
@@ -8,22 +8,24 @@ import { Text, TextProps } from "../Text"
  * HTML
  */
 export type HTMLProps = TextProps &
-  HTMLAttributes<HTMLDivElement | HTMLHeadingElement | HTMLParagraphElement> & {
-    html: string
-  }
+  HTMLAttributes<HTMLDivElement | HTMLHeadingElement | HTMLParagraphElement> &
+  ({ html: string } | { children: React.ReactNode })
 
-const htmlMixin = css`
-  > h1,
-  > h2,
-  > h3,
-  > h4,
-  > h5,
-  > ul,
-  > ol,
-  > p,
-  > blockquote,
-  > pre,
-  > hr {
+/**
+ * Sets reasonable defaults for tags that we might encounter in Markdown output.
+ */
+export const htmlMixin = css`
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  ul,
+  ol,
+  p,
+  blockquote,
+  pre,
+  hr {
     margin: ${space(1)}px auto;
 
     &:first-child {
@@ -35,7 +37,7 @@ const htmlMixin = css`
     }
   }
 
-  > hr {
+  hr {
     height: 1px;
     border: 0;
     background-color: ${color("black10")};
@@ -46,11 +48,25 @@ const Container = styled(Text)`
   ${htmlMixin}
 `
 
+Container.defaultProps = {
+  variant: "text",
+}
+
 /**
- * HTML
+ * Sets reasonable defaults for tags that we might encounter in Markdown output.
+ * If `html` prop is passed; it's set as innerHTML, otherwise contents are wrapped
+ * with default HTML styling.
  */
-export const HTML: React.FC<HTMLProps> = ({ html, ...rest }) => {
-  return <Container dangerouslySetInnerHTML={{ __html: html }} {...rest} />
+export const HTML: React.FC<HTMLProps> = props => {
+  if ("html" in props) {
+    const { html, ...htmlRest } = props
+    return (
+      <Container dangerouslySetInnerHTML={{ __html: html }} {...htmlRest} />
+    )
+  }
+
+  const { children, ...childrenRest } = props
+  return <Container {...childrenRest}>{children}</Container>
 }
 
 HTML.displayName = "HTML"

--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/react"
 import React from "react"
+import { HTML } from "../HTML"
 import { ReadMore } from "./ReadMore"
 
 storiesOf("Components/ReadMore", module)
@@ -42,14 +43,109 @@ storiesOf("Components/ReadMore", module)
       />
     )
   })
-  .add("Character cap with html", () => {
+  .add("Character cap with HTML", () => {
     return (
       <ReadMore
         maxChars={300}
         content={
-          <p>Donald Judd, widely regarded as one of the most significant American artists of <a href="#">the post-war period</a>, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa. Donald Judd, widely regarded as one of the most significant American artists of the post-war period, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa.</p>
+          <>
+            <p>
+              Donald Judd, widely regarded as one of the most significant
+              American artists of <a href="#">the post-war period</a>, is
+              perhaps best-known for the large-scale outdoor installations and
+              long, spacious interiors he designed in Marfa. Donald Judd, widely
+              regarded as one of the most significant American artists of the
+              post-war period, is perhaps best-known for the large-scale outdoor
+              installations and long, spacious interiors he designed in Marfa.
+            </p>
+            <hr />
+            <p>
+              <strong>Lorem ipsum dolor</strong> sit amet consectetur
+              adipisicing elit. Ducimus eligendi obcaecati voluptate{" "}
+              <em>molestias vero nobis voluptatum</em>, tenetur dolorum
+              assumenda.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis
+              eveniet aliquid laborum fugiat quibusdam id suscipit est
+              temporibus labore sint aliquam, laudantium tempore. Tenetur
+              adipisci cumque alias facilis animi. Illum.
+            </p>
+          </>
         }
       />
+    )
+  })
+  .add("With customizable typography", () => {
+    return (
+      <HTML>
+        <ReadMore
+          maxChars={300}
+          content={
+            <>
+              <p>
+                Donald Judd, widely regarded as one of the most significant
+                American artists of <a href="#">the post-war period</a>, is
+                perhaps best-known for the large-scale outdoor installations and
+                long, spacious interiors he designed in Marfa. Donald Judd,
+                widely regarded as one of the most significant American artists
+                of the post-war period, is perhaps best-known for the
+                large-scale outdoor installations and long, spacious interiors
+                he designed in Marfa.
+              </p>
+              <hr />
+              <p>
+                <strong>Lorem ipsum dolor</strong> sit amet consectetur
+                adipisicing elit. Ducimus eligendi obcaecati voluptate{" "}
+                <em>molestias vero nobis voluptatum</em>, tenetur dolorum
+                assumenda.
+              </p>
+              <p>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis
+                eveniet aliquid laborum fugiat quibusdam id suscipit est
+                temporibus labore sint aliquam, laudantium tempore. Tenetur
+                adipisci cumque alias facilis animi. Illum.
+              </p>
+            </>
+          }
+        />
+      </HTML>
+    )
+  })
+  .add("With customizable typography (2)", () => {
+    return (
+      <HTML variant="largeTitle">
+        <ReadMore
+          maxChars={300}
+          content={
+            <>
+              <p>
+                Donald Judd, widely regarded as one of the most significant
+                American artists of <a href="#">the post-war period</a>, is
+                perhaps best-known for the large-scale outdoor installations and
+                long, spacious interiors he designed in Marfa. Donald Judd,
+                widely regarded as one of the most significant American artists
+                of the post-war period, is perhaps best-known for the
+                large-scale outdoor installations and long, spacious interiors
+                he designed in Marfa.
+              </p>
+              <hr />
+              <p>
+                <strong>Lorem ipsum dolor</strong> sit amet consectetur
+                adipisicing elit. Ducimus eligendi obcaecati voluptate{" "}
+                <em>molestias vero nobis voluptatum</em>, tenetur dolorum
+                assumenda.
+              </p>
+              <p>
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis
+                eveniet aliquid laborum fugiat quibusdam id suscipit est
+                temporibus labore sint aliquam, laudantium tempore. Tenetur
+                adipisci cumque alias facilis animi. Illum.
+              </p>
+            </>
+          }
+        />
+      </HTML>
     )
   })
   .add("Character cap with html (disabled)", () => {

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -1,9 +1,11 @@
 import React, { Component } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import styled from "styled-components"
-import { DisplayProps } from "styled-system"
 import truncate from "trunc-html"
-export interface ReadMoreProps extends DisplayProps {
+import { Clickable, ClickableProps } from "../Clickable"
+import { Text } from "../Text"
+
+export interface ReadMoreProps {
   content: string | JSX.Element
   disabled?: boolean
   isExpanded?: boolean
@@ -86,43 +88,26 @@ export class ReadMore extends Component<ReadMoreProps, ReadMoreState> {
   }
 }
 
-const ReadMoreLink = ({ children }) => {
+const ReadMoreLink: React.FC<ClickableProps> = ({ children, ...rest }) => {
   return (
-    <span>
+    <>
       {" "}
-      <ReadMoreLinkContainer>
-        <ReadMoreLinkText>{children}</ReadMoreLinkText>
-      </ReadMoreLinkContainer>
-    </span>
+      <Clickable
+        aria-expanded="false"
+        cursor="pointer"
+        textDecoration="underline"
+        {...rest}
+      >
+        <Text variant="mediumText">{children}</Text>
+      </Clickable>
+    </>
   )
 }
 
-const ReadMoreLinkContainer = styled.span`
-  cursor: pointer;
-  text-decoration: underline;
-  display: inline-block;
-  white-space: nowrap;
-`
-
-// NOTE: Couldn't use @artsy/palette / Sans due to root element being a `div`;
-// as html content from CMS comes through as a p tag, markup is rendered invalid.
-const ReadMoreLinkText = styled.span`
-  display: inline;
-  font-family: Unica77LLWebMedium, "Helvetica Neue", Helvetica, Arial,
-    sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 16px;
-`
+ReadMoreLink.displayName = "ReadMoreLink"
 
 const Container = styled.div<ReadMoreState>`
   cursor: ${p => (p.isExpanded ? "auto" : "pointer")};
-
-  > span > * {
-    margin-block-start: 0;
-    margin-block-end: 0;
-    padding-bottom: 1em;
-  }
 
   > span > *:last-child {
     display: inline;

--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -33,9 +33,9 @@ describe("ReadMore", () => {
 
   it("expands text on click", () => {
     const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
-    expect(wrapper.find("ReadMoreLink").length).toBe(1)
-    wrapper.simulate("click")
-    expect(wrapper.find("ReadMoreLink").length).toBe(0)
+    expect(wrapper.find("button").length).toBe(1)
+    wrapper.find("button").simulate("click")
+    expect(wrapper.find("button").length).toBe(0)
   })
 
   it("does not expand if disabled", () => {


### PR DESCRIPTION
Re: [FX-2245](https://artsyproduct.atlassian.net/browse/FX-2245)

* Some minor updates to `Clickable` to make it easier to use
* Updates `HTML` to export it's default styling
* Utilizes `HTML` styling on `ReadMore`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.6.1-canary.782.13312.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.6.1-canary.782.13312.0
  # or 
  yarn add @artsy/palette@13.6.1-canary.782.13312.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
