### PR TITLE
feat(pagination): includes page number on next callback

### DIFF
--- a/packages/palette/src/elements/Pagination/LargePagination.tsx
+++ b/packages/palette/src/elements/Pagination/LargePagination.tsx
@@ -28,7 +28,7 @@ export interface PaginationProps {
   getHref?: (page: number) => string
   hasNextPage: boolean
   onClick?: (cursor: string, page: number, event: React.MouseEvent) => void
-  onNext?: (event: React.MouseEvent) => void
+  onNext?: (event: React.MouseEvent, page: number) => void
   pageCursors: PageCursors
   scrollTo?: string
 }
@@ -49,14 +49,14 @@ export const LargePagination = (props: PaginationProps) => {
     pageCursors: { around, first, last, previous },
   } = props
 
-  const handlePrevClick = (event) => {
+  const handlePrevClick = (event: React.MouseEvent) => {
     if (previous) {
       onClick(previous.cursor, previous.page, event)
     }
   }
 
-  const handleNextClick = (event) => {
-    onNext(event)
+  const handleNextClick = (event: React.MouseEvent) => {
+    onNext(event, nextPage)
   }
 
   const aroundPages = around.map((pageCursor) => {

--- a/packages/palette/src/elements/Pagination/Pagination.story.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.story.tsx
@@ -20,8 +20,14 @@ storiesOf("Components/Pagination", module)
           ],
           previous: { page: 5, cursor: "Y3Vyc29yMw==", isCurrent: false },
         }}
-        onClick={action("onClick")}
-        onNext={action("onNext")}
+        onClick={(cursor, page, event) => {
+          event.preventDefault()
+          action("onClick")(cursor, page, event)
+        }}
+        onNext={(event, ...rest) => {
+          event.preventDefault()
+          action("onNext")(event, ...rest)
+        }}
       />
     )
   })
@@ -40,8 +46,14 @@ storiesOf("Components/Pagination", module)
           ],
           previous: { page: 5, cursor: "Y3Vyc29yMw==", isCurrent: false },
         }}
-        onClick={action("onClick")}
-        onNext={action("onNext")}
+        onClick={(cursor, page, event) => {
+          event.preventDefault()
+          action("onClick")(cursor, page, event)
+        }}
+        onNext={(event, ...rest) => {
+          event.preventDefault()
+          action("onNext")(event, ...rest)
+        }}
       />
     )
   })

--- a/packages/palette/src/elements/Pagination/SmallPagination.tsx
+++ b/packages/palette/src/elements/Pagination/SmallPagination.tsx
@@ -17,14 +17,14 @@ export const SmallPagination: React.FC<PaginationProps> = (props) => {
     hasNextPage,
   } = props
 
