### PR TITLE
fix(skeleton): implements appropriate scaling for multiline texts

### DIFF
--- a/packages/palette/src/elements/Skeleton/Skeleton.story.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.story.tsx
@@ -35,6 +35,20 @@ storiesOf("Components/Skeleton", module)
         <SkeletonText variant="text" borderRadius={4} done>
           done
         </SkeletonText>
+
+        <SkeletonText my={2} maxWidth={300}>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsam ratione
+          impedit commodi quo, dolorem id animi ipsa voluptas eius cum suscipit
+          distinctio qui quae aliquam consequuntur officiis numquam iste
+          deleniti.
+        </SkeletonText>
+
+        <SkeletonText variant="largeTitle" my={2} maxWidth={300}>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsam ratione
+          impedit commodi quo, dolorem id animi ipsa voluptas eius cum suscipit
+          distinctio qui quae aliquam consequuntur officiis numquam iste
+          deleniti.
+        </SkeletonText>
       </Box>
     )
   })

--- a/packages/palette/src/elements/Skeleton/Skeleton.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.tsx
@@ -47,7 +47,7 @@ const SkeletonTextOverlay = styled(SkeletonBox)`
   top: 50%;
   left: 0;
   width: 100%;
-  height: 85%;
+  height: calc(100% - 0.25em);
   transform: translateY(-50%);
 `
 
@@ -60,7 +60,7 @@ export const SkeletonText: React.FC<SkeletonTextProps> = ({
   const [borderProps, notBorderProps] = splitBorderProps(rest)
 
   return (
-    <Text aria-busy={!done} {...notBorderProps}>
+    <Text aria-busy={!done} color="transparent" {...notBorderProps}>
       <Box
         as="span"
         display="inline-flex"


### PR DESCRIPTION
Previously, multi-line texts would have the underlaid text peek out, because the overlay was scaled using a percentage.

![](https://static.damonzucconi.com/_capture/k5udqLHwypA2.png)

Now it just tucks in the overlay a small amount, scaled to the current font size. The text is also transparent incase an edge peeks out around an aggressive border radius.

![](http://static.damonzucconi.com/_capture/66H9mR0LZ110.png)