### PR TITLE
Extract palette tokens into a separate package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "13.22.0",
+  "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "private": true,
   "scripts": {
     "build-docs": "yarn compile-palette && yarn workspace artsy-palette-docs build",
-    "compile-palette": "yarn workspace @artsy/palette compile",
+    "compile-palette": "lerna run compile",
     "deploy-docs": "yarn compile-palette && yarn workspace artsy-palette-docs deploy",
-    "lint": "yarn workspaces run lint",
+    "lint": "lerna run lint",
     "start": "concurrently --raw --kill-others 'yarn workspace @artsy/palette watch' 'yarn workspace artsy-palette-docs start'",
     "storybook": "yarn workspace @artsy/palette storybook",
-    "test": "yarn workspaces run test",
-    "type-check": "yarn compile-palette && yarn workspace @artsy/palette run type-declarations && yarn workspaces run type-check",
+    "test": "lerna run test",
+    "pretype-check": "yarn compile-palette && lerna run type-declarations",
+    "type-check": "lerna run type-check",
     "visual-test": "yarn workspace @artsy/palette visual-test"
   },
   "repository": {

--- a/packages/palette-tokens/README.md
+++ b/packages/palette-tokens/README.md
@@ -2,18 +2,31 @@
 
 The [design tokens](https://www.lightningdesignsystem.com/design-tokens/) that power [Artsy](https://www.artsy.net)'s [Palette](https://palette.artsy.net).
 
-This package isn't intended to be consumed directly, but rather included as a transitive dependency of palette.
+:warning: This package isn't intended to be consumed directly, but rather included as a transitive dependency of palette. :warning:
 
 ## Usage
 
-In the main theme file...
+In the main theme file for a Palette implementation:
 
 ```
-import buildTheme from "@artsy/palette-tokens"
-export * from "@artsy/palette-tokens";
+import tokens from "@artsy/palette-tokens"
 import { fontFamily } from "./platform/fonts"
 
-export const themeConfig = buildTheme(fontFamily);
+/**
+ * This is required only in consuming versions of palette to keep
+ * the existing api the same. If you're using the tokens as a standalone
+ * you may not necessarily need to include this export statement.
+ */
+export * from "@artsy/palette-tokens";
+
+/**
+ * Any platform specific tokens can be included in the final `themeConfig` as
+ * shown.
+ */
+export const themeConfig = {
+  ...tokens,
+  fontFamily
+}
 ```
 
 ## License

--- a/packages/palette-tokens/README.md
+++ b/packages/palette-tokens/README.md
@@ -1,0 +1,46 @@
+# `palette-tokens`
+
+The [design tokens](https://www.lightningdesignsystem.com/design-tokens/) that power [Artsy](https://www.artsy.net)'s [Palette](https://palette.artsy.net).
+
+This package isn't intended to be consumed directly, but rather included as a transitive dependency of palette.
+
+## Usage
+
+In the main theme file...
+
+```
+import buildTheme from "@artsy/palette-tokens"
+export * from "@artsy/palette-tokens";
+import { fontFamily } from "./platform/fonts"
+
+export const themeConfig = buildTheme(fontFamily);
+```
+
+## License
+
+MIT License. See [LICENSE](../../LICENSE).
+
+## About Artsy
+
+<a href="https://www.artsy.net/">
+  <img align="left" src="https://avatars2.githubusercontent.com/u/546231?s=200&v=4"/>
+</a>
+
+This project is the work of engineers at [Artsy][footer_website], the world's
+leading and largest online art marketplace and platform for discovering art.
+One of our core [Engineering Principles][footer_principles] is being [Open
+Source by Default][footer_open] which means we strive to share as many details
+of our work as possible.
+
+You can learn more about this work from [our blog][footer_blog] and by following
+[@ArtsyOpenSource][footer_twitter] or explore our public data by checking out
+[our API][footer_api]. If you're interested in a career at Artsy, read through
+our [job postings][footer_jobs]!
+
+[footer_website]: https://www.artsy.net/
+[footer_principles]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md
+[footer_open]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default
+[footer_blog]: https://artsy.github.io/
+[footer_twitter]: https://twitter.com/ArtsyOpenSource
+[footer_api]: https://developers.artsy.net/
+[footer_jobs]: https://www.artsy.net/jobs

--- a/packages/palette-tokens/package.json
+++ b/packages/palette-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/palette-tokens",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "The design tokens for Artsy's palette",
   "keywords": [
     "design",

--- a/packages/palette-tokens/package.json
+++ b/packages/palette-tokens/package.json
@@ -30,8 +30,7 @@
     "clean": "rm -rf dist",
     "compile": "tsc -p tsconfig.json",
     "type-check": "tsc --noEmit --pretty",
-    "prepublishOnly": "yarn clean && yarn compile",
-    "test": "echo \"Error: run tests from root\" && exit 1"
+    "prepublishOnly": "yarn clean && yarn compile"
   },
   "bugs": {
     "url": "https://github.com/artsy/palette/issues"

--- a/packages/palette-tokens/package.json
+++ b/packages/palette-tokens/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@artsy/palette-tokens",
+  "version": "1.0.0",
+  "description": "The design tokens for Artsy's palette",
+  "keywords": [
+    "design",
+    "tokens",
+    "theme",
+    "config",
+    "styled-system",
+    "styled-components",
+    "design",
+    "system"
+  ],
+  "author": "Justin Bennett <justin.bennett@artsymail.com>",
+  "homepage": "https://palette.artsy.net",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "directories": {
+    "dist": "dist"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/artsy/palette.git"
+  },
+  "scripts": {
+    "clean": "rm -rf dist",
+    "compile": "tsc -p tsconfig.json",
+    "type-check": "tsc --noEmit --pretty",
+    "prepublishOnly": "yarn clean && yarn compile",
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/artsy/palette/issues"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
+}

--- a/packages/palette-tokens/src/index.ts
+++ b/packages/palette-tokens/src/index.ts
@@ -1,0 +1,390 @@
+import {
+  TEXT_FONT_SIZES,
+  TEXT_FONTS,
+  TEXT_LETTER_SPACING,
+  TEXT_LINE_HEIGHTS,
+  TEXT_VARIANTS,
+} from "./text";
+
+/**
+ * Spec: https://www.notion.so/artsy/Design-92030f16ed7c4c72bb3eb832b4243d04
+ * Styled System API: https://jxnblk.com/styled-system/api
+ * Table: https://jxnblk.com/styled-system/table
+ */
+
+/**
+ * A list of breakpoints accessible by key/value. See:
+ * https://www.notion.so/artsy/Grid-e489a52e26bd4319b6ee7898044a8a53
+ */
+export const breakpoints = {
+  /** Above 1192 */
+  xl: "1192px",
+  /** Between 1024 and  1191 */
+  lg: "1024px",
+  /** Between 900 and 1023 */
+  md: "900px",
+  /** Between 768 and  899 */
+  sm: "768px",
+  /** Below 767 */
+  xs: "767px",
+} as const;
+
+/**
+ * Copy of `breakpoints` as integers
+ */
+export const unitlessBreakpoints = {
+  /** Above 1192 */
+  xl: parseInt(breakpoints.xl, 10),
+  /** Between 1024 and  1191 */
+  lg: parseInt(breakpoints.lg, 10),
+  /** Between 900 and 1023 */
+  md: parseInt(breakpoints.md, 10),
+  /** Between 768 and  899 */
+  sm: parseInt(breakpoints.sm, 10),
+  /** Below 767 */
+  xs: parseInt(breakpoints.xs, 10),
+};
+
+/**
+ * We alias breakpoints onto the scale so that styled-system has access
+ * to the named breakpoints as well as the scale
+ */
+const BREAKPOINTS_SCALE = Object.assign(
+  [breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl],
+  breakpoints
+);
+
+/**
+ * All of the config for the Artsy theming system, based on the
+ * design system from our design team:
+ * https://www.notion.so/artsy/Master-Library-810612339f474d0997fe359af4285c56
+ */
+export default function buildTheme<FontFamily>(fontFamily: FontFamily) {
+  return {
+    /** Border variations */
+    borders: ["1px solid", "2px solid"],
+
+    /**
+     *  This allows styled-system to hook into our breakpoints
+     */
+    breakpoints: BREAKPOINTS_SCALE,
+
+    /**
+     * Artsy's color schemes:
+     * https://www.notion.so/artsy/Color-a0c24896daf8433d9409aee2146ac267
+     */
+    colors: {
+      /** Full black, primary brand color  */
+      black100: "#000",
+      /** 80% black  */
+      black80: "#333",
+      /** 60% black, bold copy, lower in hierarchy  */
+      black60: "#666",
+      /** 30 black (dark grey), placeholder text only  */
+      black30: "#C2C2C2",
+      /** 10 black (grey), borders, divider lines, and grey button only */
+      black10: "#E5E5E5",
+      /** 5 black (light grey), backgrounds only */
+      black5: "#F8F8F8",
+      /** 100 Blue, highlight */
+      blue100: "#0A1AB4",
+      /** Full purple, secondary brand color. Should only used in time/transitions (on hover, active state), for highlighting vital text, and links.   */
+      purple100: "#6E1EFF",
+      /** 30 purple (light purple), avoid usage  */
+      purple30: "#D3BBFF",
+      /* 5 purple, highlight, accent */
+      purple5: "#F8F3FF",
+      /** Full green, success */
+      green100: "#0EDA83",
+      /** Full red, error */
+      red100: "#F7625A",
+      /** Full yellow, warn */
+      yellow100: "#F1AF1B",
+      /** 30 yellow (light yellow), avoid future use */
+      yellow30: "#FAE7BA",
+      /** 10 yellow (lightest yellow), avoid future use */
+      yellow10: "#FDF7E8",
+      /** Full white */
+      white100: "#FFF",
+    },
+
+    fontFamily,
+
+    fonts: TEXT_FONTS,
+    fontSizes: TEXT_FONT_SIZES,
+    letterSpacings: TEXT_LETTER_SPACING,
+    lineHeights: TEXT_LINE_HEIGHTS,
+
+    // prettier-ignore
+    /** Media queries to work with in web  */
+    mediaQueries: {
+      xl: `(min-width: ${breakpoints.xl})`,
+      lg: `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1})`,
+      md: `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1})`,
+      sm: `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1})`,
+      xs: `(max-width: ${parseInt(breakpoints.sm, 10) - 1})`,
+      /** Determines if the input device has the notion of hover, e.g. mouse. */
+      hover: `not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)`,
+    },
+
+    // https://github.com/dragma/styled-bootstrap-grid#styled-bootstrap-grid
+    grid: {
+      /**
+       * Breakpoints for the Artsy grid,
+       * https://www.notion.so/artsy/Grid-e489a52e26bd4319b6ee7898044a8a53
+       *
+       * This version of `styled-bootstrap-grid` requires breakpoint
+       * values to be integers (not px literals)
+       */
+      breakpoints: unitlessBreakpoints,
+      container: {
+        padding: 0,
+      },
+      row: {
+        padding: 0,
+      },
+      col: {
+        padding: 0,
+      },
+    },
+
+    /**
+     * The spacing system is based on
+     * https://www.notion.so/artsy/Spacing-93eeaed9fdf9480099fec7094fd1b9f3
+     */
+    space: {
+      // unit: px value
+      /** Equivalent to 3px  */
+      0.3: "3px",
+      /** Equivalent to 5px  */
+      0.5: "5px",
+      /** Equivalent to 10px  */
+      1: "10px",
+      /** Equivalent to 15px  */
+      1.5: "15px",
+      /** Equivalent to 20px  */
+      2: "20px",
+      /** Equivalent to 30px  */
+      3: "30px",
+      /** Equivalent to 40px  */
+      4: "40px",
+      /** Equivalent to 50px  */
+      5: "50px",
+      /** Equivalent to 60px  */
+      6: "60px",
+      /** Equivalent to 90px  */
+      9: "90px",
+      /** Equivalent to 120px  */
+      12: "120px",
+      /** Equivalent to 180px  */
+      18: "180px",
+    },
+
+    /**
+     * Our type system is based on:
+     * https://www.notion.so/artsy/Typography-d1f9f6731f3d47c78003d6d016c30221
+     */
+    typeSizes: {
+      /** Unica  */
+      sans: {
+        /** Equivalent to 8px size / 8px line-height  */
+        "0": {
+          fontSize: "8px",
+          lineHeight: "8px",
+        },
+        /** Equivalent to 10px size / 14px line-height  */
+        "1": {
+          fontSize: "10px",
+          lineHeight: "14px",
+        },
+        /** Equivalent to 12px size / 16px line-height  */
+        "2": {
+          fontSize: "12px",
+          lineHeight: "16px",
+        },
+        /** Equivalent to 14px size / 24px line-height  */
+        "3": {
+          fontSize: "14px",
+          lineHeight: "24px",
+        },
+        /** Equivalent to 14px size / 20px line-height  */
+        "3t": {
+          fontSize: "14px",
+          lineHeight: "20px",
+        },
+        /** Equivalent to 16px size / 26px line-height  */
+        "4": {
+          fontSize: "16px",
+          lineHeight: "26px",
+        },
+        /** Equivalent to 16px size / 22px line-height  */
+        "4t": {
+          fontSize: "16px",
+          lineHeight: "22px",
+        },
+        /** Equivalent to 18px size / 30px line-height  */
+        "5": {
+          fontSize: "18px",
+          lineHeight: "30px",
+        },
+        /** Equivalent to 18px size / 26px line-height  */
+        "5t": {
+          fontSize: "18px",
+          lineHeight: "26px",
+        },
+        /** Equivalent to 22px size / 30px line-height  */
+        "6": {
+          fontSize: "22px",
+          lineHeight: "30px",
+        },
+        /** Equivalent to 28px size / 36px line-height  */
+        "8": {
+          fontSize: "28px",
+          lineHeight: "36px",
+        },
+        /** Equivalent to 42px size / 50px line-height  */
+        "10": {
+          fontSize: "42px",
+          lineHeight: "50px",
+        },
+        /** Equivalent to 60px size / 66px line-height  */
+        "12": {
+          fontSize: "60px",
+          lineHeight: "66px",
+        },
+        /** Equivalent to 80px size / 84px line-height  */
+        "14": {
+          fontSize: "80px",
+          lineHeight: "84px",
+        },
+        /** Equivalent to 100px size / 104px line-height  */
+        "16": {
+          fontSize: "100px",
+          lineHeight: "104px",
+        },
+      },
+
+      /** Garamond  */
+      serif: {
+        /** Equivalent to 12px size / 16px line-height  */
+        "1": {
+          fontSize: "12px",
+          lineHeight: "16px",
+        },
+        /** Equivalent to 14px size / 18px line-height  */
+        "2": {
+          fontSize: "14px",
+          lineHeight: "18px",
+        },
+        /** Equivalent to 16px size / 24px line-height  */
+        "3": {
+          fontSize: "16px",
+          lineHeight: "24px",
+        },
+        /** Equivalent to 16px size / 20px line-height  */
+        "3t": {
+          fontSize: "16px",
+          lineHeight: "20px",
+        },
+        /** Equivalent to 18px size / 26px line-height  */
+        "4": {
+          fontSize: "18px",
+          lineHeight: "26px",
+        },
+        /** Equivalent to 18px size / 22px line-height  */
+        "4t": {
+          fontSize: "18px",
+          lineHeight: "22px",
+        },
+        /** Equivalent to 22px size / 32px line-height  */
+        "5": {
+          fontSize: "22px",
+          lineHeight: "32px",
+        },
+        /** Equivalent to 22px size / 28px line-height  */
+        "5t": {
+          fontSize: "22px",
+          lineHeight: "28px",
+        },
+        /** Equivalent to 26px size / 32px line-height  */
+        "6": {
+          fontSize: "26px",
+          lineHeight: "32px",
+        },
+        /** Equivalent to 32px size / 38px line-height  */
+        "8": {
+          fontSize: "32px",
+          lineHeight: "38px",
+        },
+        /** Equivalent to 44px size / 50px line-height  */
+        "10": {
+          fontSize: "44px",
+          lineHeight: "50px",
+        },
+        /** Equivalent to 60px size / 70px line-height  */
+        "12": {
+          fontSize: "60px",
+          lineHeight: "70px",
+        },
+      },
+
+      /** Avant Garde  */
+      display: {
+        /** Equivalent to 10px size / 12px line-height  */
+        "2": {
+          fontSize: "10px",
+          lineHeight: "12px",
+        },
+        /** Equivalent to 12px size / 16px line-height  */
+        "3t": {
+          fontSize: "12px",
+          lineHeight: "16px",
+        },
+        /** Equivalent to 14px size / 18px line-height  */
+        "4t": {
+          fontSize: "14px",
+          lineHeight: "18px",
+        },
+        /** Equivalent to 16px size / 20px line-height  */
+        "5t": {
+          fontSize: "16px",
+          lineHeight: "20px",
+        },
+        /** Equivalent to 18px size / 22px line-height  */
+        "6": {
+          fontSize: "18px",
+          lineHeight: "22px",
+        },
+        /** Equivalent to 22px size / 24px line-height  */
+        "8": {
+          fontSize: "22px",
+          lineHeight: "24px",
+        },
+      },
+    },
+
+    textVariants: TEXT_VARIANTS,
+  } as const;
+}
+
+type ThemeProps = ReturnType<typeof buildTheme>;
+
+/** All available px spacing maps */
+export type SpacingUnit = keyof ThemeProps["space"];
+/** All available color keys */
+export type Color = keyof ThemeProps["colors"];
+/** All available width breakpoint */
+export type Breakpoint = keyof typeof breakpoints;
+
+/** All available type sizes */
+export type TypeSizes = ThemeProps["typeSizes"];
+/** All available sizes for our sans font */
+export type SansSize = keyof TypeSizes["sans"] | Array<keyof TypeSizes["sans"]>;
+/** All available sizes for our serif font */
+export type SerifSize =
+  | keyof TypeSizes["serif"]
+  | Array<keyof TypeSizes["serif"]>;
+/** All available sizes for our display font */
+export type DisplaySize =
+  | keyof TypeSizes["display"]
+  | Array<keyof TypeSizes["display"]>;

--- a/packages/palette-tokens/src/index.ts
+++ b/packages/palette-tokens/src/index.ts
@@ -59,65 +59,62 @@ const BREAKPOINTS_SCALE = Object.assign(
  * design system from our design team:
  * https://www.notion.so/artsy/Master-Library-810612339f474d0997fe359af4285c56
  */
-export default function buildTheme<FontFamily>(fontFamily: FontFamily) {
-  return {
-    /** Border variations */
-    borders: ["1px solid", "2px solid"],
+const tokens = {
+  /** Border variations */
+  borders: ["1px solid", "2px solid"],
 
-    /**
-     *  This allows styled-system to hook into our breakpoints
-     */
-    breakpoints: BREAKPOINTS_SCALE,
+  /**
+   *  This allows styled-system to hook into our breakpoints
+   */
+  breakpoints: BREAKPOINTS_SCALE,
 
-    /**
-     * Artsy's color schemes:
-     * https://www.notion.so/artsy/Color-a0c24896daf8433d9409aee2146ac267
-     */
-    colors: {
-      /** Full black, primary brand color  */
-      black100: "#000",
-      /** 80% black  */
-      black80: "#333",
-      /** 60% black, bold copy, lower in hierarchy  */
-      black60: "#666",
-      /** 30 black (dark grey), placeholder text only  */
-      black30: "#C2C2C2",
-      /** 10 black (grey), borders, divider lines, and grey button only */
-      black10: "#E5E5E5",
-      /** 5 black (light grey), backgrounds only */
-      black5: "#F8F8F8",
-      /** 100 Blue, highlight */
-      blue100: "#0A1AB4",
-      /** Full purple, secondary brand color. Should only used in time/transitions (on hover, active state), for highlighting vital text, and links.   */
-      purple100: "#6E1EFF",
-      /** 30 purple (light purple), avoid usage  */
-      purple30: "#D3BBFF",
-      /* 5 purple, highlight, accent */
-      purple5: "#F8F3FF",
-      /** Full green, success */
-      green100: "#0EDA83",
-      /** Full red, error */
-      red100: "#F7625A",
-      /** Full yellow, warn */
-      yellow100: "#F1AF1B",
-      /** 30 yellow (light yellow), avoid future use */
-      yellow30: "#FAE7BA",
-      /** 10 yellow (lightest yellow), avoid future use */
-      yellow10: "#FDF7E8",
-      /** Full white */
-      white100: "#FFF",
-    },
+  /**
+   * Artsy's color schemes:
+   * https://www.notion.so/artsy/Color-a0c24896daf8433d9409aee2146ac267
+   */
+  colors: {
+    /** Full black, primary brand color  */
+    black100: "#000",
+    /** 80% black  */
+    black80: "#333",
+    /** 60% black, bold copy, lower in hierarchy  */
+    black60: "#666",
+    /** 30 black (dark grey), placeholder text only  */
+    black30: "#C2C2C2",
+    /** 10 black (grey), borders, divider lines, and grey button only */
+    black10: "#E5E5E5",
+    /** 5 black (light grey), backgrounds only */
+    black5: "#F8F8F8",
+    /** 100 Blue, highlight */
+    blue100: "#0A1AB4",
+    /** Full purple, secondary brand color. Should only used in time/transitions (on hover, active state), for highlighting vital text, and links.   */
+    purple100: "#6E1EFF",
+    /** 30 purple (light purple), avoid usage  */
+    purple30: "#D3BBFF",
+    /* 5 purple, highlight, accent */
+    purple5: "#F8F3FF",
+    /** Full green, success */
+    green100: "#0EDA83",
+    /** Full red, error */
+    red100: "#F7625A",
+    /** Full yellow, warn */
+    yellow100: "#F1AF1B",
+    /** 30 yellow (light yellow), avoid future use */
+    yellow30: "#FAE7BA",
+    /** 10 yellow (lightest yellow), avoid future use */
+    yellow10: "#FDF7E8",
+    /** Full white */
+    white100: "#FFF",
+  },
 
-    fontFamily,
+  fonts: TEXT_FONTS,
+  fontSizes: TEXT_FONT_SIZES,
+  letterSpacings: TEXT_LETTER_SPACING,
+  lineHeights: TEXT_LINE_HEIGHTS,
 
-    fonts: TEXT_FONTS,
-    fontSizes: TEXT_FONT_SIZES,
-    letterSpacings: TEXT_LETTER_SPACING,
-    lineHeights: TEXT_LINE_HEIGHTS,
-
-    // prettier-ignore
-    /** Media queries to work with in web  */
-    mediaQueries: {
+  // prettier-ignore
+  /** Media queries to work with in web  */
+  mediaQueries: {
       xl: `(min-width: ${breakpoints.xl})`,
       lg: `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1})`,
       md: `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1})`,
@@ -127,247 +124,254 @@ export default function buildTheme<FontFamily>(fontFamily: FontFamily) {
       hover: `not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)`,
     },
 
-    // https://github.com/dragma/styled-bootstrap-grid#styled-bootstrap-grid
-    grid: {
-      /**
-       * Breakpoints for the Artsy grid,
-       * https://www.notion.so/artsy/Grid-e489a52e26bd4319b6ee7898044a8a53
-       *
-       * This version of `styled-bootstrap-grid` requires breakpoint
-       * values to be integers (not px literals)
-       */
-      breakpoints: unitlessBreakpoints,
-      container: {
-        padding: 0,
-      },
-      row: {
-        padding: 0,
-      },
-      col: {
-        padding: 0,
-      },
-    },
-
+  // https://github.com/dragma/styled-bootstrap-grid#styled-bootstrap-grid
+  grid: {
     /**
-     * The spacing system is based on
-     * https://www.notion.so/artsy/Spacing-93eeaed9fdf9480099fec7094fd1b9f3
+     * Breakpoints for the Artsy grid,
+     * https://www.notion.so/artsy/Grid-e489a52e26bd4319b6ee7898044a8a53
+     *
+     * This version of `styled-bootstrap-grid` requires breakpoint
+     * values to be integers (not px literals)
      */
-    space: {
-      // unit: px value
-      /** Equivalent to 3px  */
-      0.3: "3px",
-      /** Equivalent to 5px  */
-      0.5: "5px",
-      /** Equivalent to 10px  */
-      1: "10px",
-      /** Equivalent to 15px  */
-      1.5: "15px",
-      /** Equivalent to 20px  */
-      2: "20px",
-      /** Equivalent to 30px  */
-      3: "30px",
-      /** Equivalent to 40px  */
-      4: "40px",
-      /** Equivalent to 50px  */
-      5: "50px",
-      /** Equivalent to 60px  */
-      6: "60px",
-      /** Equivalent to 90px  */
-      9: "90px",
-      /** Equivalent to 120px  */
-      12: "120px",
-      /** Equivalent to 180px  */
-      18: "180px",
+    breakpoints: unitlessBreakpoints,
+    container: {
+      padding: 0,
     },
+    row: {
+      padding: 0,
+    },
+    col: {
+      padding: 0,
+    },
+  },
 
-    /**
-     * Our type system is based on:
-     * https://www.notion.so/artsy/Typography-d1f9f6731f3d47c78003d6d016c30221
-     */
-    typeSizes: {
-      /** Unica  */
-      sans: {
-        /** Equivalent to 8px size / 8px line-height  */
-        "0": {
-          fontSize: "8px",
-          lineHeight: "8px",
-        },
-        /** Equivalent to 10px size / 14px line-height  */
-        "1": {
-          fontSize: "10px",
-          lineHeight: "14px",
-        },
-        /** Equivalent to 12px size / 16px line-height  */
-        "2": {
-          fontSize: "12px",
-          lineHeight: "16px",
-        },
-        /** Equivalent to 14px size / 24px line-height  */
-        "3": {
-          fontSize: "14px",
-          lineHeight: "24px",
-        },
-        /** Equivalent to 14px size / 20px line-height  */
-        "3t": {
-          fontSize: "14px",
-          lineHeight: "20px",
-        },
-        /** Equivalent to 16px size / 26px line-height  */
-        "4": {
-          fontSize: "16px",
-          lineHeight: "26px",
-        },
-        /** Equivalent to 16px size / 22px line-height  */
-        "4t": {
-          fontSize: "16px",
-          lineHeight: "22px",
-        },
-        /** Equivalent to 18px size / 30px line-height  */
-        "5": {
-          fontSize: "18px",
-          lineHeight: "30px",
-        },
-        /** Equivalent to 18px size / 26px line-height  */
-        "5t": {
-          fontSize: "18px",
-          lineHeight: "26px",
-        },
-        /** Equivalent to 22px size / 30px line-height  */
-        "6": {
-          fontSize: "22px",
-          lineHeight: "30px",
-        },
-        /** Equivalent to 28px size / 36px line-height  */
-        "8": {
-          fontSize: "28px",
-          lineHeight: "36px",
-        },
-        /** Equivalent to 42px size / 50px line-height  */
-        "10": {
-          fontSize: "42px",
-          lineHeight: "50px",
-        },
-        /** Equivalent to 60px size / 66px line-height  */
-        "12": {
-          fontSize: "60px",
-          lineHeight: "66px",
-        },
-        /** Equivalent to 80px size / 84px line-height  */
-        "14": {
-          fontSize: "80px",
-          lineHeight: "84px",
-        },
-        /** Equivalent to 100px size / 104px line-height  */
-        "16": {
-          fontSize: "100px",
-          lineHeight: "104px",
-        },
+  /**
+   * The spacing system is based on
+   * https://www.notion.so/artsy/Spacing-93eeaed9fdf9480099fec7094fd1b9f3
+   */
+  space: {
+    // unit: px value
+    /** Equivalent to 3px  */
+    0.3: "3px",
+    /** Equivalent to 5px  */
+    0.5: "5px",
+    /** Equivalent to 10px  */
+    1: "10px",
+    /** Equivalent to 15px  */
+    1.5: "15px",
+    /** Equivalent to 20px  */
+    2: "20px",
+    /** Equivalent to 30px  */
+    3: "30px",
+    /** Equivalent to 40px  */
+    4: "40px",
+    /** Equivalent to 50px  */
+    5: "50px",
+    /** Equivalent to 60px  */
+    6: "60px",
+    /** Equivalent to 90px  */
+    9: "90px",
+    /** Equivalent to 120px  */
+    12: "120px",
+    /** Equivalent to 180px  */
+    18: "180px",
+  },
+
+  /**
+   * Our type system is based on:
+   * https://www.notion.so/artsy/Typography-d1f9f6731f3d47c78003d6d016c30221
+   */
+  typeSizes: {
+    /** Unica  */
+    sans: {
+      /** Equivalent to 8px size / 8px line-height  */
+      "0": {
+        fontSize: "8px",
+        lineHeight: "8px",
       },
-
-      /** Garamond  */
-      serif: {
-        /** Equivalent to 12px size / 16px line-height  */
-        "1": {
-          fontSize: "12px",
-          lineHeight: "16px",
-        },
-        /** Equivalent to 14px size / 18px line-height  */
-        "2": {
-          fontSize: "14px",
-          lineHeight: "18px",
-        },
-        /** Equivalent to 16px size / 24px line-height  */
-        "3": {
-          fontSize: "16px",
-          lineHeight: "24px",
-        },
-        /** Equivalent to 16px size / 20px line-height  */
-        "3t": {
-          fontSize: "16px",
-          lineHeight: "20px",
-        },
-        /** Equivalent to 18px size / 26px line-height  */
-        "4": {
-          fontSize: "18px",
-          lineHeight: "26px",
-        },
-        /** Equivalent to 18px size / 22px line-height  */
-        "4t": {
-          fontSize: "18px",
-          lineHeight: "22px",
-        },
-        /** Equivalent to 22px size / 32px line-height  */
-        "5": {
-          fontSize: "22px",
-          lineHeight: "32px",
-        },
-        /** Equivalent to 22px size / 28px line-height  */
-        "5t": {
-          fontSize: "22px",
-          lineHeight: "28px",
-        },
-        /** Equivalent to 26px size / 32px line-height  */
-        "6": {
-          fontSize: "26px",
-          lineHeight: "32px",
-        },
-        /** Equivalent to 32px size / 38px line-height  */
-        "8": {
-          fontSize: "32px",
-          lineHeight: "38px",
-        },
-        /** Equivalent to 44px size / 50px line-height  */
-        "10": {
-          fontSize: "44px",
-          lineHeight: "50px",
-        },
-        /** Equivalent to 60px size / 70px line-height  */
-        "12": {
-          fontSize: "60px",
-          lineHeight: "70px",
-        },
+      /** Equivalent to 10px size / 14px line-height  */
+      "1": {
+        fontSize: "10px",
+        lineHeight: "14px",
       },
-
-      /** Avant Garde  */
-      display: {
-        /** Equivalent to 10px size / 12px line-height  */
-        "2": {
-          fontSize: "10px",
-          lineHeight: "12px",
-        },
-        /** Equivalent to 12px size / 16px line-height  */
-        "3t": {
-          fontSize: "12px",
-          lineHeight: "16px",
-        },
-        /** Equivalent to 14px size / 18px line-height  */
-        "4t": {
-          fontSize: "14px",
-          lineHeight: "18px",
-        },
-        /** Equivalent to 16px size / 20px line-height  */
-        "5t": {
-          fontSize: "16px",
-          lineHeight: "20px",
-        },
-        /** Equivalent to 18px size / 22px line-height  */
-        "6": {
-          fontSize: "18px",
-          lineHeight: "22px",
-        },
-        /** Equivalent to 22px size / 24px line-height  */
-        "8": {
-          fontSize: "22px",
-          lineHeight: "24px",
-        },
+      /** Equivalent to 12px size / 16px line-height  */
+      "2": {
+        fontSize: "12px",
+        lineHeight: "16px",
+      },
+      /** Equivalent to 14px size / 24px line-height  */
+      "3": {
+        fontSize: "14px",
+        lineHeight: "24px",
+      },
+      /** Equivalent to 14px size / 20px line-height  */
+      "3t": {
+        fontSize: "14px",
+        lineHeight: "20px",
+      },
+      /** Equivalent to 16px size / 26px line-height  */
+      "4": {
+        fontSize: "16px",
+        lineHeight: "26px",
+      },
+      /** Equivalent to 16px size / 22px line-height  */
+      "4t": {
+        fontSize: "16px",
+        lineHeight: "22px",
+      },
+      /** Equivalent to 18px size / 30px line-height  */
+      "5": {
+        fontSize: "18px",
+        lineHeight: "30px",
+      },
+      /** Equivalent to 18px size / 26px line-height  */
+      "5t": {
+        fontSize: "18px",
+        lineHeight: "26px",
+      },
+      /** Equivalent to 22px size / 30px line-height  */
+      "6": {
+        fontSize: "22px",
+        lineHeight: "30px",
+      },
+      /** Equivalent to 28px size / 36px line-height  */
+      "8": {
+        fontSize: "28px",
+        lineHeight: "36px",
+      },
+      /** Equivalent to 42px size / 50px line-height  */
+      "10": {
+        fontSize: "42px",
+        lineHeight: "50px",
+      },
+      /** Equivalent to 60px size / 66px line-height  */
+      "12": {
+        fontSize: "60px",
+        lineHeight: "66px",
+      },
+      /** Equivalent to 80px size / 84px line-height  */
+      "14": {
+        fontSize: "80px",
+        lineHeight: "84px",
+      },
+      /** Equivalent to 100px size / 104px line-height  */
+      "16": {
+        fontSize: "100px",
+        lineHeight: "104px",
       },
     },
 
-    textVariants: TEXT_VARIANTS,
-  } as const;
-}
+    /** Garamond  */
+    serif: {
+      /** Equivalent to 12px size / 16px line-height  */
+      "1": {
+        fontSize: "12px",
+        lineHeight: "16px",
+      },
+      /** Equivalent to 14px size / 18px line-height  */
+      "2": {
+        fontSize: "14px",
+        lineHeight: "18px",
+      },
+      /** Equivalent to 16px size / 24px line-height  */
+      "3": {
+        fontSize: "16px",
+        lineHeight: "24px",
+      },
+      /** Equivalent to 16px size / 20px line-height  */
+      "3t": {
+        fontSize: "16px",
+        lineHeight: "20px",
+      },
+      /** Equivalent to 18px size / 26px line-height  */
+      "4": {
+        fontSize: "18px",
+        lineHeight: "26px",
+      },
+      /** Equivalent to 18px size / 22px line-height  */
+      "4t": {
+        fontSize: "18px",
+        lineHeight: "22px",
+      },
+      /** Equivalent to 22px size / 32px line-height  */
+      "5": {
+        fontSize: "22px",
+        lineHeight: "32px",
+      },
+      /** Equivalent to 22px size / 28px line-height  */
+      "5t": {
+        fontSize: "22px",
+        lineHeight: "28px",
+      },
+      /** Equivalent to 26px size / 32px line-height  */
+      "6": {
+        fontSize: "26px",
+        lineHeight: "32px",
+      },
+      /** Equivalent to 32px size / 38px line-height  */
+      "8": {
+        fontSize: "32px",
+        lineHeight: "38px",
+      },
+      /** Equivalent to 44px size / 50px line-height  */
+      "10": {
+        fontSize: "44px",
+        lineHeight: "50px",
+      },
+      /** Equivalent to 60px size / 70px line-height  */
+      "12": {
+        fontSize: "60px",
+        lineHeight: "70px",
+      },
+    },
 
-type ThemeProps = ReturnType<typeof buildTheme>;
+    /** Avant Garde  */
+    display: {
+      /** Equivalent to 10px size / 12px line-height  */
+      "2": {
+        fontSize: "10px",
+        lineHeight: "12px",
+      },
+      /** Equivalent to 12px size / 16px line-height  */
+      "3t": {
+        fontSize: "12px",
+        lineHeight: "16px",
+      },
+      /** Equivalent to 14px size / 18px line-height  */
+      "4t": {
+        fontSize: "14px",
+        lineHeight: "18px",
+      },
+      /** Equivalent to 16px size / 20px line-height  */
+      "5t": {
+        fontSize: "16px",
+        lineHeight: "20px",
+      },
+      /** Equivalent to 18px size / 22px line-height  */
+      "6": {
+        fontSize: "18px",
+        lineHeight: "22px",
+      },
+      /** Equivalent to 22px size / 24px line-height  */
+      "8": {
+        fontSize: "22px",
+        lineHeight: "24px",
+      },
+    },
+  },
+
+  textVariants: TEXT_VARIANTS,
+} as const;
+
+/**
+ * NOTE: This is a default export explicitly so it isn't accidentally
+ * exported by the consuming implementation of package. Changing this
+ * to a named export would leak it to consumers of palette which
+ * should be avoided.
+ */
+export default tokens;
+
+type ThemeProps = typeof tokens;
 
 /** All available px spacing maps */
 export type SpacingUnit = keyof ThemeProps["space"];

--- a/packages/palette-tokens/src/text.ts
+++ b/packages/palette-tokens/src/text.ts
@@ -1,0 +1,173 @@
+/**
+ * font-families
+ */
+export const TEXT_FONTS = {
+  sans: '"ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif',
+  serif: '"adobe-garamond-pro", "Times New Roman", Times, serif',
+};
+
+/**
+ * font-size scale
+ */
+export const TEXT_FONT_SIZES = {
+  size12: "62px",
+  size11: "55px",
+  size10: "48px",
+  size9: "32px",
+  size8: "28px",
+  size7: "24px",
+  size6: "18px",
+  size5: "16px",
+  size4: "15px",
+  size3: "14px",
+  size2: "13px",
+  size1: "12px",
+};
+
+/**
+ * Available font-sizes
+ */
+export type TextFontSize = keyof typeof TEXT_FONT_SIZES;
+
+/**
+ * line-height scale
+ */
+export const TEXT_LINE_HEIGHTS = {
+  solid: 1,
+  title: 1.25,
+  body: 1.5,
+};
+
+/**
+ * Available line-heights
+ */
+export type TextLineHeight = keyof typeof TEXT_LINE_HEIGHTS;
+
+/**
+ * letter-spacing scale
+ */
+export const TEXT_LETTER_SPACING = {
+  tight: "-0.02em",
+  tightest: "-0.03em",
+};
+
+/**
+ * Available letter-spacings
+ */
+export type TextLetterSpacing = keyof typeof TEXT_LETTER_SPACING;
+
+export interface TextTreatment {
+  fontSize: TextFontSize;
+  lineHeight: TextLineHeight;
+  letterSpacing?: TextLetterSpacing;
+  fontWeight?: "normal" | "bold";
+}
+
+/**
+ * Names of typographic treatments
+ */
+export const TEXT_TREATMENTS = [
+  "largeTitle",
+  "title",
+  "subtitle",
+  "text",
+  "mediumText",
+  "caption",
+  "small",
+] as const;
+
+/**
+ * TextTreatments
+ */
+export type TextTreatments = {
+  [K in typeof TEXT_TREATMENTS[number]]: TextTreatment
+};
+
+/**
+ * Available typographic treatments
+ */
+export const TEXT_VARIANTS: { [key: string]: TextTreatments } = {
+  large: {
+    largeTitle: {
+      fontSize: "size9",
+      lineHeight: "title",
+      letterSpacing: "tight",
+      fontWeight: "normal",
+    },
+    title: {
+      fontSize: "size7",
+      lineHeight: "title",
+      letterSpacing: "tight",
+      fontWeight: "normal",
+    },
+    subtitle: {
+      fontSize: "size6",
+      lineHeight: "title",
+      fontWeight: "normal",
+    },
+    text: {
+      fontSize: "size3",
+      lineHeight: "body",
+      fontWeight: "normal",
+    },
+    mediumText: {
+      fontSize: "size3",
+      lineHeight: "body",
+      fontWeight: "bold",
+    },
+    caption: {
+      fontSize: "size2",
+      lineHeight: "body",
+      fontWeight: "normal",
+    },
+    small: {
+      fontSize: "size1",
+      lineHeight: "body",
+      fontWeight: "normal",
+    },
+  },
+  small: {
+    largeTitle: {
+      fontSize: "size8",
+      lineHeight: "title",
+      letterSpacing: "tight",
+      fontWeight: "normal",
+    },
+    title: {
+      fontSize: "size6",
+      lineHeight: "title",
+      letterSpacing: "tight",
+      fontWeight: "normal",
+    },
+    subtitle: {
+      fontSize: "size5",
+      lineHeight: "title",
+      fontWeight: "normal",
+    },
+    text: {
+      fontSize: "size4",
+      lineHeight: "body",
+      fontWeight: "normal",
+    },
+    mediumText: {
+      fontSize: "size4",
+      lineHeight: "body",
+      fontWeight: "bold",
+    },
+    caption: {
+      fontSize: "size3",
+      lineHeight: "body",
+      fontWeight: "normal",
+    },
+    small: {
+      fontSize: "size2",
+      lineHeight: "body",
+      fontWeight: "normal",
+    },
+  },
+};
+
+/**
+ * Name of typographic treatment
+ */
+export type TextVariant = keyof TextTreatments;

--- a/packages/palette-tokens/tsconfig.json
+++ b/packages/palette-tokens/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "jsx": "react",
+    "lib": ["dom", "es2015", "es2016", "es2017"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "target": "es2015"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules/*", "dist/*"]
+}


### PR DESCRIPTION
It was decided in https://github.com/artsy/README/issues/318 to pull all react native specific components out of palette and into eigen. There was a note in the RFC that sharing tokens would be good, but that ended up not getting implemented. There was recent confusion about some specific spacing sizes missing in eigen that had been recently added to palette. That re-raised the need to share tokens. 

Check out the [slack thread](https://artsy.slack.com/archives/C02BAQ5K7/p1605638079020600) for more details. 

Essentially, this pulls out our design tokens and theme config into a separate package. It'll be followed up w/ a PR to migrate palette to begin consuming this. The last step will be to upgrade eigen to also consume it. 

I've switched lerna over to indpendent versioning mode so that the token package isn't updated every time we make a change to palette web. I also made an active effort to minimized/eliminate any dependencies in the tokens package so some things (like the `Theme` wrapper component) will need to be implemented upstream via palette web or palette native (or however we refer to it). 