### PR TITLE
Only calls onChange when the active index actually changes

### DIFF
--- a/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
@@ -7,7 +7,7 @@ storiesOf("Components/EntityHeader", module)
   .add("Default", () => {
     return (
       <EntityHeader
-        imageUrl="https://picsum.photos/110/110/?random"
+        imageUrl="https://picsum.photos/seed/example/110/110"
         initials="FD"
         name="Francesca DiMattio"
         meta="American, b. 1979"
@@ -33,7 +33,7 @@ storiesOf("Components/EntityHeader", module)
         smallVariant
         initials="FD"
         name="Francesca DiMattio"
-        imageUrl="https://picsum.photos/110/110/?random"
+        imageUrl="https://picsum.photos/seed/example/110/110"
         href="http://www.artsy.net/artist/francesca-dimattio"
         FollowButton={
           <Text style={{ textDecoration: "underline" }}>Following</Text>
@@ -44,7 +44,7 @@ storiesOf("Components/EntityHeader", module)
   .add("with less info", () => {
     return (
       <EntityHeader
-        imageUrl="https://picsum.photos/110/110/?random"
+        imageUrl="https://picsum.photos/seed/example/110/110"
         name="Francesca DiMattio"
       />
     )

--- a/packages/palette/src/elements/Swiper/Swiper.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react"
 import styled, { css } from "styled-components"
 import { Box, BoxProps } from "../Box"
@@ -102,6 +103,8 @@ export const Swiper: React.FC<SwiperProps> = ({
     [children]
   )
 
+  const [index, setIndex] = useState(0)
+
   useEffect(() => {
     // Not mounted
     if (!containerRef.current) return
@@ -118,7 +121,7 @@ export const Swiper: React.FC<SwiperProps> = ({
         left: rail.scrollLeft,
       })
 
-      onChange && onChange(activeIndex({ progress, length: cells.length }))
+      onChange && setIndex(activeIndex({ progress, length: cells.length }))
     }
 
     rail.addEventListener("scroll", handleScroll, { passive: true })
@@ -126,6 +129,10 @@ export const Swiper: React.FC<SwiperProps> = ({
       rail.removeEventListener("scroll", handleScroll)
     }
   }, [cells])
+
+  useEffect(() => {
+    onChange && onChange(index)
+  }, [onChange, index])
 
   return (
     <Container ref={containerRef as any} {...rest}>


### PR DESCRIPTION
`onChange` in `Swiper` was being called on scroll. This PR keeps track with an internal state and only calls `onChange` when the active index actually changes.