-  const handlePrevClick = (event) => {
+  const handlePrevClick = (event: React.MouseEvent) => {
     if (previous) {
       onClick(previous.cursor, previous.page, event)
     }
   }
 
-  const handleNextClick = (event) => {
-    onNext(event)
+  const handleNextClick = (event: React.MouseEvent) => {
+    onNext(event, nextPage)
   }
 
   const nextPage = (previous?.page || 0) + 2

--- a/packages/palette/src/elements/Pagination/__tests__/LargePagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/LargePagination.test.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { Theme } from "../../../Theme"
 import { LargePagination } from "../LargePagination"
 
-const mockGetHref = (page) => {
+const mockGetHref = page => {
   const baseUrl = "http://www.example.com"
 
   if (page > 1) {
@@ -37,7 +37,7 @@ describe("LargePagination", () => {
     onClick: onClickMock,
     onNext: onNextMock,
     pageCursors,
-    getHref: (x) => x,
+    getHref: x => x,
   }
 
   const mountWrapper = (passedProps = {}) => {
@@ -129,10 +129,13 @@ describe("LargePagination", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
         const pages = ["6", "7", "8", "9"]
-        pages.forEach((page) => {
+        pages.forEach(page => {
           expect(html).toContain(`>${page}<`)
         })
-        wrapper.find("Link").first().simulate("click")
+        wrapper
+          .find("Link")
+          .first()
+          .simulate("click")
         expect(onClickMock).toHaveBeenCalled()
       })
     })
@@ -148,7 +151,7 @@ describe("LargePagination", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
         const pages = ["6", "7", "8", "9", "...", "20"]
-        pages.forEach((page) => {
+        pages.forEach(page => {
           expect(html).toContain(`>${page}<`)
         })
       })
@@ -165,7 +168,7 @@ describe("LargePagination", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
         const pages = ["1", "...", "6", "7", "8", "9"]
-        pages.forEach((page) => {
+        pages.forEach(page => {
           expect(html).toContain(`>${page}<`)
         })
       })
@@ -182,7 +185,7 @@ describe("LargePagination", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
         const pages = ["1", "...", "6", "7", "8", "9", "...", "20"]
-        pages.forEach((page) => {
+        pages.forEach(page => {
           expect(html).toContain(`>${page}<`)
         })
       })
@@ -198,14 +201,19 @@ describe("LargePagination", () => {
 
       it("renders the previous button and calls the onClick function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("PrevButton Link").simulate("click")
+        wrapper.find("PrevButton").simulate("click")
         expect(onClickMock).toHaveBeenCalled()
+        expect(onClickMock).toHaveBeenCalledWith(
+          "Y3Vyc29yMw==",
+          5,
+          expect.anything()
+        )
       })
 
       it("renders the next button as disabled and calls the onNext function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("NextButton Link").simulate("click")
-        expect(onNextMock).toHaveBeenCalled()
+        wrapper.find("NextButton").simulate("click")
+        expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 7)
       })
     })
 
@@ -217,14 +225,14 @@ describe("LargePagination", () => {
 
       it("renders the previous button as disabled and does not call the onClick function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("PrevButton Link").simulate("click")
+        wrapper.find("PrevButton").simulate("click")
         expect(onClickMock).not.toHaveBeenCalled()
       })
 
       it("renders the next button and calls the onNext function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("NextButton Link").simulate("click")
-        expect(onNextMock).toHaveBeenCalled()
+        wrapper.find("NextButton").simulate("click")
+        expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 2)
       })
     })
 
@@ -236,14 +244,18 @@ describe("LargePagination", () => {
 
       it("renders the previous button and calls the onClick function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("PrevButton Link").simulate("click")
-        expect(onClickMock).toHaveBeenCalled()
+        wrapper.find("PrevButton").simulate("click")
+        expect(onClickMock).toHaveBeenCalledWith(
+          "Y3Vyc29yMw==",
+          5,
+          expect.anything()
+        )
       })
 
       it("renders the next button and calls the onNext function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("NextButton Link").simulate("click")
-        expect(onNextMock).toHaveBeenCalled()
+        wrapper.find("NextButton").simulate("click")
+        expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 7)
       })
     })
   })

--- a/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
@@ -4,7 +4,7 @@ import { Theme } from "../../../Theme"
 import { PageCursors } from "../LargePagination"
 import { SmallPagination } from "../SmallPagination"
 
-const mockGetHref = (page) => {
+const mockGetHref = page => {
   const baseUrl = "http://www.example.com"
 
   if (page > 1) {
@@ -115,13 +115,13 @@ describe("SmallPagination", () => {
     it("renders the previous button and calls the onClick function when clicked", () => {
       const wrapper = mountWrapper()
       wrapper.find("PrevButton Link").simulate("click")
-      expect(onClickMock).toHaveBeenCalled()
+      expect(onClickMock).toHaveBeenCalledWith("ABC123==", 1, expect.anything())
     })
 
     it("renders the next button as disabled and calls the onNext function when clicked", () => {
       const wrapper = mountWrapper()
       wrapper.find("NextButton Link").simulate("click")
-      expect(onNextMock).toHaveBeenCalled()
+      expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 3)
     })
   })
 
@@ -140,7 +140,7 @@ describe("SmallPagination", () => {
     it("renders the next button and calls the onNext function when clicked", () => {
       const wrapper = mountWrapper()
       wrapper.find("NextButton Link").simulate("click")
-      expect(onNextMock).toHaveBeenCalled()
+      expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 2)
     })
   })
 
@@ -153,13 +153,13 @@ describe("SmallPagination", () => {
     it("renders the previous button and calls the onClick function when clicked", () => {
       const wrapper = mountWrapper()
       wrapper.find("PrevButton Link").simulate("click")
-      expect(onClickMock).toHaveBeenCalled()
+      expect(onClickMock).toHaveBeenCalledWith("ABC123==", 1, expect.anything())
     })
 
     it("renders the next button and calls the onNext function when clicked", () => {
       const wrapper = mountWrapper()
       wrapper.find("NextButton Link").simulate("click")
-      expect(onNextMock).toHaveBeenCalled()
+      expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 3)
     })
   })
 })


### PR DESCRIPTION
I'm having a lot of trouble actually using this component — this is the minimal change that allows me to use it. The main problem is how it encodes knowledge of cursors, but fixing that would result in a lot of breaking changes that would have to be dealt with in force. Thus: just appending the page number into the onNext callback args.

Publishing a canary incase there are any type issues; though there shouldn't be.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.27.3-canary.840.14569.0
  # or 
  yarn add @artsy/palette@13.27.3-canary.840.14569.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
