### PR TITLE
trivial: add target to MenuItem

### DIFF
--- a/packages/palette/src/elements/Menu/Menu.tsx
+++ b/packages/palette/src/elements/Menu/Menu.tsx
@@ -64,6 +64,7 @@ interface MenuItemProps extends BoxProps {
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
   px?: SpaceProps["px"]
   py?: SpaceProps["py"]
+  target?: HTMLAnchorElement['target']
   textColor?: string
   textWeight?: "medium" | "regular"
   hasLighterTextColor?: boolean


### PR DESCRIPTION
Related to https://github.com/artsy/force/pull/6639, adds `target` to `MenuItem` links, to open `href` in a new tab (in this use-case, Google Calendar).

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.17.1-canary.812.13759.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.17.1-canary.812.13759.0
  # or 
  yarn add @artsy/palette@13.17.1-canary.812.13759.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
