### PR TITLE
fix(checkbox): makes a11y updates without using button

### DIFF
--- a/packages/palette/src/elements/Checkbox/Check.tsx
+++ b/packages/palette/src/elements/Checkbox/Check.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import styled, { css } from "styled-components"
+import { color, space } from "../../helpers"
+import { CheckIcon } from "../../svgs"
+import { Box } from "../Box"
+import { CheckboxProps } from "./Checkbox"
+
+const SIZE = 2 // 20px
+const BORDER_WIDTH = 2 // 2px
+
+const Container = styled(Box)<CheckProps>`
+  width: ${space(SIZE)}px;
+  height: ${space(SIZE)}px;
+  transition: background-color 0.25s, border-color 0.25s;
+
+  ${({ disabled, selected, error }) => {
+    switch (true) {
+      case disabled:
+        return css`
+          background-color: ${color("black5")};
+          border-color: ${color("black10")};
+        `
+      case selected:
+        return css`
+          background-color: ${color("black100")};
+          border-color: ${color("black100")};
+        `
+      case error:
+        return css`
+          background-color: ${color("white100")};
+          border-color: ${color("red100")};
+        `
+      default:
+        return css`
+          background-color: ${color("white100")};
+          border-color: ${color("black10")};
+        `
+    }
+  }}
+
+  svg {
+    position: relative;
+    top: -${BORDER_WIDTH}px;
+    left: -${BORDER_WIDTH}px;
+  }
+`
+
+export interface CheckProps
+  extends Pick<CheckboxProps, "disabled" | "selected" | "error"> {}
+
+/** Toggeable check mark */
+export const Check: React.FC<CheckProps> = ({
+  disabled,
+  selected,
+  ...rest
+}) => {
+  const iconColor = () => {
+    if (disabled && selected) return "black30"
+    if (disabled) return "black5"
+    return "white100"
+  }
+
+  return (
+    <Container
+      mr={1}
+      border={1}
+      disabled={disabled}
+      selected={selected}
+      {...rest}
+    >
+      <CheckIcon fill={iconColor()} />
+    </Container>
+  )
+}

--- a/packages/palette/src/elements/Checkbox/Check.tsx
+++ b/packages/palette/src/elements/Checkbox/Check.tsx
@@ -68,7 +68,7 @@ export const Check: React.FC<CheckProps> = ({
       selected={selected}
       {...rest}
     >
-      <CheckIcon fill={iconColor()} />
+      <CheckIcon aria-hidden fill={iconColor()} />
     </Container>
   )
 }

--- a/packages/palette/src/elements/Checkbox/Checkbox.story.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.story.tsx
@@ -1,5 +1,7 @@
 import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
 import { Text } from "../Text"
 import { Checkbox } from "./Checkbox"
 
