### PR TITLE
feat: implements base tabs

### DIFF
--- a/packages/palette/src/elements/BaseTabs/BaseTab.story.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTab.story.tsx
@@ -1,0 +1,182 @@
+import { action } from "@storybook/addon-actions"
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { BaseTab, BaseTabs } from "."
+import { ChevronIcon } from "../../svgs"
+import { Box } from "../Box"
+import { Clickable } from "../Clickable"
+
+// Fake `RouterLink`
+const RouterLink: React.FC<{ to: string }> = ({ to, children, ...rest }) => {
+  return (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  )
+}
+
+storiesOf("Components/BaseTabs", module)
+  .add("Default", () => {
+    return (
+      <BaseTabs m={3}>
+        <BaseTab>First</BaseTab>
+        <BaseTab>Second</BaseTab>
+        <BaseTab active>Active</BaseTab>
+        <BaseTab>Last</BaseTab>
+      </BaseTabs>
+    )
+  })
+  .add('as="a"', () => {
+    return (
+      <BaseTabs m={3}>
+        <BaseTab as="a" href="#overview">
+          Overview
+        </BaseTab>
+
+        <BaseTab as="a" href="#cv">
+          CV
+        </BaseTab>
+
+        <BaseTab as="a" href="#shows" active>
+          Shows
+        </BaseTab>
+
+        <BaseTab as="a" href="#auction-results">
+          Auction Results
+        </BaseTab>
+
+        <BaseTab as="a" href="#articles">
+          Articles
+        </BaseTab>
+
+        <BaseTab as="a" href="#related-artists">
+          Related Artists
+        </BaseTab>
+      </BaseTabs>
+    )
+  })
+  .add("as={Clickable}", () => {
+    return (
+      <BaseTabs m={3}>
+        <BaseTab as={Clickable} onClick={action("onClick")}>
+          Overview
+        </BaseTab>
+
+        <BaseTab as={Clickable} onClick={action("onClick")}>
+          CV
+        </BaseTab>
+
+        <BaseTab as={Clickable} onClick={action("onClick")} active>
+          Shows
+        </BaseTab>
+
+        <BaseTab as={Clickable} onClick={action("onClick")}>
+          Auction Results
+        </BaseTab>
+
+        <BaseTab as={Clickable} onClick={action("onClick")}>
+          Articles
+        </BaseTab>
+
+        <BaseTab as={Clickable} onClick={action("onClick")}>
+          Related Artists
+        </BaseTab>
+      </BaseTabs>
+    )
+  })
+  .add("as={RouterLink}", () => {
+    return (
+      <BaseTabs m={3}>
+        <BaseTab as={RouterLink} to="#example" activeClassName="active" garbage>
+          Example
+        </BaseTab>
+      </BaseTabs>
+    )
+  })
+  .add("Overflowing", () => {
+    return (
+      <BaseTabs m={3}>
+        {[
+          "Artworks (580656)",
+          "Artists (8)",
+          "Collections (7)",
+          "Artist Series (13)",
+          "Galleries (4)",
+          "Shows (3667)",
+          "Categories (21)",
+          "Articles (656)",
+          "Auctions (23)",
+          "More (46)",
+        ].map((label, i) => {
+          return (
+            <BaseTab key={label} active={i === 1}>
+              {label}
+            </BaseTab>
+          )
+        })}
+      </BaseTabs>
+    )
+  })
+  .add("Fill", () => {
+    return (
+      <Box m={3}>
+        <BaseTabs fill my={3}>
+          <BaseTab as="a" href="#">
+            One
+          </BaseTab>
+        </BaseTabs>
+
+        <BaseTabs fill my={3}>
+          <BaseTab as="a" href="#">
+            One
+          </BaseTab>
+
+          <BaseTab as="a" href="#" active>
+            Two
+          </BaseTab>
+        </BaseTabs>
+
+        <BaseTabs fill my={3}>
+          <BaseTab as="a" href="#">
+            One
+          </BaseTab>
+
+          <BaseTab as="a" href="#" active>
+            Two
+          </BaseTab>
+
+          <BaseTab as="a" href="#">
+            Three
+          </BaseTab>
+        </BaseTabs>
+      </Box>
+    )
+  })
+  .add("Breaking out of container margin", () => {
+    return (
+      <Box m={3}>
+        <BaseTabs mx={-3} px={3}>
+          <BaseTab active>Example</BaseTab>
+        </BaseTabs>
+      </Box>
+    )
+  })
+  .add("Centered", () => {
+    return (
+      <BaseTabs m={3} justifyContent="center">
+        <BaseTab active>Alone</BaseTab>
+      </BaseTabs>
+    )
+  })
+  .add("with a separator", () => {
+    return (
+      <BaseTabs
+        m={3}
+        separator={<ChevronIcon mx={2} fill="black30" width="12px" />}
+      >
+        <BaseTab>Review</BaseTab>
+        <BaseTab>Confirm</BaseTab>
+        <BaseTab active>Pay</BaseTab>
+      </BaseTabs>
+    )
+  })

