### PR TITLE
GridColumns typing

### DIFF
--- a/packages/palette/src/elements/GridColumns/GridColumns.tsx
+++ b/packages/palette/src/elements/GridColumns/GridColumns.tsx
@@ -10,12 +10,12 @@ import {
 } from "./calculateGridColumn"
 
 /** GridColumns implements `Box` and the common grid properties */
-export type GridColumnsProps = CSSGridProps
+export type GridColumnsProps = Omit<CSSGridProps, "gridTemplateColumns">
 
 /**
  * A 12-column fluid grid
  */
-export const GridColumns = styled(CSSGrid).attrs({})`
+export const GridColumns = styled(CSSGrid)`
   grid-template-columns: repeat(12, 1fr);
 `
 


### PR DESCRIPTION
Trying to get rid of this `css` prop error.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.9.1-canary.795.13515.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.9.1-canary.795.13515.0
  # or 
  yarn add @artsy/palette@13.9.1-canary.795.13515.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
