### PR TITLE
fix(basetabs): support nested fragments

### DIFF
--- a/packages/palette/src/elements/BaseTabs/BaseTab.story.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTab.story.tsx
@@ -180,3 +180,17 @@ storiesOf("Components/BaseTabs", module)
       </BaseTabs>
     )
   })
+  .add("nested children", () => {
+    return (
+      <BaseTabs m={3}>
+        <>
+          <BaseTab>First</BaseTab>
+          <BaseTab>Second</BaseTab>
+          <>
+            <BaseTab active>Active</BaseTab>
+            <BaseTab>Last</BaseTab>
+          </>
+        </>
+      </BaseTabs>
+    )
+  })

--- a/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Children,
-  isValidElement,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import React, { useMemo, useRef, useState } from "react"
 import styled from "styled-components"
 import {
   compose,
@@ -14,6 +8,7 @@ import {
   PaddingProps,
 } from "styled-system"
 import { space } from "../../helpers"
+import { flattenChildren } from "../../helpers/flattenChildren"
 import { splitProps } from "../../utils/splitProps"
 import { Box, BoxProps } from "../Box"
 import { Join } from "../Join"
@@ -86,10 +81,7 @@ export const BaseTabs: React.FC<BaseTabsProps> = ({
 
   const [atEnd, setAtEnd] = useState(false)
 
-  const cells = useMemo(
-    () => Children.toArray(children).filter(isValidElement),
-    [children]
-  )
+  const cells = useMemo(() => flattenChildren(children), [children])
 
   const handleScroll = () => {
     if (!ref.current) return

--- a/packages/palette/src/helpers/__tests__/flattenChildren.test.tsx
+++ b/packages/palette/src/helpers/__tests__/flattenChildren.test.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import { flattenChildren } from "../flattenChildren"
+
+describe("flattenChildren", () => {
+  it("flattens the children", () => {
+    const flattened = flattenChildren(
+      <>
+        <div>one</div>
+        <div>two</div>
+        <>
+          <div>three</div>
+          <>
+            <div>four</div>
+          </>
+        </>
+      </>
+    )
+
+    expect(flattened).toHaveLength(4)
+  })
+})

--- a/packages/palette/src/helpers/flattenChildren.ts
+++ b/packages/palette/src/helpers/flattenChildren.ts
@@ -1,0 +1,21 @@
+import React from "react"
+
+/**
+ * Convert a fragment or nested fragment into an array of elements
+ */
+export const flattenChildren = (
+  children: React.ReactNode
+): React.ReactElement[] => {
+  const xs = React.Children.toArray(children).filter(React.isValidElement)
+
+  return xs.reduce(
+    (acc, child: React.ReactElement) => {
+      if (child.type === React.Fragment) {
+        return acc.concat(flattenChildren(child.props.children))
+      }
+
+      return [...acc, child]
+    },
+    [] as React.ReactElement[]
+  )
+}


### PR DESCRIPTION
Previously if we were using a fragment within the tabs we'd get:
![](http://static.damonzucconi.com/_capture/mAaUc38yq16d.png)

This PR introduces a simple helper to flatten out the fragments:
![](http://static.damonzucconi.com/_capture/xVtsPvEZ0taj.png)