### PR TITLE
Sets default Text variant to `"text"`

### DIFF
--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -63,4 +63,5 @@ Text.displayName = "Text"
 
 Text.defaultProps = {
   fontFamily: "sans",
+  variant: "text",
 }


### PR DESCRIPTION
This sets the default `Text` variant as `text`, which is the obvious thing to do here. Thanks for raising @anandaroop.