--- a/packages/palette/src/elements/BaseTabs/BaseTab.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTab.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import styled, { css } from "styled-components"
+import { color } from "../../helpers"
+import { Text, TextProps } from "../Text"
+
+/**
+ * Utilize as="a" or as={Component} to alter functionality
+ */
+export type BaseTabProps = TextProps & {
+  active?: boolean
+} & (// FIXME: Should be able to remove this typing once styled-components is updated
+  // Default:
+  | {}
+    // When displaying as an anchor tag, accept anchor props:
+    | ({ as: "a" } & (React.AnchorHTMLAttributes<HTMLAnchorElement>))
+    // Cop-out: if you pass as with a complex component, loosen up the types:
+    | ({ as: React.ReactElement<unknown> } & Record<string, unknown>))
+
+const BaseTabActiveMixin = css`
+  outline: 0;
+  color: ${color("black100")};
+  border-bottom-color: ${color("black100")} !important;
+`
+
+/**
+ * Extends `Text`. Should always be nested within a `BaseTabs` container.
+ *
+ * Use the `as` prop to alter behavior.
+ * E.g.: `<BaseTab as={RouterLink} to="/foo">Foo</BaseTab>`
+ * or `<BaseTab as={Clickable} onClick={handleClick}>Foo</BaseTab>`
+ */
+export const BaseTab = styled(Text)<BaseTabProps>`
+  display: block;
+  width: 100%;
+  position: relative;
+  text-decoration: none;
+  white-space: nowrap;
+  z-index: 1;
+  color: ${color("black60")};
+
+  ${({ active }) => active && BaseTabActiveMixin}
+  &:focus,
+  &.active {
+    ${BaseTabActiveMixin}
+  }
+
+  &:focus {
+    color: ${color("purple100")};
+  }
+`
+
+BaseTab.defaultProps = {
+  variant: "mediumText",
+  mb: "-1px",
+  pb: 1.5,
+  borderBottom: "2px solid",
+  borderColor: "transparent",
+}
+
+BaseTab.displayName = "BaseTab"

