### PR TITLE
fix: Populate pagination next/prev hrefs correctly

### DIFF
--- a/packages/palette/src/elements/Pagination/LargePagination.tsx
+++ b/packages/palette/src/elements/Pagination/LargePagination.tsx
@@ -72,7 +72,7 @@ export const LargePagination = (props: PaginationProps) => {
     )
   })
 
-  const nextPage = (previous?.page || -1) + 2
+  const nextPage = (previous?.page || 0) + 2
 
   const DotDotDot = () => {
     return (
@@ -167,7 +167,7 @@ const PrevButton: React.FC<PageButton> = (props) => {
 
   let href = ""
 
-  if (page && typeof getHref !== "undefined") {
+  if (enabled && page && typeof getHref !== "undefined") {
     href = getHref(page)
   }
 
@@ -193,7 +193,7 @@ const NextButton: React.FC<PageButton> = (props) => {
 
   let href = ""
 
-  if (page && typeof getHref !== "undefined") {
+  if (enabled && page && typeof getHref !== "undefined") {
     href = getHref(page)
   }
 

--- a/packages/palette/src/elements/Pagination/SmallPagination.tsx
+++ b/packages/palette/src/elements/Pagination/SmallPagination.tsx
@@ -27,7 +27,7 @@ export const SmallPagination: React.FC<PaginationProps> = (props) => {
     onNext(event)
   }
 
-  const nextPage = (previous?.page || -1) + 2
+  const nextPage = (previous?.page || 0) + 2
 
   return (
     <Flex flexDirection="row" height="40px" width="100%">
@@ -69,7 +69,7 @@ const PrevButton: React.FC<PageButton> = (props) => {
   const opacity = enabled ? 1 : 0.1
   let href = ""
 
-  if (page && typeof getHref !== "undefined") {
+  if (enabled && page && typeof getHref !== "undefined") {
     href = getHref(page)
   }
 
@@ -89,7 +89,7 @@ const NextButton: React.FC<PageButton> = (props) => {
   const opacity = enabled ? 1 : 0.1
   let href = ""
 
-  if (page && typeof getHref !== "undefined") {
+  if (enabled && page && typeof getHref !== "undefined") {
     href = getHref(page)
   }
 

--- a/packages/palette/src/elements/Pagination/__tests__/LargePagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/LargePagination.test.tsx
@@ -3,6 +3,16 @@ import React from "react"
 import { Theme } from "../../../Theme"
 import { LargePagination } from "../LargePagination"
 
+const mockGetHref = (page) => {
+  const baseUrl = "http://www.example.com"
+
+  if (page > 1) {
+    return `${baseUrl}?page=${page}`
+  } else {
+    return baseUrl
+  }
+}
+
 describe("LargePagination", () => {
   const first = { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false }
   const last = { page: 20, cursor: "Y3Vyc29yMw==", isCurrent: false }
@@ -49,6 +59,62 @@ describe("LargePagination", () => {
     const wrapper = mountWrapper({ getHref: () => "http://foo.com" })
     const html = wrapper.html()
     expect(html).toContain("http://foo.com")
+  })
+
+  describe("button hrefs", () => {
+    it("on page 1", () => {
+      const wrapper = mountWrapper({
+        getHref: mockGetHref,
+        hasNextPage: true,
+        pageCursors: {
+          ...pageCursors,
+          previous: undefined,
+        },
+      })
+
+      const prevButton = wrapper.find("PrevButton")
+      expect(prevButton.find("Link").prop("href")).toEqual("")
+
+      const nextButton = wrapper.find("NextButton")
+      expect(nextButton.find("Link").prop("href")).toMatch("page=2")
+    })
+
+    it("on page 2", () => {
+      const wrapper = mountWrapper({
+        getHref: mockGetHref,
+        hasNextPage: true,
+        pageCursors: {
+          ...pageCursors,
+          previous: { page: 1, cursor: "first==", isCurrent: false },
+        },
+      })
+
+      const prevButton = wrapper.find("PrevButton")
+      expect(prevButton.find("Link").prop("href")).toEqual(
+        "http://www.example.com"
+      )
+
+      const nextButton = wrapper.find("NextButton")
+      expect(nextButton.find("Link").prop("href")).toMatch("page=3")
+    })
+
+    it("on page 3", () => {
+      const wrapper = mountWrapper({
+        getHref: mockGetHref,
+        hasNextPage: false,
+        pageCursors: {
+          ...pageCursors,
+          previous: { page: 2, cursor: "second==", isCurrent: false },
+        },
+      })
+
+      const prevButton = wrapper.find("PrevButton")
+      expect(prevButton.find("Link").prop("href")).toMatch("page=2")
+
+      const nextButton = wrapper.find("NextButton")
+      expect(nextButton.prop("enabled")).toEqual(false)
+      expect(nextButton.find("Link").prop("href")).toEqual("")
+    })
   })
 
   describe("page numbers", () => {

--- a/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
@@ -4,6 +4,16 @@ import { Theme } from "../../../Theme"
 import { PageCursors } from "../LargePagination"
 import { SmallPagination } from "../SmallPagination"
 
+const mockGetHref = (page) => {
+  const baseUrl = "http://www.example.com"
+
+  if (page > 1) {
+    return `${baseUrl}?page=${page}`
+  } else {
+    return baseUrl
+  }
+}
+
 describe("SmallPagination", () => {
   const previous = { page: 1, cursor: "ABC123==", isCurrent: false }
   const first = { page: 1, cursor: "first==", isCurrent: false }
@@ -38,6 +48,62 @@ describe("SmallPagination", () => {
     const wrapper = mountWrapper({ getHref: () => "http://foo.com" })
     const html = wrapper.html()
     expect(html).toContain("http://foo.com")
+  })
+
+  describe("button hrefs", () => {
+    it("on page 1", () => {
+      const wrapper = mountWrapper({
+        getHref: mockGetHref,
+        hasNextPage: true,
+        pageCursors: {
+          ...pageCursors,
+          previous: undefined,
+        },
+      })
+
+      const prevButton = wrapper.find("PrevButton")
+      expect(prevButton.find("Link").prop("href")).toEqual("")
+
+      const nextButton = wrapper.find("NextButton")
+      expect(nextButton.find("Link").prop("href")).toMatch("page=2")
+    })
+
+    it("on page 2", () => {
+      const wrapper = mountWrapper({
+        getHref: mockGetHref,
+        hasNextPage: true,
+        pageCursors: {
+          ...pageCursors,
+          previous: { page: 1, cursor: "first==", isCurrent: false },
+        },
+      })
+
+      const prevButton = wrapper.find("PrevButton")
+      expect(prevButton.find("Link").prop("href")).toEqual(
+        "http://www.example.com"
+      )
+
+      const nextButton = wrapper.find("NextButton")
+      expect(nextButton.find("Link").prop("href")).toMatch("page=3")
+    })
+
+    it("on page 3", () => {
+      const wrapper = mountWrapper({
+        getHref: mockGetHref,
+        hasNextPage: false,
+        pageCursors: {
+          ...pageCursors,
+          previous: { page: 2, cursor: "second==", isCurrent: false },
+        },
+      })
+
+      const prevButton = wrapper.find("PrevButton")
+      expect(prevButton.find("Link").prop("href")).toMatch("page=2")
+
+      const nextButton = wrapper.find("NextButton")
+      expect(nextButton.prop("enabled")).toEqual(false)
+      expect(nextButton.find("Link").prop("href")).toEqual("")
+    })
   })
 
   describe("when there is only a previous page", () => {


### PR DESCRIPTION
After doing some QA on staging I noticed a bug I made when I wrote an untested bit of logic about determining the next page number. I got it right when the previous page existed but on the first page, this bit of logic would return `1` and cause the Next button's HREF to be incorrect. SIGH.

How many times must I re-learn that I need tests!!

So, this PR introduces a set of tests that verify both the Next and Prev button HREF values. It ensures that the first and last pages have the correct empty hrefs and that each step along the way has the right page param being set.

https://artsyproduct.atlassian.net/browse/GRO-146

/cc @artsy/grow-devs