### PR TITLE
feat: Add chevronSize prop to Toggle component

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/Toggle.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Toggle.mdx
@@ -35,6 +35,17 @@ name: Toggle
   </Toggle>
 </Playground>
 
+<Playground title="ChevronSize">
+  <Toggle label="Larger Chevron Size" expanded chevronSize={18}>
+    <Sans size="3">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat.
+    </Sans>
+  </Toggle>
+</Playground>
+
 <Playground title="Artwork filter">
   <>
     <Toggle label="Purchase type" expanded disabled>

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -8,6 +8,7 @@ import { Separator } from "../Separator"
 import { Sans } from "../Typography"
 
 export interface ToggleProps {
+  chevronSize?: number
   disabled?: boolean
   expanded?: boolean
   label?: string
@@ -30,6 +31,7 @@ export interface ToggleState {
 export class Toggle extends React.Component<ToggleProps> {
   static defaultProps = {
     textSize: "2",
+    chevronSize: 12
   }
 
   state = {
@@ -55,7 +57,7 @@ export class Toggle extends React.Component<ToggleProps> {
 
   render() {
     const { disabled, expanded } = this.state
-    const { children, label, textSize, renderSecondaryAction } = this.props
+    const { children, chevronSize, label, textSize, renderSecondaryAction } = this.props
 
     return (
       <Flex width="100%" flexDirection="column" pb={2}>
@@ -76,8 +78,8 @@ export class Toggle extends React.Component<ToggleProps> {
               <ChevronIcon
                 style={{ visibility: disabled ? "hidden" : "visible" }}
                 direction={expanded ? "up" : "down"}
-                width={12}
-                height={12}
+                width={chevronSize}
+                height={chevronSize}
                 ml={1}
               />
             </Flex>

--- a/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
+import { ChevronIcon } from "../../../svgs"
 import { Toggle } from "../Toggle"
 
 describe("Toggle", () => {
@@ -34,5 +35,16 @@ describe("Toggle", () => {
     expect(wrapper.html()).toContain("tab content")
     header.simulate("click")
     expect(wrapper.html()).toContain("tab content")
+  })
+
+  it("defaults chevron size to 12px", () => {
+    const wrapper = mount(
+      <Toggle>
+        tab content
+      </Toggle>
+    )
+    const chevron = wrapper.find(ChevronIcon)
+    expect(chevron.props().width).toEqual(12)
+    expect(chevron.props().height).toEqual(12)
   })
 })


### PR DESCRIPTION
Added optional `chevronSize` prop (`number`) to `Toggle` component that defaults to `12`.  

I had also considered a less flexible prop in the form a string that allows for "big" or "small" to limit the options for size, but I think providing the flexibility is probably better?

<img width="904" alt="Screen Shot 2021-02-03 at 2 28 59 PM" src="https://user-images.githubusercontent.com/9466631/106811871-2fb64280-662c-11eb-8fa0-b5bc91ec1be7.png">