--- a/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
@@ -1,0 +1,137 @@
+import React, {
+  Children,
+  isValidElement,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import styled from "styled-components"
+import {
+  compose,
+  justifyContent,
+  JustifyContentProps,
+  padding,
+  PaddingProps,
+} from "styled-system"
+import { space } from "../../helpers"
+import { splitProps } from "../../utils/splitProps"
+import { Box, BoxProps } from "../Box"
+import { Join } from "../Join"
+
+const splitRailProps = splitProps<PaddingProps & JustifyContentProps>(
+  compose(
+    padding,
+    justifyContent
+  )
+)
+
+const Overlay = styled(Box)<{ atEnd: boolean }>`
+  position: relative;
+
+  /* Fade-out gradient */
+  &::after {
+    display: block;
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 2px;
+    width: ${space(6)}px;
+    z-index: 1;
+    pointer-events: none;
+    background: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 1) 100%
+    );
+
+    /* Hide when scrolled all the way over */
+    transition: opacity 250ms;
+    opacity: ${({ atEnd }) => (atEnd ? 0 : 1)};
+  }
+`
+
+const Viewport = styled(Box)`
+  overflow-x: auto;
+`
+
+const Rail = styled(Box)`
+  white-space: nowrap;
+  min-width: 100%;
+`
+
+/** Extends `Box` */
+export type BaseTabsProps = Omit<BoxProps, "children"> & {
+  /**
+   * Enable if tabs should fill the width of the container
+   * (as opposed to left-align)
+   */
+  fill?: boolean
+  separator?: JSX.Element
+  children: JSX.Element | JSX.Element[]
+}
+
+const DEFAULT_SEPARATOR = <Box mx={1} />
+
+/** Extends `Box`, provides configurable gutter */
+export const BaseTabs: React.FC<BaseTabsProps> = ({
+  fill,
+  separator = DEFAULT_SEPARATOR,
+  children,
+  ...rest
+}) => {
+  const ref = useRef<HTMLDivElement | null>()
+
+  const [paddingProps, boxProps] = splitRailProps(rest)
+
+  const [atEnd, setAtEnd] = useState(false)
+
+  const cells = useMemo(
+    () => Children.toArray(children).filter(isValidElement),
+    [children]
+  )
+
+  const handleScroll = () => {
+    if (!ref.current) return
+
+    const {
+      current: { scrollLeft, scrollWidth, clientWidth },
+    } = ref
+
+    if (scrollLeft + clientWidth === scrollWidth) {
+      setAtEnd(true)
+      return
+    }
+
+    setAtEnd(false)
+  }
+
+  return (
+    <Overlay atEnd={atEnd} {...boxProps}>
+      <Viewport ref={ref as any} onScroll={handleScroll}>
+        <Rail
+          display="inline-flex"
+          borderBottom="1px solid"
+          borderColor="black10"
+          verticalAlign="top"
+          {...paddingProps}
+        >
+          <Join separator={separator}>
+            {cells.map((child, i) => {
+              return (
+                <Box
+                  key={i}
+                  display="inline-flex"
+                  textAlign="center"
+                  flex={fill ? 1 : undefined}
+                >
+                  {child}
+                </Box>
+              )
+            })}
+          </Join>
+        </Rail>
+      </Viewport>
+    </Overlay>
+  )
+}

--- a/packages/palette/src/elements/BaseTabs/index.ts
+++ b/packages/palette/src/elements/BaseTabs/index.ts
@@ -1,0 +1,2 @@
+export * from "./BaseTab"
+export * from "./BaseTabs"

--- a/packages/palette/src/elements/Stepper/Stepper.story.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.story.tsx
@@ -1,0 +1,22 @@
+import { action } from "@storybook/addon-actions"
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Box } from "../Box"
+import { Step, Stepper } from "./"
+
+storiesOf("Components/Stepper", module).add("Stepper", () => {
+  return (
+    <Box m={3}>
+      <Stepper
+        onChange={action("onChange")}
+        initialTabIndex={2}
+        currentStepIndex={2}
+        disableNavigation={false}
+      >
+        <Step name="Review" />
+        <Step name="Confirm" />
+        <Step name="Pay" />
+      </Stepper>
+    </Box>
+  )
+})

--- a/packages/palette/src/elements/Tabs/Tabs.story.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.story.tsx
@@ -1,0 +1,44 @@
+import { action } from "@storybook/addon-actions"
+import { storiesOf } from "@storybook/react"
+import React from "react"
+import { Box } from "../Box"
+import { Tab, Tabs } from "./"
+
+storiesOf("Components/Tabs", module)
+  .add("Tabs", () => {
+    return (
+      <Box m={3}>
+        <Tabs onChange={action("onChange")}>
+          <Tab name="Overview">Overview panel</Tab>
+          <Tab name="CV">CV panel</Tab>
+        </Tabs>
+      </Box>
+    )
+  })
+  // Doesn't work?
+  .add("autoScroll", () => {
+    return (
+      <Box m={3}>
+        <Tabs onChange={action("onChange")}>
+          {[
+            "Artworks (580656)",
+            "Artists (8)",
+            "Collections (7)",
+            "Artist Series (13)",
+            "Galleries (4)",
+            "Shows (3667)",
+            "Categories (21)",
+            "Articles (656)",
+            "Auctions (23)",
+            "More (46)",
+          ].map(label => {
+            return (
+              <Tab key={label} name={label}>
+                {label} content
+              </Tab>
+            )
+          })}
+        </Tabs>
+      </Box>
+    )
+  })

--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -7,21 +7,21 @@ import { Join } from "../Join"
 import { Sans } from "../Typography"
 
 import { color, media } from "../../helpers"
+import { Text } from "../Text"
 
 export interface TabLike extends JSX.Element {
   props: TabProps
 }
 
 type TabNameType = string | JSX.Element
+
 export interface TabInfo {
   /** Display name of the newly selected Tab */
   name: TabNameType
-
   /** Index of the newly selected Tab */
   tabIndex: number
-
   /** Data associated with the newly selected Tab */
-  data: any
+  data: unknown
 }
 
 // tslint:disable-next-line:ban-types
