### PR TITLE
[FX-2317] Fixes pagination arrow alignment

### DIFF
--- a/packages/palette/src/elements/Pagination/Pagination.story.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.story.tsx
@@ -1,0 +1,47 @@
+import { action } from "@storybook/addon-actions"
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { LargePagination, SmallPagination } from "./Pagination"
+
+storiesOf("Components/Pagination", module)
+  .add("LargePagination", () => {
+    return (
+      <LargePagination
+        hasNextPage
+        pageCursors={{
+          first: { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false },
+          last: { page: 20, cursor: "Y3Vyc29yMw==", isCurrent: false },
+          around: [
+            { page: 6, cursor: "Y3Vyc29yMw==", isCurrent: true },
+            { page: 7, cursor: "Y3Vyc29yMg==", isCurrent: false },
+            { page: 8, cursor: "Y3Vyc29yMw==", isCurrent: false },
+            { page: 9, cursor: "Y3Vyc29yMw==", isCurrent: false },
+          ],
+          previous: { page: 5, cursor: "Y3Vyc29yMw==", isCurrent: false },
+          " $refType": null,
+        }}
+        onClick={action("onClick")}
+        onNext={action("onNext")}
+      />
+    )
+  })
+  .add("SmallPagination", () => {
+    return (
+      <SmallPagination
+        hasNextPage
+        pageCursors={{
+          first: { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false },
+          last: { page: 20, cursor: "Y3Vyc29yMw==", isCurrent: false },
+          around: [
+            { page: 6, cursor: "Y3Vyc29yMw==", isCurrent: true },
+            { page: 7, cursor: "Y3Vyc29yMg==", isCurrent: false },
+            { page: 8, cursor: "Y3Vyc29yMw==", isCurrent: false },
+            { page: 9, cursor: "Y3Vyc29yMw==", isCurrent: false },
+          ],
+          previous: { page: 5, cursor: "Y3Vyc29yMw==", isCurrent: false },
+        }}
+        onClick={action("onClick")}
+        onNext={action("onNext")}
+      />
+    )
+  })

--- a/packages/palette/src/elements/Pagination/Pagination.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import styled, { css } from "styled-components"
-
 import { color } from "../../helpers/color"
 import { space } from "../../helpers/space"
 import { ChevronIcon } from "../../svgs/ChevronIcon"
@@ -177,7 +176,7 @@ const PrevButton = ({ onClick, disabled }) => {
     <PrevNextContainer className={disabled ? "disabled" : null}>
       <Sans size="3" weight="medium" display="inline" mx={0.5}>
         <a onClick={() => onClick()} className="noUnderline">
-          <ChevronIcon direction="left" top={space(0.5)} /> Prev
+          <ChevronIcon direction="left" top={0.5} /> Prev
         </a>
       </Sans>
     </PrevNextContainer>
@@ -189,7 +188,7 @@ const NextButton = ({ onClick, disabled }) => {
     <PrevNextContainer className={disabled ? "disabled" : null}>
       <Sans size="3" weight="medium" display="inline" mx={0.5}>
         <a onClick={() => onClick()} className="noUnderline">
-          Next <ChevronIcon direction="right" top={space(0.5)} />
+          Next <ChevronIcon direction="right" top={0.5} />
         </a>
       </Sans>
     </PrevNextContainer>


### PR DESCRIPTION
The bug here surfaced when we added `5` to the spacing scale: `top` accepts themed values and since `space(0.5)` yields `5` this no longer falls back to `5px` but rather maps to the themed value of `50`.

I've added some stories to serve as visual specs since we'll have to edit this component a bit in the future.