### PR TITLE
chore(webfonts): update webfonts domain references

### DIFF
--- a/packages/palette-docs/content/docs/home/getting-started.mdx
+++ b/packages/palette-docs/content/docs/home/getting-started.mdx
@@ -70,7 +70,7 @@ import { HeadProvider, Link } from 'react-head';
 const App = () => (
   <HeadProvider>
     <Link
-      href="https://production-webfonts.artsy.net/all-webfonts.css"
+      href="https://webfonts.artsy.net/all-webfonts.css"
       rel="stylesheet"
       type="text/css"
     />
@@ -85,7 +85,7 @@ import {Helmet} from "react-helmet";
 
 <Helmet>
   <link
-    href="https://production-webfonts.artsy.net/all-webfonts.css"
+    href="https://webfonts.artsy.net/all-webfonts.css"
     rel="stylesheet"
     type="text/css"
   />
@@ -98,6 +98,6 @@ import {Helmet} from "react-helmet";
 import { createGlobalStyle } from "styled-components"
 
 const GlobalStyles = createGlobalStyle`
-  @import url("https://production-webfonts.artsy.net/all-webfonts.css");
+  @import url("https://webfonts.artsy.net/all-webfonts.css");
 `
 ```

--- a/packages/palette-docs/src/layouts/DefaultLayout.tsx
+++ b/packages/palette-docs/src/layouts/DefaultLayout.tsx
@@ -26,7 +26,7 @@ export default function DocsLayout(props) {
         <Helmet defaultTitle="Palette" titleTemplate="Palette | %s">
           <title>{name}</title>
           <link
-            href="https://production-webfonts.artsy.net/all-webfonts.css"
+            href="https://webfonts.artsy.net/all-webfonts.css"
             rel="stylesheet"
             type="text/css"
           />

--- a/packages/palette/.storybook/preview-head.html
+++ b/packages/palette/.storybook/preview-head.html
@@ -1,5 +1,5 @@
 <link
   rel="stylesheet"
   type="text/css"
-  href="https://production-webfonts.artsy.net/all-webfonts.css"
+  href="https://webfonts.artsy.net/all-webfonts.css"
 />


### PR DESCRIPTION
Re: [FX-2540](https://artsyproduct.atlassian.net/browse/FX-2540)

These were changed to `production-webfonts` during the transition. The bare `webfonts` subdomain now points to the same Cloudfront distro as `production-webfonts` and so this can be restored.