### PR TITLE
Fix failing storybook tests by guarding getHref call

### DIFF
--- a/packages/palette/src/elements/Pagination/LargePagination.tsx
+++ b/packages/palette/src/elements/Pagination/LargePagination.tsx
@@ -143,7 +143,11 @@ const Page: React.FC<PageProps> = (props) => {
 
   const highlight = isCurrent ? "black5" : "white100"
 
-  const href = getHref(page)
+  let href = ""
+
+  if (page && typeof getHref !== "undefined") {
+    href = getHref(page)
+  }
 
   return (
     <Box bg={highlight} borderRadius={2}>


### PR DESCRIPTION
cc @jonallured 

I was trying to do some dependency updates and I noticed the UI tests were failing due to `getHref` being called when it wasn't defined. Looking over at the story it's not being passed in and was erroring out here. 

I used the same guard pattern here that existed in other places in this file. That said, something feels a little off. Should this `getHref` prop be required? If not, adding a default value to the deconstructed prop below would allow us to avoid propagating all those checks. 

https://github.com/artsy/palette/blob/64cd9a89860b3f983ab5dd04fd8190087dabd1e6/packages/palette/src/elements/Pagination/LargePagination.tsx#L44-L50

.e.g.

```diff
  const {
+   getHref = () => "",
    hasNextPage,
    onClick,
    onNext,
    pageCursors: { around, first, last, previous },
  } = props
```

Thoughts? I'm gonna merge this one to unblock me, but we can follow up tomorrow. 