### PR TITLE
fix(toggle): supports keyboard accessibility

### DIFF
--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { States } from "storybook-states"
-import { Box } from "../Box"
 import { Link } from "../Link"
 import { Text } from "../Text"
 import { Toggle, ToggleProps } from "./Toggle"
@@ -28,7 +27,8 @@ export const Default = () => {
       states={[
         {},
         { expanded: true },
-        { expanded: true, disabled: false },
+        { expanded: false, disabled: true },
+        { expanded: true, disabled: true },
         { renderSecondaryAction: SecondaryAction },
         { renderSecondaryAction: SecondaryAction, disabled: true },
         {
@@ -41,7 +41,7 @@ export const Default = () => {
         },
       ]}
     >
-      <Toggle label="Example">
+      <Toggle label="Example" maxWidth={350}>
         <Text>Expanded content</Text>
       </Toggle>
     </States>

--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -1,8 +1,9 @@
 import React from "react"
+import { States } from "storybook-states"
 import { Box } from "../Box"
 import { Link } from "../Link"
 import { Text } from "../Text"
-import { Toggle } from "./Toggle"
+import { Toggle, ToggleProps } from "./Toggle"
 
 const SecondaryAction = () => {
   return (
@@ -21,81 +22,28 @@ export default {
   title: "Components/Toggle",
 }
 
-export const _Toggle = () => {
+export const Default = () => {
   return (
-    <Box width="350px">
-      <Toggle label="Test" expanded>
-        <h1>Hello world</h1>
+    <States<ToggleProps>
+      states={[
+        {},
+        { expanded: true },
+        { expanded: true, disabled: false },
+        { renderSecondaryAction: SecondaryAction },
+        { renderSecondaryAction: SecondaryAction, disabled: true },
+        {
+          label: (
+            <>
+              <Text variant="mediumText">Heading</Text>
+              <Text variant="text">Subheading</Text>
+            </>
+          ),
+        },
+      ]}
+    >
+      <Toggle label="Example">
+        <Text>Expanded content</Text>
       </Toggle>
-    </Box>
+    </States>
   )
-}
-
-export const ToggleDisabled = () => {
-  return (
-    <Box width="350px">
-      <Toggle label="Test" expanded disabled>
-        <h1>Hello world</h1>
-      </Toggle>
-    </Box>
-  )
-}
-
-ToggleDisabled.story = {
-  name: "Toggle disabled",
-}
-
-export const ToggleWithSecondaryAction = () => {
-  return (
-    <Box width="350px">
-      <Toggle label="Test" expanded renderSecondaryAction={SecondaryAction}>
-        <h1>Hello world</h1>
-      </Toggle>
-    </Box>
-  )
-}
-
-ToggleWithSecondaryAction.story = {
-  name: "Toggle with secondary action",
-}
-
-export const ToggleDisabledWithSecondaryAction = () => {
-  return (
-    <Box width="350px">
-      <Toggle
-        label="Test"
-        expanded
-        disabled
-        renderSecondaryAction={SecondaryAction}
-      >
-        <h1>Hello world</h1>
-      </Toggle>
-    </Box>
-  )
-}
-
-ToggleDisabledWithSecondaryAction.story = {
-  name: "Toggle disabled with secondary action",
-}
-
-export const ToggleWithAComponentAsTheLabel = () => {
-  return (
-    <Box width="350px">
-      <Toggle
-        label={
-          <>
-            <Text variant="mediumText">Heading</Text>
-            <Text variant="text">Subheading</Text>
-          </>
-        }
-        expanded
-      >
-        <h1>Hello world</h1>
-      </Toggle>
-    </Box>
-  )
-}
-
-ToggleWithAComponentAsTheLabel.story = {
-  name: "Toggle with a component as the label",
 }

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from "react"
 import styled from "styled-components"
-import { space, SpaceProps } from "styled-system"
 import { ChevronIcon } from "../../svgs/ChevronIcon"
 import { SansSize } from "../../Theme"
-import { Flex } from "../Flex"
-import { Separator } from "../Separator"
+import { Clickable } from "../Clickable"
+import { Flex, FlexProps } from "../Flex"
 import { Sans } from "../Typography"
 
-export interface ToggleProps {
+export interface ToggleProps extends FlexProps {
   chevronSize?: number
   disabled?: boolean
   expanded?: boolean
@@ -36,6 +35,7 @@ export const Toggle: React.FC<ToggleProps> = ({
   disabled,
   children,
   renderSecondaryAction,
+  ...rest
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded)
 
@@ -46,9 +46,15 @@ export const Toggle: React.FC<ToggleProps> = ({
   }
 
   return (
-    <Flex width="100%" flexDirection="column" pb={2}>
-      <Separator mb={2} />
-      <Header onClick={toggleExpand} disabled={disabled}>
+    <Flex width="100%" flexDirection="column" pb={2} {...rest}>
+      <Header
+        onClick={toggleExpand}
+        disabled={disabled}
+        borderTop="1px solid"
+        borderColor="black10"
+        pt={2}
+        aria-expanded={expanded}
+      >
         <Flex justifyContent="space-between" alignItems="center">
           {typeof label === "string" ? (
             <Sans
@@ -73,6 +79,7 @@ export const Toggle: React.FC<ToggleProps> = ({
               width={chevronSize}
               height={chevronSize}
               ml={1}
+              aria-hidden="true"
             />
           </Flex>
         </Flex>
@@ -87,11 +94,9 @@ export const Toggle: React.FC<ToggleProps> = ({
   )
 }
 
-const Header = styled.div<ToggleProps & SpaceProps>`
-  cursor: pointer;
+const Header = styled(Clickable)`
   pointer-events: ${(props) => (props.disabled ? "none" : "auto")};
   user-select: none;
-  ${space};
 `
 
 Header.displayName = "Header"

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import styled from "styled-components"
 import { space, SpaceProps } from "styled-system"
 import { ChevronIcon } from "../../svgs/ChevronIcon"
@@ -28,84 +28,63 @@ export interface ToggleState {
 }
 
 /** A toggle component used to show / hide / expand content  */
-export class Toggle extends React.Component<ToggleProps> {
-  static defaultProps = {
-    textSize: "2",
-    chevronSize: 12,
-  }
+export const Toggle: React.FC<ToggleProps> = ({
+  label,
+  textSize = "2",
+  chevronSize = 12,
+  expanded: defaultExpanded,
+  disabled,
+  children,
+  renderSecondaryAction,
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded)
 
-  state = {
-    expanded: false,
-    disabled: false,
-  }
-
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      ...props,
+  const toggleExpand = () => {
+    if (!disabled) {
+      setExpanded((prevExpanded) => !prevExpanded)
     }
   }
 
-  toggleExpand = () => {
-    if (!this.props.disabled) {
-      this.setState({
-        expanded: !this.state.expanded,
-      })
-    }
-  }
+  return (
+    <Flex width="100%" flexDirection="column" pb={2}>
+      <Separator mb={2} />
+      <Header onClick={toggleExpand} disabled={disabled}>
+        <Flex justifyContent="space-between" alignItems="center">
+          {typeof label === "string" ? (
+            <Sans
+              size={textSize as SansSize}
+              weight="medium"
+              color="black100"
+              my={0.5}
+            >
+              {label}
+            </Sans>
+          ) : (
+            label
+          )}
 
-  render() {
-    const { disabled, expanded } = this.state
-    const {
-      children,
-      chevronSize,
-      label,
-      textSize,
-      renderSecondaryAction,
-    } = this.props
+          <Flex justifyContent="right" alignItems="center">
+            {renderSecondaryAction &&
+              renderSecondaryAction({ disabled, expanded, textSize })}
 
-    const labelComponent =
-      typeof label === "string" ? (
-        <Sans
-          size={textSize as SansSize}
-          weight="medium"
-          color="black100"
-          my={0.5}
-        >
-          {label}
-        </Sans>
-      ) : (
-        label
-      )
-
-    return (
-      <Flex width="100%" flexDirection="column" pb={2}>
-        <Separator mb={2} />
-        <Header onClick={this.toggleExpand} disabled={disabled}>
-          <Flex justifyContent="space-between" alignItems="center">
-            {labelComponent}
-            <Flex justifyContent="right" alignItems="center">
-              {renderSecondaryAction &&
-                renderSecondaryAction({ disabled, expanded, textSize })}
-              <ChevronIcon
-                style={{ visibility: disabled ? "hidden" : "visible" }}
-                direction={expanded ? "up" : "down"}
-                width={chevronSize}
-                height={chevronSize}
-                ml={1}
-              />
-            </Flex>
+            <ChevronIcon
+              style={{ visibility: disabled ? "hidden" : "visible" }}
+              direction={expanded ? "up" : "down"}
+              width={chevronSize}
+              height={chevronSize}
+              ml={1}
+            />
           </Flex>
-        </Header>
-        {expanded && children && (
-          <Flex flexDirection="column" alignItems="left">
-            {children}
-          </Flex>
-        )}
-      </Flex>
-    )
-  }
+        </Flex>
+      </Header>
+
+      {expanded && children && (
+        <Flex flexDirection="column" alignItems="left">
+          {children}
+        </Flex>
+      )}
+    </Flex>
+  )
 }
 
 const Header = styled.div<ToggleProps & SpaceProps>`


### PR DESCRIPTION
Trying to make filters fully keyboard accessible.

Not much to this:

* refactored the component from class => functional
* made the header a `Clickable`
* added aria-expanded tag

One thing I didn't handle with this PR is doing the appropriate labelledby/region markup. We need to be able to generate unique IDs that are consistent across SSR/client-side render. Loathe to add a dependency; but looking at what [react-uid](https://github.com/thearnica/react-uid) is doing.

Another little wrinkle here is that I want to upgrade this to the `Text` component but will have to cut a breaking change for that since the types will break. Will probably do that separately picking up where https://github.com/artsy/palette/pull/780 left off.

![](https://static.damonzucconi.com/_capture/J4JrrzyK.gif)


----

Also my evergreen reminder that adding the accessibility dropdown to your top bar makes testing this stuff super simple: ![](https://static.damonzucconi.com/_capture/F0hKsGGm.png) 🎩 