### PR TITLE
Ensures consistent typography in EntityHeaders

### DIFF
--- a/packages/palette-docs/content/docs/components/EntityHeader.mdx
+++ b/packages/palette-docs/content/docs/components/EntityHeader.mdx
@@ -9,11 +9,7 @@ name: EntityHeader
     name="Francesca DiMattio"
     meta="American, b. 1979"
     href="http://www.artsy.net/artist/francesca-dimattio"
-    FollowButton={
-      <Text variant="caption" weight="medium" color="black">
-        Follow
-      </Text>
-    }
+    FollowButton={<>Follow</>}
   />
 </Playground>
 
@@ -25,14 +21,9 @@ When no `imageURL` is provided it will defer to the `initials` prop:
     name="Francesca DiMattio"
     meta="American, b. 1979"
     href="http://www.artsy.net/artist/francesca-dimattio"
-    FollowButton={
-      <Text variant="caption" weight="medium" color="black">
-        Follow
-      </Text>
-    }
+    FollowButton={<>Follow</>}
   />
 </Playground>
-
 
 When `smallVariant` prop is provided:
 
@@ -44,13 +35,10 @@ When `smallVariant` prop is provided:
     imageUrl="https://picsum.photos/110/110/?random"
     href="http://www.artsy.net/artist/francesca-dimattio"
     FollowButton={
-      <Text variant="text" style={{ textDecoration: "underline" }}>
-        Following
-      </Text>
+      <Text style={{ textDecoration: "underline" }}>Following</Text>
     }
   />
 </Playground>
-
 
 <Playground>
   <EntityHeader

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
@@ -1,0 +1,54 @@
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Text } from "../Text"
+import { EntityHeader } from "./EntityHeader"
+
+storiesOf("Components/EntityHeader", module)
+  .add("Default", () => {
+    return (
+      <EntityHeader
+        imageUrl="https://picsum.photos/110/110/?random"
+        initials="FD"
+        name="Francesca DiMattio"
+        meta="American, b. 1979"
+        href="http://www.artsy.net/artist/francesca-dimattio"
+        FollowButton={<>Follow</>}
+      />
+    )
+  })
+  .add("Without imageUrl", () => {
+    return (
+      <EntityHeader
+        initials="FD"
+        name="Francesca DiMattio"
+        meta="American, b. 1979"
+        href="http://www.artsy.net/artist/francesca-dimattio"
+        FollowButton={<>Follow</>}
+      />
+    )
+  })
+  .add("smallVariant", () => {
+    return (
+      <EntityHeader
+        smallVariant
+        initials="FD"
+        name="Francesca DiMattio"
+        imageUrl="https://picsum.photos/110/110/?random"
+        href="http://www.artsy.net/artist/francesca-dimattio"
+        FollowButton={
+          <Text style={{ textDecoration: "underline" }}>Following</Text>
+        }
+      />
+    )
+  })
+  .add("with less info", () => {
+    return (
+      <EntityHeader
+        imageUrl="https://picsum.photos/110/110/?random"
+        name="Francesca DiMattio"
+      />
+    )
+  })
+  .add("with only name", () => {
+    return <EntityHeader name="Francesca DiMattio" />
+  })

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -40,8 +40,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
   ...remainderProps
 }) => {
   const ContainerComponent = href ? FlexLink : Flex
-  // new () => React.Component < any, any >
-  // StyledComponentClass < React.ClassAttributes < HTMLAnchorElement >
+
   const containerProps: ContainerComponentProps = href
     ? { color: "black100", noUnderline: true, href }
     : {}
@@ -90,14 +89,14 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
             {name}
           </Text>
 
-          <Text variant="caption" color="black60">
+          <Text variant="text" color="black60">
             {!!meta && <span>{meta}</span>}
 
             {FollowButton && (
               <>
                 {meta && (
                   <Text
-                    variant="caption"
+                    variant="text"
                     color="black60"
                     mx={0.3}
                     display="inline-block"


### PR DESCRIPTION
Re: [FX-2251](https://artsyproduct.atlassian.net/browse/FX-2251)

The use of caption was causing some line-height differences as well due to the way this component nests a (faux-)button (necessitating the use of stopPropagation).

![](http://static.damonzucconi.com/_capture/UsTz2cxN86jy.png)

-----

Added stories for use as visual specs and simplified the examples a bit.