### PR TITLE
fix(swiper): inlines default margins to simplify setting alternatives

### DIFF
--- a/packages/palette/src/elements/Swiper/Swiper.story.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.story.tsx
@@ -200,3 +200,6 @@ storiesOf("Components/Swiper", module)
   .add("Navigate via props", () => {
     return <Navigation />
   })
+  .add("Overwriting default margins", () => {
+    return <Demo mt={6} ml={6} />
+  })

--- a/packages/palette/src/elements/Swiper/Swiper.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.tsx
@@ -36,11 +36,6 @@ const Container = styled(Box)`
   ${visuallyDisableScrollbar}
 `
 
-Container.defaultProps = {
-  mx: 0,
-  my: 0,
-}
-
 /** SwiperRailProps */
 export type SwiperRailProps = BoxProps
 
@@ -170,7 +165,7 @@ export const Swiper: React.FC<SwiperProps> = ({
   }, [onChange, index])
 
   return (
-    <Container ref={containerRef as any} {...rest}>
+    <Container ref={containerRef as any} mx={0} my={0} {...rest}>
       <Rail as="ul">
         {cells.map(({ child, ref }, i) => {
           const isLast = i === cells.length - 1


### PR DESCRIPTION
This change allows us to, for instance, use an `mt` value which will override the `my` default.

Re: https://github.com/styled-system/styled-system/issues/599