@@ -30,25 +30,23 @@ type InnerRef<T> = Extract<Ref<T>, Function>
 export interface TabsProps extends WidthProps, JustifyContentProps {
   /** Function that will be called when a new Tab is selected */
   onChange?: (tabInfo?: TabInfo) => void
-
   /** Index of the Tab that should be pre-selected */
   initialTabIndex?: number
-
-  /** To be able to extend or modify the way tab buttons are getting rendered
+  /**
+   * To be able to extend or modify the way tab buttons are getting rendered
    * default value is an identity function
    */
   transformTabBtn?: (
     Button: JSX.Element,
     tabIndex?: number,
-    props?: any
+    props?: unknown
   ) => JSX.Element
-
   separator?: JSX.Element
-
-  // If the tabs do not fit on screen, should the list automatically scroll
-  // to keep the active tab in view
+  /**
+   * If the tabs do not fit on screen, should the list automatically scroll
+   * to keep the active tab in view.
+   */
   autoScroll?: boolean
-
   children: TabLike[]
 }
 
@@ -56,7 +54,7 @@ export interface TabsState {
   activeTabIndex: number
 }
 
-/** A tabbar navigation component */
+/** A tab bar navigation component */
 export class Tabs extends React.Component<TabsProps, TabsState> {
   public static defaultProps: Partial<TabsProps> = {
     justifyContent: "left",
@@ -156,7 +154,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
         >
           <Join separator={separator}>{children.map(this.renderTab)}</Join>
         </TabsContainer>
-        <Box pt={3}>{children[this.state.activeTabIndex]}</Box>
+        <Box pt={2}>{children[this.state.activeTabIndex]}</Box>
       </>
     )
   }
@@ -187,10 +185,9 @@ interface TabProps {
   name: TabNameType
   /**
    * Arbitrary data that can be associated with a Tab.
-   *
    * Will be passed to the parent <Tabs>'s onChange handler.
    */
-  data?: any
+  data?: unknown
 }
 
 /** An individual tab */
@@ -203,9 +200,9 @@ export class Tab extends React.Component<TabProps> {
 const TabButton = ({ children, ...props }) => {
   return (
     <TabContainer {...props}>
-      <Sans size="3t" weight="medium" color="black30">
+      <Text variant="mediumText" color="black60">
         {children}
-      </Sans>
+      </Text>
     </TabContainer>
   )
 }
@@ -213,9 +210,7 @@ const TabButton = ({ children, ...props }) => {
 const ActiveTabButton: React.SFC = ({ children }) => {
   return (
     <ActiveTabContainer>
-      <Sans size="3t" weight="medium">
-        {children}
-      </Sans>
+      <Text variant="mediumText">{children}</Text>
     </ActiveTabContainer>
   )
 }
@@ -231,7 +226,7 @@ export const sharedTabsStyles = {
     pointer-events: none;
     padding-bottom: 13px;
     white-space: nowrap;
-    border-bottom: 1px solid ${color("black60")};
+    border-bottom: 2px solid ${color("black100")};
   `,
 }
 

--- a/packages/palette/src/elements/index.tsx
+++ b/packages/palette/src/elements/index.tsx
@@ -1,6 +1,7 @@
 export * from "./Avatar"
 export * from "./Banner"
 export * from "./BarChart"
+export * from "./BaseTabs"
 export * from "./BorderBox"
 export * from "./Box"
 export * from "./Button"


### PR DESCRIPTION
This PR implements a new `BaseTabs` component which adheres to the most recent Figma specs — it's essentially just a display component for a tab list and set of tabs (not the tab panels). Which allows us to `as={RouterLink}` them as needed for the `RouterTabs` in Force, which are more common lately. To that end it also overflows and gives a little fade-out affordance for use in the search page so that we can get rid of the `TabCarousel` and that instance of Flickity.

![tabs](https://user-images.githubusercontent.com/112297/101819286-01682b00-3af3-11eb-9cba-86f95ff4116f.gif)

I'd like to utilize these `BaseTabs` to build out the client-side `Tabs` for consistency and a11y. Which should be straightforward enough. But before I do that I'd like to simplify the API a bit to drop functionality we're not using.

* `autoScroll` appears to be broken? I can try to glean the intention here and support this if desired. `OrderStepper` in Force looks to be the only component that is using this functionality.
  * Native `el.scrollIntoView` would be much simpler and should probably just be default on rather than a prop
* `transformTabBtn` appears to not be used anywhere, and I don't really understand why it would be used and what for.
* `Sup` appears to be not used and seems extraneous.

So I'd propose dropping those props and exports, cutting a major release and then updating the call-sites in Force and Volt.

I've also styled the existing tabs to update the typography, colors, and spacing to bring it inline with the spec.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.24.3-canary.821.14150.0
  # or 
  yarn add @artsy/palette@13.24.3-canary.821.14150.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