@@ -8,7 +10,16 @@ export default {
 }
 
 export const States = () => {
-  const states = [{}, { selected: true }, { disabled: true }, { error: true }]
+  const states = [
+    {},
+    { selected: true },
+    { disabled: true },
+    { error: true },
+    { selected: true, disabled: true },
+    { error: true, disabled: true },
+    { selected: true, error: true, disabled: true },
+  ]
+
   return (
     <>
       {states.map((props, i) => {
@@ -32,7 +43,22 @@ export const Demo = () => {
         action("onClick")(selected)
       }}
     >
-      <Text>click me</Text>
+      <Text lineHeight="solid">
+        use a `solid` line-height to ensure vertical centering
+      </Text>
     </Checkbox>
+  )
+}
+
+export const Extended = () => {
+  return (
+    <Box width={300} border="1px solid" borderColor="black10" p={2}>
+      <Checkbox width="100%">
+        <Flex width="35%" justifyContent="space-between" alignItems="center">
+          <Text lineHeight="solid">Purple</Text>
+          <Box bg="purple100" width={20} height={20} borderRadius="50%" />
+        </Flex>
+      </Checkbox>
+    </Box>
   )
 }

--- a/packages/palette/src/elements/Checkbox/Checkbox.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.tsx
@@ -1,26 +1,11 @@
 import React from "react"
 import styled, { css } from "styled-components"
-import { color, space } from "../../helpers"
-import { Flex, FlexProps } from "../Flex"
+import { color } from "../../helpers"
+import { Clickable, ClickableProps } from "../Clickable"
+import { Flex } from "../Flex"
+import { Check } from "./Check"
 
-import { CheckIcon } from "../../svgs"
-
-import {
-  BorderProps,
-  borders,
-  SizeProps,
-  space as styledSpace,
-  SpaceProps,
-} from "styled-system"
-
-/**
- * Spec: zpl.io/bAvnwlB
- */
-
-const SIZE = 2
-const BORDER_WIDTH = 2
-
-export interface CheckboxProps {
+export interface CheckboxProps extends Omit<ClickableProps, "onSelect"> {
   /** Disable checkbox interactions */
   disabled?: boolean
   /** Select the checkbox on render */
@@ -33,144 +18,84 @@ export interface CheckboxProps {
   onSelect?: (selected: boolean) => void
 }
 
-export interface CheckboxToggleProps
-  extends CheckboxProps,
-    BorderProps,
-    SizeProps,
-    SpaceProps {}
-
-/**
- * A checkbox
- */
-export class Checkbox extends React.Component<CheckboxProps> {
-  labelColor = () => {
-    const { disabled, error } = this.props
-    if (disabled) return { color: color("black10") }
-    if (error) return { color: color("red100") }
-  }
-
-  iconColor = () => {
-    const { disabled, selected } = this.props
-    if (disabled && selected) return "black30"
-    if (disabled) return "black5"
-    return "white100"
-  }
-
-  render() {
-    const {
-      selected,
-      children,
-      error,
-      disabled,
-      hover,
-      onSelect,
-      ...other
-    } = this.props
-
-    return (
-      <Container
-        className={hover && "hover"}
-        my={0.5}
-        onClick={() => !disabled && onSelect && onSelect(!selected)}
-        selected={selected}
-        hover={hover}
-        disabled={disabled}
-        alignItems="center"
-        {...other}
-      >
-        <CheckboxButton
-          border={1}
-          mr={1}
-          selected={selected}
-          error={error}
-          disabled={disabled}
-        >
-          <CheckIcon fill={this.iconColor()} />
-        </CheckboxButton>
-        <Label style={this.labelColor()}>{children}</Label>
-      </Container>
-    )
-  }
-}
-
-interface CheckboxFeedbackState {
-  disabled?: boolean
-  selected?: boolean
-  error?: boolean
-}
-
-const checkBorderColor = ({
-  disabled,
+/** A checkbox */
+export const Checkbox: React.FC<CheckboxProps> = ({
+  className,
   selected,
+  children,
   error,
-}: CheckboxFeedbackState) => {
-  if (disabled) return color("black10")
-  if (selected) return color("black100")
-  if (error) return color("red100")
-  return color("black10")
-}
-
-const checkBackgroundColor = ({
   disabled,
-  selected,
-}: CheckboxFeedbackState) => {
-  switch (true) {
-    case disabled:
-      return color("black5")
-    case selected:
-      return color("black100")
-    default:
-      return color("white100")
+  hover,
+  onSelect,
+  onClick,
+  ...rest
+}) => {
+  const labelColor = () => {
+    if (disabled) return "black10"
+    if (error) return "red100"
   }
+
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    if (!disabled && onSelect !== undefined) {
+      onSelect(!selected)
+    }
+
+    if (onClick !== undefined) {
+      onClick(event)
+    }
+  }
+
+  return (
+    <Container
+      className={hover && "hover"}
+      my={0.5}
+      display="flex"
+      alignItems="center"
+      selected={selected}
+      hover={hover}
+      disabled={disabled}
+      error={error}
+      onClick={handleClick}
+      role="checkbox"
+      aria-checked={selected}
+      {...rest}
+    >
+      <Check selected={selected} error={error} disabled={disabled} />
+
+      <Flex color={labelColor()} alignItems="center" flex={1}>
+        {children}
+      </Flex>
+    </Container>
+  )
 }
 
-const CheckboxButton = styled.div<CheckboxToggleProps>`
-  ${borders};
-  ${styledSpace};
-  background-color: ${checkBackgroundColor};
-  border-color: ${checkBorderColor};
-  width: ${space(SIZE)}px;
-  height: ${space(SIZE)}px;
-  transition: background-color 0.25s, border-color 0.25s;
-
-  svg {
-    position: relative;
-    top: -${BORDER_WIDTH}px;
-    left: -${BORDER_WIDTH}px;
-  }
-`
-
-const Label = styled.div``
-
-const hoverStyles = ({ selected, hover, disabled }) => {
-  const styles = `
-    background-color: ${color("black10")};
-    border-color: ${color("black10")};
-  `
-  if (hover && !selected && !disabled) {
-    return css`
-      ${CheckboxButton} {
-        ${styles};
-      }
-    `
-  }
-  if (!selected && !disabled) {
-    return css`
-      &:hover ${CheckboxButton} {
-        ${styles};
-      }
-    `
-  }
-}
-
-interface ContainerProps extends FlexProps {
-  selected: boolean
-  hover: boolean
-  disabled: boolean
-}
-const Container = styled(Flex)<ContainerProps>`
+const Container = styled(Clickable)<
+  Pick<CheckboxProps, "selected" | "error" | "hover" | "disabled">
+>`
   user-select: none;
-  cursor: ${({ disabled }) => !disabled && "pointer"};
   transition: color 0.25s;
-  ${hoverStyles};
+
+  ${({ selected, disabled, error, hover }) => {
+    if (selected || disabled || error) return
+
+    const hoverMixin = css`
+      /* Targets just the Check */
+      > div:first-of-type {
+        background-color: ${color("black10")};
+        border-color: ${color("black10")};
+      }
+    `
+
+    if (hover) {
+      return hoverMixin
+    }
+
+    return css`
+      &:hover {
+        ${hoverMixin}
+      }
+    `
+  }}
 `

--- a/packages/palette/src/elements/Checkbox/Checkbox.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.tsx
@@ -1,11 +1,13 @@
 import React from "react"
 import styled, { css } from "styled-components"
 import { color } from "../../helpers"
-import { Clickable, ClickableProps } from "../Clickable"
+import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
 import { Check } from "./Check"
 
-export interface CheckboxProps extends Omit<ClickableProps, "onSelect"> {
+export interface CheckboxProps
+  extends BoxProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect"> {
   /** Disable checkbox interactions */
   disabled?: boolean
   /** Select the checkbox on render */
@@ -20,8 +22,7 @@ export interface CheckboxProps extends Omit<ClickableProps, "onSelect"> {
 
 /** A checkbox */
 export const Checkbox: React.FC<CheckboxProps> = ({
-  className,
-  selected,
+  selected = false,
   children,
   error,
   disabled,
@@ -35,10 +36,10 @@ export const Checkbox: React.FC<CheckboxProps> = ({
     if (error) return "red100"
   }
 
-  const handleClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
-    if (!disabled && onSelect !== undefined) {
+  const isSelectable = !disabled && onSelect !== undefined
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (isSelectable) {
       onSelect(!selected)
     }
 
@@ -47,9 +48,14 @@ export const Checkbox: React.FC<CheckboxProps> = ({
     }
   }
 
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.code === "Space" && isSelectable) {
+      onSelect(!selected)
+    }
+  }
+
   return (
     <Container
-      className={hover && "hover"}
       my={0.5}
       display="flex"
       alignItems="center"
@@ -58,6 +64,8 @@ export const Checkbox: React.FC<CheckboxProps> = ({
       disabled={disabled}
       error={error}
       onClick={handleClick}
+      tabIndex={0}
+      onKeyPress={handleKeyPress}
       role="checkbox"
       aria-checked={selected}
       {...rest}
@@ -71,7 +79,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   )
 }
 
-const Container = styled(Clickable)<
+const Container = styled(Box)<
   Pick<CheckboxProps, "selected" | "error" | "hover" | "disabled">
 >`
   user-select: none;
@@ -99,3 +107,5 @@ const Container = styled(Clickable)<
     `
   }}
 `
+
+Container.displayName = "Container"

--- a/packages/palette/src/elements/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/palette/src/elements/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,0 +1,41 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Checkbox } from "../index"
+
+describe("Checkbox", () => {
+  it("renders correctly", () => {
+    const wrapper1 = mount(<Checkbox onSelect={jest.fn()}>a label</Checkbox>)
+
+    expect(wrapper1.find("Container").prop("aria-checked")).toBe(false)
+
+    const wrapper2 = mount(
+      <Checkbox onSelect={jest.fn()} selected>
+        a label
+      </Checkbox>
+    )
+
+    expect(wrapper2.find("Container").prop("aria-checked")).toBe(true)
+  })
+
+  it("triggers onSelect on click", () => {
+    const handleSelect = jest.fn()
+    const wrapper = mount(<Checkbox onSelect={handleSelect}>a label</Checkbox>)
+
+    expect(handleSelect).not.toBeCalled()
+
+    wrapper.simulate("click")
+
+    expect(handleSelect).toBeCalledTimes(1)
+  })
+
+  it("triggers onSelect on spacebar keypress", () => {
+    const handleSelect = jest.fn()
+    const wrapper = mount(<Checkbox onSelect={handleSelect}>a label</Checkbox>)
+
+    expect(handleSelect).not.toBeCalled()
+
+    wrapper.simulate("keypress", { code: "Space" })
+
+    expect(handleSelect).toBeCalledTimes(1)
+  })
+})

--- a/packages/palette/src/elements/Clickable/Clickable.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.tsx
@@ -24,11 +24,11 @@ export const Clickable = styled.button<ClickableProps>`
   padding: 0;
   border: 0;
   background-color: transparent;
-  ${compose(
-    boxMixin,
-    cursor,
-    textDecoration
-  )}
+  ${compose(boxMixin, cursor, textDecoration)}
+
+  &:disabled {
+    cursor: default;
+  }
 `
 
 Clickable.defaultProps = {


### PR DESCRIPTION
Thanks for catching this. This PR reverts my revert. Then 5a4946ea8b6a34061c0fd32bad215dd5b2880425 changes it from a button back to a div, but handles the a11y changes manually.