### PR TITLE
fix: [Text] update variant type to support array syntax

### DIFF
--- a/packages/palette/src/elements/Text/tokens.ts
+++ b/packages/palette/src/elements/Text/tokens.ts
@@ -170,4 +170,4 @@ export const TEXT_VARIANTS: { [key: string]: TextTreatments } = {
 /**
  * Name of typographic treatment
  */
-export type TextVariant = keyof TextTreatments
+export type TextVariant = keyof TextTreatments | Array<keyof TextTreatment>


### PR DESCRIPTION
For most stuff we can fall back to the automatic responsive sizes, but in some instances its nice to be able to use responsive array syntax when the differences are greater. (Versus `<Media>` component) 