### PR TITLE
Fixes horizontal margin overrides

### DIFF
--- a/packages/palette/src/elements/Swiper/Swiper.story.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.story.tsx
@@ -108,6 +108,15 @@ storiesOf("Components/Swiper", module)
     const widths = [...new Array(25)].map(_ => 300)
     return <Demo widths={widths} />
   })
+  .add("With horizontal margins", () => {
+    const widths = [...new Array(25)].map(_ => 300)
+    return (
+      <>
+        <Text>Should be flush with horizontal edges</Text>
+        <Demo widths={widths} mx={[-2, -4]} />
+      </>
+    )
+  })
   .add("Simple with left-edge snapping", () => {
     const widths = [...new Array(25)].map(_ => 300)
     return <Demo widths={widths} snap="start" />

--- a/packages/palette/src/elements/Swiper/Swiper.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.tsx
@@ -26,7 +26,6 @@ const visuallyDisableScrollbar = css`
 const Container = styled(Box)`
   display: flex;
   height: 100%;
-  margin: 0;
   padding: 0;
   list-style: none;
   overflow-y: hidden;
@@ -35,6 +34,11 @@ const Container = styled(Box)`
   scroll-snap-type: x mandatory;
   ${visuallyDisableScrollbar}
 `
+
+Container.defaultProps = {
+  mx: 0,
+  my: 0,
+}
 
 /** SwiperRailProps */
 export type SwiperRailProps = BoxProps


### PR DESCRIPTION
Some `Swiper` updates included `margin: 0` in the container which was overriding any passed in `mx` — here we set a default and set up a story to use as a visual spec.

![](http://static.damonzucconi.com/_capture/qLLa4bfauhwW.png)