### PR TITLE
Converts ReadMore class component to functional component

### DIFF
--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -44,4 +44,14 @@ describe("ReadMore", () => {
     wrapper.simulate("click")
     expect(wrapper.find("ReadMoreLink").length).toBe(1)
   })
+
+  it("calls the click callback when clicked", () => {
+    const callback = jest.fn()
+    const wrapper = mount(
+      <ReadMore maxChars={20} content={copy} onReadMoreClicked={callback} />
+    )
+    expect(callback).not.toBeCalled()
+    wrapper.simulate("click")
+    expect(callback).toBeCalled()
+  })
 })


### PR DESCRIPTION
Shouldn't see any difference in the visual specs. Will publish a canary to confirm this fixes the stale render issue.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.7.4-canary.790.13409.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.7.4-canary.790.13409.0
  # or 
  yarn add @artsy/palette@13.7.4-canary.790.13409.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
