### PR TITLE
[PCI-3] Supports props based navigation in Swiper/Carousel

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -130,7 +130,7 @@
     "styled-bootstrap-grid": "3.1.0",
     "styled-system": "^5.1.5",
     "trunc-html": "^1.1.2",
-    "use-cursor": "^1.2.0"
+    "use-cursor": "^1.2.2"
   },
   "husky": {
     "hooks": {

--- a/packages/palette/src/elements/Carousel/Carousel.story.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.story.tsx
@@ -57,6 +57,22 @@ const Dynamic = () => {
   return <Demo widths={widths} />
 }
 
+const Navigation = () => {
+  const [initialIndex, resetIndex] = useState(0)
+  return (
+    <Box>
+      <Demo initialIndex={initialIndex} onChange={resetIndex} />
+      <Box display="flex" justifyContent="space-around">
+        <Clickable onClick={() => resetIndex(0)}>Navigate to page 1</Clickable>
+        <Clickable onClick={() => resetIndex(1)}>Navigate to page 2</Clickable>
+        <Clickable onClick={() => resetIndex(2)}>Navigate to page 3</Clickable>
+        <Clickable onClick={() => resetIndex(3)}>Navigate to page 4</Clickable>
+        <Clickable onClick={() => resetIndex(4)}>Navigate to page 5</Clickable>
+      </Box>
+    </Box>
+  )
+}
+
 storiesOf("Components/Carousel", module)
   .add("Simple", () => {
     return <Demo />
@@ -200,4 +216,10 @@ storiesOf("Components/Carousel", module)
         </Carousel>
       </Box>
     )
+  })
+  .add("initialIndex on mount", () => {
+    return <Demo initialIndex={3} />
+  })
+  .add("Navigate via props", () => {
+    return <Navigation />
   })

--- a/packages/palette/src/elements/Carousel/Carousel.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.tsx
@@ -76,6 +76,7 @@ const Viewport = styled(Box)`
 `
 
 export interface CarouselProps extends BoxProps {
+  initialIndex?: number
   children: JSX.Element | JSX.Element[]
   Next?: typeof CarouselNext | React.FC<CarouselNavigationProps>
   Previous?: typeof CarouselPrevious | React.FC<CarouselNavigationProps>
@@ -95,6 +96,7 @@ export interface CarouselProps extends BoxProps {
  * through them.
  */
 export const Carousel: React.FC<CarouselProps> = ({
+  initialIndex = 0,
   children,
   Previous = CarouselPrevious,
   Next = CarouselNext,
@@ -119,13 +121,13 @@ export const Carousel: React.FC<CarouselProps> = ({
   const [pages, setPages] = useState([0])
 
   const { index, handleNext, handlePrev, setCursor } = useCursor({
+    initialCursor: initialIndex,
     max: pages.length,
   })
 
   const init = () => {
     const { current: viewport } = viewportRef
-    const els = cells.map(({ ref }) => ref.current)
-    const values = els.map(node => node.clientWidth)
+    const values = cells.map(({ ref }) => ref.current.clientWidth)
     setPages(paginateCarousel({ viewport: viewport.clientWidth, values }))
   }
 
@@ -182,7 +184,7 @@ export const Carousel: React.FC<CarouselProps> = ({
 
   return (
     <Container ref={containerRef as any} {...rest}>
-      <Skip ref={startRef} onClick={skipToEnd} mb={1}>
+      <Skip ref={startRef} onClick={skipToEnd} width="100%" mb={1}>
         Skip to end of content
       </Skip>
 
@@ -218,7 +220,7 @@ export const Carousel: React.FC<CarouselProps> = ({
         </Rail>
       </Viewport>
 
-      <Skip ref={endRef} onClick={skipToStart} mt={1}>
+      <Skip ref={endRef} onClick={skipToStart} width="100%" mt={1}>
         Skip to beginning of content
       </Skip>
 

--- a/packages/palette/src/elements/Swiper/Swiper.story.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.story.tsx
@@ -11,11 +11,11 @@ const LOREM =
   "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Quis dicta sunt nihil perspiciatis aperiam asperiores, earum facere repellendus in veniam, mollitia, ducimus delectus perferendis beatae facilis molestiae et ad quaerat!"
 
 const Demo = ({
-  widths,
+  widths = [...new Array(25)].map(_ => 300),
   heights = [400],
   ...rest
 }: {
-  widths: Array<number | string>
+  widths?: Array<number | string>
   heights?: number[]
 } & Omit<SwiperProps, "children">) => {
   return (
@@ -70,7 +70,7 @@ const ProgressBarDemo = () => {
 
   return (
     <>
-      <Demo widths={widths} onChange={setIndex} snap="start" />
+      <Demo widths={widths} onChange={setIndex} />
       <ProgressBar progress={progress} />
     </>
   )
@@ -106,23 +106,35 @@ const Dynamic = () => {
   )
 }
 
+const Navigation = () => {
+  const [initialIndex, resetIndex] = useState(0)
+  return (
+    <Box>
+      <Demo initialIndex={initialIndex} onChange={resetIndex} />
+      <Box display="flex" justifyContent="space-around">
+        <Clickable onClick={() => resetIndex(0)}>Navigate to page 1</Clickable>
+        <Clickable onClick={() => resetIndex(1)}>Navigate to page 2</Clickable>
+        <Clickable onClick={() => resetIndex(2)}>Navigate to page 3</Clickable>
+        <Clickable onClick={() => resetIndex(3)}>Navigate to page 4</Clickable>
+      </Box>
+    </Box>
+  )
+}
+
 storiesOf("Components/Swiper", module)
   .add("Simple", () => {
-    const widths = [...new Array(25)].map(_ => 300)
-    return <Demo widths={widths} />
+    return <Demo />
   })
   .add("With horizontal margins", () => {
-    const widths = [...new Array(25)].map(_ => 300)
     return (
       <>
         <Text>Should be flush with horizontal edges</Text>
-        <Demo widths={widths} mx={[-2, -4]} />
+        <Demo mx={[-2, -4]} />
       </>
     )
   })
   .add("Simple with left-edge snapping", () => {
-    const widths = [...new Array(25)].map(_ => 300)
-    return <Demo widths={widths} snap="start" />
+    return <Demo snap="start" />
   })
   .add("Progress bar example", () => {
     return <ProgressBarDemo />
@@ -181,4 +193,10 @@ storiesOf("Components/Swiper", module)
         </Swiper>
       </Box>
     )
+  })
+  .add("initialIndex on mount", () => {
+    return <Demo initialIndex={3} />
+  })
+  .add("Navigate via props", () => {
+    return <Navigation />
   })

--- a/packages/palette/src/elements/Swiper/__tests__/activeIndex.test.ts
+++ b/packages/palette/src/elements/Swiper/__tests__/activeIndex.test.ts
@@ -6,7 +6,7 @@ describe("activeIndex", () => {
   })
 
   it("calculates the active index given the progress (2)", () => {
-    expect(activeIndex({ progress: 50, length: 50 })).toBe(24)
+    expect(activeIndex({ progress: 50, length: 50 })).toBe(25)
   })
 
   it("calculates the active index given the progress (3)", () => {

--- a/packages/palette/src/elements/Swiper/activeIndex.ts
+++ b/packages/palette/src/elements/Swiper/activeIndex.ts
@@ -10,5 +10,5 @@ export const activeIndex = ({
   progress: number
   length: number
 }) => {
-  return Math.floor((progress * (length - 1)) / 100)
+  return Math.round((progress * (length - 1)) / 100)
 }

--- a/packages/palette/src/elements/Swiper/percentage.ts
+++ b/packages/palette/src/elements/Swiper/percentage.ts
@@ -14,5 +14,5 @@ export const percentage = ({
   total: number
   left: number
 }) => {
-  return Math.floor((left / (total - viewport)) * 100)
+  return Math.round((left / (total - viewport)) * 100)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26898,10 +26898,10 @@ use-callback-ref@^1.2.3:
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.3.tgz#9f939dfb5740807bbf9dd79cdd4e99d27e827756"
   integrity sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA==
 
-use-cursor@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/use-cursor/-/use-cursor-1.2.0.tgz#41f4bd0c99dc8c4b7c5b49973ca9c3c6f4bffaee"
-  integrity sha512-oljIxk/VFhTHrnrrY4nhHGMjVrQm0P7K1zsqRP3m3Oe9lNtikruMiyF98PE0tCDAD3LRPENrp7rwPDwfWyciIA==
+use-cursor@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-cursor/-/use-cursor-1.2.2.tgz#9f9fe356cff043fc7b3b59835245782c40526ed3"
+  integrity sha512-x6UBGPjqsjs3zIrCQFRP93hD60uzY8njRUnsBIKXB53uwZwCbHZHMQnAw8Gw9VeD0jhWxqyPicdpKSFyK21Q5w==
   dependencies:
     map-cursor-to-max "^1.0.0"
 


### PR DESCRIPTION
Closes: [PCI-3](https://artsyproduct.atlassian.net/browse/PCI-3)

Will follow up with a spec here, just drafting for now.

The use-case here is being able to reset the artwork image browser to the beginning/default image if you click "View in Room".

This is a bit more straight-forward in `<Carousel />` vs `<Swiper />` since you're updating the index as you scroll already.

I think this API makes sense (re: ***initial***Index) as it works as you'd expect by default and then if you want to gain full control over the state via props, you need to lift it up a level by passing a setter into `onChange`.

-----
### Swiper
![](http://static.damonzucconi.com/_capture/xLEjvuh7yGKg.gif)

-----
### Carousel
![](http://static.damonzucconi.com/_capture/wCgWkh2lopQC.gif)