### PR TITLE
style(FX-2320): Remove XS horizontal padding within tabs container

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -6,7 +6,7 @@ import { Flex, FlexProps } from "../Flex"
 import { Join } from "../Join"
 import { Sans } from "../Typography"
 
-import { color, media, space } from "../../helpers"
+import { color, media } from "../../helpers"
 
 export interface TabLike extends JSX.Element {
   props: TabProps
@@ -174,9 +174,9 @@ export const TabsContainer: React.SFC<
         {...props}
         ref={scrollRef as any}
       >
-        <TabsPaddingContainer justifyContent={props.justifyContent}>
+        <TabsJustifyContentContainer justifyContent={props.justifyContent}>
           {props.children}
-        </TabsPaddingContainer>
+        </TabsJustifyContentContainer>
       </TabsScrollContainer>
     </TabsOuterContainer>
   )
@@ -247,12 +247,8 @@ const TabsOuterContainer = styled(Flex)`
   }
 `
 // TODO: This justifyContent ternary should be removed after we move TabCarousel to Palette
-const TabsPaddingContainer = styled(Flex)<JustifyContentProps>`
+const TabsJustifyContentContainer = styled(Flex)<JustifyContentProps>`
   width: ${props => (props.justifyContent ? "auto" : "100%")};
-
-  ${media.xs`
-    padding: 0 ${space(2)}px;
-  `};
 `
 
 const TabsScrollContainer = styled(Flex)`


### PR DESCRIPTION
This change is prompted by the new fair page redesign and we decided to change this globally to wherever the tab component is used elsewhere.

Jira: https://artsyproduct.atlassian.net/browse/FX-2320

### Screenshots

![Screenshot from 2020-10-06 16-49-21](https://user-images.githubusercontent.com/123595/95258526-ec6dd380-07f3-11eb-9faf-9117a3a8271d.png)
