### PR TITLE
Removed white background from XCircleIcon

### DIFF
--- a/packages/palette/src/svgs/XCircleIcon.tsx
+++ b/packages/palette/src/svgs/XCircleIcon.tsx
@@ -10,7 +10,6 @@ export const XCircleIcon: React.SFC<IconProps> = ({
   return (
     <Icon {...props} viewBox="0 0 18 18">
       <Title>{title}</Title>
-      <Path d="M0 0H18V18H0V0Z" fill="white" />
       <Path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
Necessary for Order History page
__Before:__
<img width="113" alt="Screen Shot 2020-09-22 at 12 09 30 PM" src="https://user-images.githubusercontent.com/5643895/93909138-76368080-fccd-11ea-95b8-a1a2584fb119.png">

__After:__
<img width="110" alt="Screen Shot 2020-09-22 at 12 09 25 PM" src="https://user-images.githubusercontent.com/5643895/93909092-6a4abe80-fccd-11ea-9935-ca82f7b4da3d.png">
