### PR TITLE
feat: support boolean errors for Input

### DIFF
--- a/packages/palette/src/elements/Input/Input.test.tsx
+++ b/packages/palette/src/elements/Input/Input.test.tsx
@@ -35,12 +35,22 @@ describe("Input", () => {
     expect(wrapper.text()).toEqual(props.description)
   })
 
-  it("returns an input with error when provided", () => {
-    const props = {
-      error: "This is the title",
-    }
-    const wrapper = mount(<Input {...props} />)
-    expect(wrapper.text()).toEqual(props.error)
+  describe("error states", () => {
+    it("returns an input with error text when provided", () => {
+      const props = {
+        error: "This is the title",
+      }
+      const wrapper = mount(<Input {...props} />)
+      expect(wrapper.text()).toEqual(props.error)
+      expect(wrapper.find("Sans").length).toEqual(1)
+    })
+    it("returns an input without an error text box if error is boolean", () => {
+      const props = {
+        error: true,
+      }
+      const wrapper = mount(<Input {...props} />)
+      expect(wrapper.find("Sans").length).toEqual(0)
+    })
   })
 })
 

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -9,7 +9,7 @@ import { Sans } from "../Typography"
 export interface InputProps extends React.HTMLProps<HTMLInputElement> {
   description?: string
   disabled?: boolean
-  error?: string
+  error?: string | boolean
   required?: boolean
   title?: string
 }
@@ -40,7 +40,7 @@ export const Input: React.ForwardRefExoticComponent<
           error={!!error}
           {...rest as any}
         />
-        {error && (
+        {error && typeof error === "string" && (
           <Sans color="red100" mt="1" size="2">
             {error}
           </Sans>


### PR DESCRIPTION
In Volt, we sometimes use an `<Input>` element from Palette without wanting to use the built-in text error rendering (we instead display custom formatted error message to match older components). This means we sometimes just pass a boolean error value to `<Input>`, which then renders the nice red border error state - but it also renders an empty `<Sans>` component.

I know this non-standard error handling is sorta an anti-pattern, _but_ I feel that it's helpful to support boolean errors since we can already do this in practice and it causes an unexpected render. 

Here's a gif that shows the issue with rendering an empty component (stretches out other adjacent components): https://share.getcloudapp.com/8LurzAWq

This PR adds official support for a boolean error being passed to the `<Input>`, which would cause it to render a red border but without rendering an empty text component.