### PR TITLE
feat: Add ability to pass in a component into Toggle label prop

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/Toggle.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Toggle.mdx
@@ -46,6 +46,19 @@ name: Toggle
   </Toggle>
 </Playground>
 
+<Playground title="Label">
+  <Toggle label={
+    <div>Passing a component as the label</div>
+  }>
+    <Sans size="3">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat.
+    </Sans>
+  </Toggle>
+</Playground>
+
 <Playground title="Artwork filter">
   <>
     <Toggle label="Purchase type" expanded disabled>

--- a/packages/palette-docs/package.json
+++ b/packages/palette-docs/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "artsy-palette-docs",
   "description": "Artsy's design system",
-  "version": "13.30.0",
+  "version": "13.31.0",
   "scripts": {
     "build": "gatsby build",
     "clean": "rm -rf .cache && yarn start",
@@ -70,7 +70,7 @@
     "webpack-shell-plugin": "0.5.0"
   },
   "dependencies": {
-    "@artsy/palette": "^13.30.0",
+    "@artsy/palette": "^13.31.0",
     "@babel/core": "^7.2.2",
     "@mdx-js/mdx": "^0.20.0",
     "@mdx-js/tag": "^0.20.0",

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/palette",
-  "version": "13.30.0",
+  "version": "13.31.0",
   "description": "Design system library for react components",
   "main": "dist/index.js",
   "publishConfig": {

--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -18,13 +18,6 @@ const SecondaryAction = () => {
   )
 }
 
-const labelComponent = (
-  <>
-    <Text variant="mediumText">Heading</Text>
-    <Text variant="text">Subheading</Text>
-  </>
-)
-
 storiesOf("Components/Toggle", module)
   .add("Toggle", () => {
     return (
@@ -71,7 +64,12 @@ storiesOf("Components/Toggle", module)
     return (
       <Box width="350px">
         <Toggle
-          label={labelComponent}
+          label={
+            <>
+              <Text variant="mediumText">Heading</Text>
+              <Text variant="text">Subheading</Text>
+            </>
+          }
           expanded
         >
           <h1>Hello world</h1>

--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -2,12 +2,13 @@ import { storiesOf } from "@storybook/react"
 import React from "react"
 import { Box } from "../Box"
 import { Link } from "../Link"
+import { Text } from "../Text"
 import { Toggle } from "./Toggle"
 
 const SecondaryAction = () => {
   return (
     <Link
-      onClick={e => {
+      onClick={(e) => {
         alert("hello world!")
         e.stopPropagation()
       }}
@@ -16,6 +17,13 @@ const SecondaryAction = () => {
     </Link>
   )
 }
+
+const labelComponent = (
+  <>
+    <Text variant="mediumText">Heading</Text>
+    <Text variant="text">Subheading</Text>
+  </>
+)
 
 storiesOf("Components/Toggle", module)
   .add("Toggle", () => {
@@ -53,6 +61,18 @@ storiesOf("Components/Toggle", module)
           expanded
           disabled
           renderSecondaryAction={SecondaryAction}
+        >
+          <h1>Hello world</h1>
+        </Toggle>
+      </Box>
+    )
+  })
+  .add("Toggle with a component as the label", () => {
+    return (
+      <Box width="350px">
+        <Toggle
+          label={labelComponent}
+          expanded
         >
           <h1>Hello world</h1>
         </Toggle>

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -11,7 +11,7 @@ export interface ToggleProps {
   chevronSize?: number
   disabled?: boolean
   expanded?: boolean
-  label?: string
+  label?: string | JSX.Element
   textSize?: SansSize
   /**
    * Adds the ability to render a set of components by the chevron for
@@ -31,7 +31,7 @@ export interface ToggleState {
 export class Toggle extends React.Component<ToggleProps> {
   static defaultProps = {
     textSize: "2",
-    chevronSize: 12
+    chevronSize: 12,
   }
 
   state = {
@@ -57,21 +57,34 @@ export class Toggle extends React.Component<ToggleProps> {
 
   render() {
     const { disabled, expanded } = this.state
-    const { children, chevronSize, label, textSize, renderSecondaryAction } = this.props
+    const {
+      children,
+      chevronSize,
+      label,
+      textSize,
+      renderSecondaryAction,
+    } = this.props
+
+    const labelComponent =
+      typeof label === "string" ? (
+        <Sans
+          size={textSize as SansSize}
+          weight="medium"
+          color="black100"
+          my={0.5}
+        >
+          {label}
+        </Sans>
+      ) : (
+        label
+      )
 
     return (
       <Flex width="100%" flexDirection="column" pb={2}>
         <Separator mb={2} />
         <Header onClick={this.toggleExpand} disabled={disabled}>
           <Flex justifyContent="space-between" alignItems="center">
-            <Sans
-              size={textSize as SansSize}
-              weight="medium"
-              color="black100"
-              my={0.5}
-            >
-              {label}
-            </Sans>
+            {labelComponent}
             <Flex justifyContent="right" alignItems="center">
               {renderSecondaryAction &&
                 renderSecondaryAction({ disabled, expanded, textSize })}
@@ -97,7 +110,7 @@ export class Toggle extends React.Component<ToggleProps> {
 
 const Header = styled.div<ToggleProps & SpaceProps>`
   cursor: pointer;
-  pointer-events: ${props => (props.disabled ? "none" : "auto")};
+  pointer-events: ${(props) => (props.disabled ? "none" : "auto")};
   user-select: none;
   ${space};
 `

--- a/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
@@ -1,6 +1,7 @@
 import { mount } from "enzyme"
 import React from "react"
 import { ChevronIcon } from "../../../svgs"
+import { Text } from "../../Text"
 import { Toggle } from "../Toggle"
 
 describe("Toggle", () => {
@@ -38,13 +39,21 @@ describe("Toggle", () => {
   })
 
   it("defaults chevron size to 12px", () => {
-    const wrapper = mount(
-      <Toggle>
-        tab content
-      </Toggle>
-    )
+    const wrapper = mount(<Toggle>tab content</Toggle>)
     const chevron = wrapper.find(ChevronIcon)
     expect(chevron.props().width).toEqual(12)
     expect(chevron.props().height).toEqual(12)
+  })
+
+  it("renders proper component when passed component as label", () => {
+    const component = <Text>Hello</Text>
+    const wrapper = mount(<Toggle label={component}>tab content</Toggle>)
+    expect(wrapper.find("Text")).toHaveLength(1)
+  })
+
+  it("renders Sans component when passed string as label", () => {
+    const wrapper = mount(<Toggle label="label">tab content</Toggle>)
+    expect(wrapper.find("Sans")).toHaveLength(1)
+    expect(wrapper.find("Sans").text()).toEqual("label")
   })
 })


### PR DESCRIPTION
Added option to pass a component instead of a string to the Toggle component.

What is the best way to test this out in the UI w/o bringing it into another app? Seems like the Playground is a bit limiting to make sure this looks how I want it to.

Storybook:
<img width="406" alt="Screen Shot 2021-02-11 at 2 35 12 PM" src="https://user-images.githubusercontent.com/9466631/107701638-674d6c00-6c76-11eb-978b-ce65982231f7.png">

Update to docs:
<img width="875" alt="Screen Shot 2021-02-11 at 11 26 29 AM" src="https://user-images.githubusercontent.com/9466631/107681311-1fb9e680-6c5c-11eb-8172-1e6cafb08913.png">
