### PR TITLE
Change default Clickable type; minor checkbox fix

### DIFF
--- a/packages/palette/src/elements/Checkbox/Checkbox.story.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.story.tsx
@@ -36,17 +36,19 @@ export const States = () => {
 export const Demo = () => {
   const [isSelected, setSelected] = useState(false)
   return (
-    <Checkbox
-      selected={isSelected}
-      onSelect={(selected) => {
-        setSelected(selected)
-        action("onClick")(selected)
-      }}
-    >
-      <Text lineHeight="solid">
-        use a `solid` line-height to ensure vertical centering
-      </Text>
-    </Checkbox>
+    <Box height="200vh">
+      <Checkbox
+        selected={isSelected}
+        onSelect={(selected) => {
+          setSelected(selected)
+          action("onClick")(selected)
+        }}
+      >
+        <Text lineHeight="solid">
+          use a `solid` line-height to ensure vertical centering
+        </Text>
+      </Checkbox>
+    </Box>
   )
 }
 

--- a/packages/palette/src/elements/Checkbox/Checkbox.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.tsx
@@ -49,7 +49,8 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   }
 
   const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.code === "Space" && isSelectable) {
+    if (event.key === " " && isSelectable) {
+      event.preventDefault()
       onSelect(!selected)
     }
   }

--- a/packages/palette/src/elements/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/palette/src/elements/Checkbox/__tests__/Checkbox.test.tsx
@@ -34,7 +34,7 @@ describe("Checkbox", () => {
 
     expect(handleSelect).not.toBeCalled()
 
-    wrapper.simulate("keypress", { code: "Space" })
+    wrapper.simulate("keypress", { key: " " })
 
     expect(handleSelect).toBeCalledTimes(1)
   })

--- a/packages/palette/src/elements/Clickable/Clickable.story.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.story.tsx
@@ -1,6 +1,7 @@
 import { action } from "@storybook/addon-actions"
-import React from "react"
-import { Sans } from "../Typography"
+import React, { useState } from "react"
+import { Box } from "../Box"
+import { Text } from "../Text"
 import { Clickable } from "./Clickable"
 
 export default {
@@ -10,8 +11,41 @@ export default {
 export const Default = () => {
   return (
     <Clickable onClick={action("onClick")} p={3}>
-      <Sans size="4">Click</Sans>
-      <Sans size="1">or click</Sans>
+      <Text>Click</Text>
+      <Text variant="small">or click</Text>
     </Clickable>
   )
+}
+
+export const Submit = () => {
+  const [isSubmitted, setSubmitted] = useState(false)
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        setSubmitted(true)
+
+        setTimeout(() => {
+          setSubmitted(false)
+        }, 1000)
+      }}
+    >
+      <Text>submitted? {isSubmitted ? "yes" : "no"}</Text>
+
+      <Box mt={1}>
+        <Clickable border="1px solid" p={2} type="button" mr={1}>
+          type="button"
+        </Clickable>
+
+        <Clickable border="1px solid" p={2} type="submit">
+          type="submit"
+        </Clickable>
+      </Box>
+    </form>
+  )
+}
+
+Submit.story = {
+  name: "Does not submit forms by default",
 }

--- a/packages/palette/src/elements/Clickable/Clickable.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.tsx
@@ -33,4 +33,5 @@ export const Clickable = styled.button<ClickableProps>`
 
 Clickable.defaultProps = {
   cursor: "pointer",
+  type: "button",
 }

--- a/packages/palette/src/elements/Swiper/Swiper.story.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.story.tsx
@@ -196,6 +196,7 @@ export const DynamicItems = () => {
 
 DynamicItems.story = {
   name: "Dynamic items",
+  parameters: { chromatic: { delay: 1000 } },
 }
 
 export const SwiperWithText = () => {


### PR DESCRIPTION
@pepopowitz good idea re: Clickable; for some reason I thought the default button type was `button` but it's actually `submit`

We've never used a Clickable as a submit button before in Force so this shouldn't have any effect/I don't feel like we need to cut a breaking change... but let me know if you think otherwise.

I can't capture this in a test because Enzyme doesn't support event propagation; so just a story for now.

Also: I forgot to prevent the default of spacebar which is to scroll the page. Publishing a canary to verify in force.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.33.2-canary.858.15065.0
  # or 
  yarn add @artsy/palette@13.33.2-canary.858.15065.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
