### PR TITLE
fix: Use ResponsiveValue helper

### DIFF
--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -18,7 +18,7 @@ import { TEXT_VARIANTS, TextVariant } from "./tokens"
 /** BaseTextProps */
 export type BaseTextProps = TypographyProps &
   Omit<ColorProps, "color"> & {
-    variant?: TextVariant | TextVariant[]
+    variant?: ResponsiveValue<TextVariant>
     textColor?: ResponsiveValue<Color>
   }
 


### PR DESCRIPTION
Ugh, one more. Delirious night coding. 

Swaps `Thing | Thing[]` for `ResponsiveValue<Thing>` 