### PR TITLE
chore(storybook): rewrites some stories with storybook-states

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -101,6 +101,7 @@
     "regenerator-runtime": "0.13.5",
     "simple-progress-webpack-plugin": "1.1.2",
     "static-extend": "0.1.2",
+    "storybook-states": "^1.2.0",
     "styled-components": "4.3.2",
     "ts-node": "8.1.0",
     "tslint": "5.16.0",

--- a/packages/palette/src/elements/Avatar/Avatar.story.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.story.tsx
@@ -1,47 +1,31 @@
 import React from "react"
-import { Avatar } from "./Avatar"
-
-const imgURL = "https://randomuser.me/api/portraits/lego/2.jpg"
+import { States } from "storybook-states"
+import { Avatar, AvatarProps } from "./Avatar"
 
 export default {
   title: "Components/Avatar",
 }
 
-export const Xs = () => {
+export const Sizes = () => {
   return (
-    <>
-      <Avatar size="xs" src={imgURL} />
+    <States<AvatarProps>
+      states={[{ size: "xxs" }, { size: "xs" }, { size: "sm" }, { size: "md" }]}
+    >
       <Avatar size="xs" initials="TK" />
-    </>
+    </States>
   )
 }
 
-Xs.story = {
-  name: "xs",
-}
-
-export const Sm = () => {
+export const WithSrc = () => {
   return (
-    <>
-      <Avatar size="sm" src={imgURL} />
-      <Avatar size="sm" initials="TK" />
-    </>
+    <States<AvatarProps>
+      states={[{ size: "xxs" }, { size: "xs" }, { size: "sm" }, { size: "md" }]}
+    >
+      <Avatar size="xs" src="https://randomuser.me/api/portraits/lego/2.jpg" />
+    </States>
   )
 }
 
-Sm.story = {
-  name: "sm",
-}
-
-export const Md = () => {
-  return (
-    <>
-      <Avatar size="md" src={imgURL} />
-      <Avatar size="md" initials="TK" />
-    </>
-  )
-}
-
-Md.story = {
-  name: "md",
+WithSrc.story = {
+  name: "With `src`",
 }

--- a/packages/palette/src/elements/Button/Button.story.tsx
+++ b/packages/palette/src/elements/Button/Button.story.tsx
@@ -1,11 +1,104 @@
 import React, { useState } from "react"
+import { States } from "storybook-states"
 import { Box } from "../Box"
-import { Join } from "../Join"
-import { Spacer } from "../Spacer"
-import { Button, BUTTON_VARIANTS, ButtonSize } from "./index"
-import { ButtonVariant } from "./tokens"
+import { ButtonProps } from "./Button"
+import { Button, BUTTON_SIZES, BUTTON_VARIANTS } from "./index"
 
-const LoadingDemo = () => {
+export default { title: "Components/Button" }
+
+export const _States = () => {
+  return (
+    <States<ButtonProps>
+      states={[
+        {},
+        { loading: true },
+        { disabled: true },
+        { loading: true, disabled: true },
+        // TODO: { hover: true },
+        // TODO: { focus: true },
+      ]}
+    >
+      <Button>Label</Button>
+    </States>
+  )
+}
+
+_States.story = {
+  name: "States",
+}
+
+export const Sizes = () => {
+  return (
+    <States<ButtonProps>
+      states={(Object.keys(BUTTON_SIZES.block) as Array<
+        keyof typeof BUTTON_SIZES.block
+      >).map((size) => ({ size }))}
+    >
+      <Button>Label</Button>
+    </States>
+  )
+}
+
+export const Variants = () => {
+  return (
+    <States<ButtonProps>
+      states={(Object.keys(BUTTON_VARIANTS) as Array<
+        keyof typeof BUTTON_VARIANTS
+      >).map((variant) => ({ variant }))}
+    >
+      <Button>Label</Button>
+    </States>
+  )
+}
+
+export const NativeButtonProps = () => {
+  return (
+    <States<ButtonProps>
+      states={[
+        { autoFocus: true, children: "autofocused" },
+        { tabIndex: -1, children: "not focusable with keyboard" },
+        {
+          onClick: (event) => {
+            event.preventDefault()
+          },
+          children: "correctly typed click event",
+        },
+      ]}
+    >
+      <Button>Label</Button>
+    </States>
+  )
+}
+
+NativeButtonProps.story = {
+  name: "Native button tag props",
+}
+
+export const WithBoxProps = () => {
+  return (
+    <States>
+      <Box border="1px dotted" borderColor="black100">
+        <Button display="block" width="100%" my={2}>
+          full width
+        </Button>
+
+        <Button display="block" width="100%" my={2}>
+          with collapsing
+        </Button>
+
+        <Button display="block" width="100%" my={2}>
+          margins
+        </Button>
+      </Box>
+    </States>
+  )
+}
+
+WithBoxProps.story = {
+  name: "with BoxProps",
+}
+
+export const Loading = () => {
   const [loading, setLoading] = useState(false)
 
   const handleClick = () => {
@@ -16,151 +109,10 @@ const LoadingDemo = () => {
     }, 1000)
   }
   return (
-    <Button loading={loading} onClick={handleClick}>
-      click to load
-    </Button>
-  )
-}
-
-export default { title: "Components/Button" }
-
-export const Sizes = () => {
-  return (
-    <>
-      {(["small", "medium", "large"] as ButtonSize[]).map((size) => {
-        return (
-          <Box key={size} m={2} p={2} border="1px solid" borderColor="black10">
-            <Join separator={<Spacer my={1} />}>
-              {(Object.keys(BUTTON_VARIANTS) as ButtonVariant[]).map(
-                (variant) => {
-                  return (
-                    <Button key={variant} size={size} variant={variant}>
-                      {variant}
-                    </Button>
-                  )
-                }
-              )}
-            </Join>
-          </Box>
-        )
-      })}
-    </>
-  )
-}
-
-Sizes.story = {
-  name: "sizes",
-}
-
-export const Modes = () => {
-  return (
-    <>
-      {(["small", "medium", "large"] as ButtonSize[]).map((size) => {
-        return (
-          <Box key={size} m={2} p={2} border="1px solid" borderColor="black10">
-            {(Object.keys(BUTTON_VARIANTS) as ButtonVariant[]).map(
-              (variant) => {
-                return (
-                  <Box my={1} key={variant}>
-                    <Button variant={variant} size={size}>
-                      block (default)
-                    </Button>{" "}
-                    <Button variant={variant} size={size} inline>
-                      inline
-                    </Button>
-                  </Box>
-                )
-              }
-            )}
-          </Box>
-        )
-      })}
-    </>
-  )
-}
-
-Modes.story = {
-  name: "modes",
-}
-
-export const States = () => {
-  return (
-    <Box m={2} p={2} border="1px solid" borderColor="black10">
-      <Join separator={<Spacer my={1} />}>
-        <Button variant="secondaryOutline">resting</Button>
-
-        <Button variant="secondaryOutline" loading>
-          loading
-        </Button>
-
-        <Button variant="secondaryOutline" disabled>
-          disabled
-        </Button>
-
-        {/* TODO: hover, focus, active */}
-      </Join>
-    </Box>
-  )
-}
-
-States.story = {
-  name: "states",
-}
-
-export const NativeButtonProps = () => {
-  return (
-    <Box m={2} p={2} border="1px solid" borderColor="black10">
-      <Join separator={<Spacer my={1} />}>
-        <Button autoFocus>autofocused</Button>
-
-        <Button tabIndex={-1}>not focusable with keyboard</Button>
-
-        <Button
-          onClick={(event) => {
-            event.preventDefault()
-          }}
-        >
-          correctly typed click event
-        </Button>
-      </Join>
-    </Box>
-  )
-}
-
-NativeButtonProps.story = {
-  name: "native button props",
-}
-
-export const WithBoxProps = () => {
-  return (
-    <Box m={2} p={2} border="1px solid" borderColor="black10">
-      <Button display="block" width="100%" my={2}>
-        full width
+    <States>
+      <Button loading={loading} onClick={handleClick}>
+        click to load
       </Button>
-
-      <Button display="block" width="100%" my={2}>
-        with collapsing
-      </Button>
-
-      <Button display="block" width="100%" my={2}>
-        margins
-      </Button>
-    </Box>
+    </States>
   )
-}
-
-WithBoxProps.story = {
-  name: "with BoxProps",
-}
-
-export const Loading = () => {
-  return (
-    <Box m={2} p={2} border="1px solid" borderColor="black10">
-      <LoadingDemo />
-    </Box>
-  )
-}
-
-Loading.story = {
-  name: "loading",
 }

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -76,7 +76,7 @@ const Container = styled.button<ContainerProps>`
 
   ${variant({ variants: BUTTON_VARIANTS })};
 
-  ${props => {
+  ${(props) => {
     return variant({
       prop: "size",
       variants: BUTTON_SIZES[props.inline ? "inline" : "block"],

--- a/packages/palette/src/elements/Checkbox/Checkbox.story.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.story.tsx
@@ -1,5 +1,6 @@
 import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
+import { States } from "storybook-states"
 import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { Text } from "../Text"
@@ -9,34 +10,30 @@ export default {
   title: "Components/Checkbox",
 }
 
-export const States = () => {
-  const states = [
-    {},
-    { selected: true },
-    { disabled: true },
-    { error: true },
-    { selected: true, disabled: true },
-    { error: true, disabled: true },
-    { selected: true, error: true, disabled: true },
-  ]
-
+export const Default = () => {
   return (
-    <>
-      {states.map((props, i) => {
-        return (
-          <Checkbox key={i} {...props}>
-            <Text>a label ({JSON.stringify(props)})</Text>
-          </Checkbox>
-        )
-      })}
-    </>
+    <States
+      states={[
+        {},
+        { selected: true },
+        { disabled: true },
+        { error: true },
+        { selected: true, disabled: true },
+        { error: true, disabled: true },
+        { selected: true, error: true, disabled: true },
+      ]}
+    >
+      <Checkbox>
+        <Text>A label</Text>
+      </Checkbox>
+    </States>
   )
 }
 
 export const Demo = () => {
   const [isSelected, setSelected] = useState(false)
   return (
-    <Box height="200vh">
+    <States>
       <Checkbox
         selected={isSelected}
         onSelect={(selected) => {
@@ -48,19 +45,21 @@ export const Demo = () => {
           use a `solid` line-height to ensure vertical centering
         </Text>
       </Checkbox>
-    </Box>
+    </States>
   )
 }
 
 export const Extended = () => {
   return (
-    <Box width={300} border="1px solid" borderColor="black10" p={2}>
-      <Checkbox width="100%">
-        <Flex width="35%" justifyContent="space-between" alignItems="center">
-          <Text lineHeight="solid">Purple</Text>
-          <Box bg="purple100" width={20} height={20} borderRadius="50%" />
-        </Flex>
-      </Checkbox>
-    </Box>
+    <States>
+      <Box width={300}>
+        <Checkbox width="100%">
+          <Flex width="35%" justifyContent="space-between" alignItems="center">
+            <Text lineHeight="solid">Purple</Text>
+            <Box bg="purple100" width={20} height={20} borderRadius="50%" />
+          </Flex>
+        </Checkbox>
+      </Box>
+    </States>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20675,6 +20675,11 @@ store2@^2.7.1:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
+storybook-states@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/storybook-states/-/storybook-states-1.2.0.tgz#8c40aa6fc200d5e10e2ea08693968b96dd16e198"
+  integrity sha512-Kbsn7P/aCRIdX3V71woX0Q50NOKZ3519h5sM9cZd0grBGeIibCHRhjp6lMhFNjXI+xV7CNFHr/+5AFFh+TrvYw==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
This is a take it or leave it kind of thing — I find it useful in storybook to look at a story with all the (reasonably) possible states driven out simultaneously. [I packaged this component in a tiny lib](https://github.com/dzucconi/storybook-states), nothing fancy. Examples:

<img src="https://static.damonzucconi.com/_capture/NnGnOOu3.png" width="600" />

<img src="https://static.damonzucconi.com/_capture/ae2lJvYT.png" width="500" />

<img src="https://static.damonzucconi.com/_capture/zx51pu6z.gif" width="600" />

I'd refactor more stories where relevant if we are into this. 🤷 