### PR TITLE
fix(a11y): makes radio / radio groups accessible

### DIFF
--- a/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { Text } from "../Text"
-import { EntityHeader } from "./EntityHeader"
+import { States } from "storybook-states"
+import { EntityHeader, EntityHeaderProps } from "./EntityHeader"
 
 export default {
   title: "Components/EntityHeader",
@@ -8,69 +8,30 @@ export default {
 
 export const Default = () => {
   return (
-    <EntityHeader
-      imageUrl="https://picsum.photos/seed/example/110/110"
-      initials="FD"
-      name="Francesca DiMattio"
-      meta="American, b. 1979"
-      href="http://www.artsy.net/artist/francesca-dimattio"
-      FollowButton={<>Follow</>}
-    />
+    <States<EntityHeaderProps>
+      states={[
+        { name: "Francesca DiMattio" },
+        { smallVariant: true, name: "Francesca DiMattio", initials: "FD" },
+        { name: "Francesca DiMattio", initials: "FD" },
+        {
+          smallVariant: true,
+          name: "Francesca DiMattio",
+          imageUrl: "https://picsum.photos/seed/example/110/110",
+        },
+        {
+          name: "Francesca DiMattio",
+          imageUrl: "https://picsum.photos/seed/example/110/110",
+        },
+        {
+          initials: "FD",
+          name: "Francesca DiMattio",
+          imageUrl: "https://picsum.photos/seed/example/110/110",
+          meta: "American, b. 1979",
+          href: "http://www.artsy.net/artist/francesca-dimattio",
+        },
+      ]}
+    >
+      {(props) => <EntityHeader {...props} />}
+    </States>
   )
-}
-
-export const WithoutImageUrl = () => {
-  return (
-    <EntityHeader
-      initials="FD"
-      name="Francesca DiMattio"
-      meta="American, b. 1979"
-      href="http://www.artsy.net/artist/francesca-dimattio"
-      FollowButton={<>Follow</>}
-    />
-  )
-}
-
-WithoutImageUrl.story = {
-  name: "Without imageUrl",
-}
-
-export const SmallVariant = () => {
-  return (
-    <EntityHeader
-      smallVariant
-      initials="FD"
-      name="Francesca DiMattio"
-      imageUrl="https://picsum.photos/seed/example/110/110"
-      href="http://www.artsy.net/artist/francesca-dimattio"
-      FollowButton={
-        <Text style={{ textDecoration: "underline" }}>Following</Text>
-      }
-    />
-  )
-}
-
-SmallVariant.story = {
-  name: "smallVariant",
-}
-
-export const WithLessInfo = () => {
-  return (
-    <EntityHeader
-      imageUrl="https://picsum.photos/seed/example/110/110"
-      name="Francesca DiMattio"
-    />
-  )
-}
-
-WithLessInfo.story = {
-  name: "with less info",
-}
-
-export const WithOnlyName = () => {
-  return <EntityHeader name="Francesca DiMattio" />
-}
-
-WithOnlyName.story = {
-  name: "with only name",
 }

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -1,4 +1,4 @@
-import React, { SFC } from "react"
+import React from "react"
 import styled from "styled-components"
 import { Color } from "../../Theme"
 import { Avatar } from "../Avatar"
@@ -8,7 +8,7 @@ import { Link } from "../Link"
 import { SpacerProps } from "../Spacer"
 import { Text } from "../Text"
 
-interface EntityHeaderProps extends SpacerProps {
+export interface EntityHeaderProps extends SpacerProps {
   href?: string
   imageUrl?: string
   initials?: string
@@ -27,9 +27,8 @@ interface ContainerComponentProps {
 
 /**
  * Component that is used as entity header that is paired with rich information about the entity.
- * Spec: zpl.io/aNoYM6d
  */
-export const EntityHeader: SFC<EntityHeaderProps> = ({
+export const EntityHeader: React.FC<EntityHeaderProps> = ({
   href,
   imageUrl,
   initials,
@@ -71,7 +70,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
                 }
                 <Box
                   display="inline-block"
-                  onClick={event => {
+                  onClick={(event) => {
                     // Capture click event so that interacting with Follow doesn't
                     // trigger Container's link.
                     event.stopPropagation()
@@ -106,7 +105,7 @@ export const EntityHeader: SFC<EntityHeaderProps> = ({
                 )}
                 <Box
                   display="inline-block"
-                  onClick={event => {
+                  onClick={(event) => {
                     // Capture click event so that interacting with Follow doesn't
                     // trigger Container's link.
                     event.stopPropagation()

--- a/packages/palette/src/elements/Radio/Radio.story.tsx
+++ b/packages/palette/src/elements/Radio/Radio.story.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { States } from "storybook-states"
+import { Text } from "../Text"
+import { Radio, RadioProps } from "./Radio"
+
+export default {
+  title: "Components/Radio",
+}
+
+export const Default = () => {
+  return (
+    <States<RadioProps>
+      states={[
+        {},
+        { hover: true },
+        { selected: true },
+        { disabled: true },
+        { disabled: true, selected: true },
+        { hover: true, selected: true },
+        { disabled: true, hover: true, selected: true },
+        { label: "String Label" },
+        {
+          label: (
+            <Text variant="small" color="red100">
+              Small Custom Label
+            </Text>
+          ),
+        },
+        { label: <Text variant="subtitle">Large Custom Label</Text> },
+      ]}
+    >
+      <Radio />
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -1,9 +1,6 @@
 import debounce from "debounce"
 import React from "react"
 import styled, { css } from "styled-components"
-import { Flex, FlexProps } from "../../elements/Flex"
-import { color, space } from "../../helpers"
-
 import {
   BorderProps,
   borders,
@@ -11,12 +8,11 @@ import {
   space as styledSpace,
   SpaceProps,
 } from "styled-system"
+import { Flex } from "../../elements/Flex"
+import { color, space } from "../../helpers"
+import { Clickable, ClickableProps } from "../Clickable"
 
-/**
- * Spec: zpl.io/bAvnwlB
- */
-
-export interface RadioProps extends FlexProps {
+export interface RadioProps extends Omit<ClickableProps, "onSelect"> {
   /** Disable interactions */
   disabled?: boolean
   /** Select the button on render. If the Radio is inside a RadioGroup, use RadioGroup.defaultValue instead. */
@@ -41,66 +37,74 @@ export interface RadioToggleProps
 
 /**
  * A Radio button
- *
- * Spec: zpl.io/bAvnwlB
  */
-export const Radio: React.SFC<RadioProps> = props => {
-  const {
-    children,
-    disabled,
-    hover,
-    name,
-    onSelect: _onSelect,
-    selected,
-    value,
-    label,
-    ...others
-  } = props
+export const Radio: React.ForwardRefExoticComponent<
+  RadioProps & { ref?: React.Ref<HTMLButtonElement> }
+> = React.forwardRef(
+  (
+    {
+      children,
+      disabled,
+      hover,
+      name,
+      onSelect: _onSelect,
+      selected,
+      value,
+      label,
+      ...rest
+    },
+    forwardedRef
+  ) => {
+    // Ensures that only one call to `onSelect` occurs, regardless of whether the
+    // user clicks the radio element or the label.
+    const onSelect = _onSelect && debounce(_onSelect, 0)
 
-  // Ensures that only one call to `onSelect` occurs, regardless of whether the
-  // user clicks the radio element or the label.
-  const onSelect = _onSelect && debounce(_onSelect, 0)
-
-  return (
-    <Container
-      disabled={disabled}
-      alignItems="center"
-      selected={selected}
-      hover={hover}
-      onClick={() =>
-        !disabled && onSelect && onSelect({ selected: !selected, value })
-      }
-      {...others}
-    >
-      <RadioButton
-        role="presentation"
-        border={1}
-        mr={1}
-        mt="2px"
-        mb="-2px"
-        selected={selected}
+    return (
+      <Container
+        ref={forwardedRef as any}
         disabled={disabled}
+        alignItems="center"
+        selected={selected}
+        hover={hover}
+        onClick={() =>
+          !disabled && onSelect && onSelect({ selected: !selected, value })
+        }
+        {...rest}
       >
-        <InnerCircle />
-      </RadioButton>
-      <Flex flexDirection="column">
-        <Label disabled={disabled}>
-          <HiddenInput
-            type="radio"
-            name={name}
-            checked={selected}
-            disabled={disabled}
-            onChange={() =>
-              !disabled && onSelect && onSelect({ selected: !selected, value })
-            }
-          />
-          {label ? label : children}
-        </Label>
-        {label ? children : null}
-      </Flex>
-    </Container>
-  )
-}
+        <RadioButton
+          role="presentation"
+          border={1}
+          mr={1}
+          selected={selected}
+          disabled={disabled}
+        >
+          <InnerCircle />
+        </RadioButton>
+
+        <Flex flexDirection="column">
+          <Label disabled={disabled}>
+            <HiddenInput
+              tabIndex={-1}
+              type="radio"
+              name={name}
+              checked={selected}
+              disabled={disabled}
+              onChange={() =>
+                !disabled &&
+                onSelect &&
+                onSelect({ selected: !selected, value })
+              }
+            />
+            {label ? label : children}
+          </Label>
+          {label ? children : null}
+        </Flex>
+      </Container>
+    )
+  }
+)
+
+Radio.displayName = "Radio"
 
 /**
  * A radio button with a border
@@ -145,16 +149,18 @@ const hoverStyles = ({ selected, hover }) => {
   }
 }
 
-interface ContainerProps extends FlexProps {
+interface ContainerProps extends ClickableProps {
   disabled: boolean
   hover: boolean
   selected: boolean
 }
 
-const Container = styled(Flex)<ContainerProps>`
+const Container = styled(Clickable)<ContainerProps>`
+  display: flex;
   align-items: flex-start;
-  cursor: ${({ disabled }) => !disabled && "pointer"};
+  text-align: left;
   user-select: none;
+  cursor: ${({ disabled }) => !disabled && "pointer"};
   ${hoverStyles};
 `
 

--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -65,6 +65,8 @@ export const Radio: React.ForwardRefExoticComponent<
         disabled={disabled}
         alignItems="center"
         selected={selected}
+        aria-checked={selected}
+        role="radio"
         hover={hover}
         onClick={() =>
           !disabled && onSelect && onSelect({ selected: !selected, value })
@@ -75,6 +77,8 @@ export const Radio: React.ForwardRefExoticComponent<
           role="presentation"
           border={1}
           mr={1}
+          mt="2px"
+          mb="-2px"
           selected={selected}
           disabled={disabled}
         >

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.story.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.story.tsx
@@ -1,63 +1,74 @@
 import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
-import { BorderBox } from "../BorderBox"
+import { States } from "storybook-states"
+import { Button } from "../Button"
 import { Radio } from "../Radio/Radio"
-import { RadioGroup } from "./RadioGroup"
+import { Text } from "../Text"
+import { RadioGroup, RadioGroupProps } from "./RadioGroup"
 
 export default {
   title: "Components/RadioGroup",
 }
 
+export const Default = () => {
+  return (
+    <States<Partial<RadioGroupProps>>
+      states={[
+        {},
+        { defaultValue: "Aural" },
+        { deselectable: true },
+        { disabled: true },
+        { disabled: true, disabledText: "Reason for disabled" },
+      ]}
+    >
+      <RadioGroup>
+        {["Visual", "Linguistic", "Spatial", "Aural", "Gestural"].map(
+          (value) => {
+            return (
+              <Radio
+                key={value}
+                value={value}
+                label={<Text>{value}</Text>}
+                onSelect={action("onSelect")}
+              />
+            )
+          }
+        )}
+      </RadioGroup>
+    </States>
+  )
+}
+
 export const WithDefaultValue = () => {
-  const RadioGroupToggle = () => {
-    const [defaultValue, setValue] = useState("PICKUP")
-    return (
-      <>
-        <BorderBox
-          mb={2}
-          style={{ cursor: "pointer" }}
-          onClick={() => {
-            setValue(defaultValue === "PICKUP" ? "SHIP" : "PICKUP")
-          }}
-        >
-          Toggle default value: {defaultValue}
-        </BorderBox>
-        <RadioGroup defaultValue={defaultValue}>
-          <Radio
-            value="SHIP"
-            label="Provide shipping address"
-            onSelect={action("onSelect")}
-          />
-          <Radio
-            value="PICKUP"
-            label="Arrange for pickup"
-            onSelect={action("onSelect")}
-          />
-        </RadioGroup>
-      </>
-    )
-  }
-  return <RadioGroupToggle />
+  const [defaultValue, setValue] = useState("PICKUP")
+
+  return (
+    <>
+      <Button
+        mb={2}
+        onClick={() => {
+          setValue(defaultValue === "PICKUP" ? "SHIP" : "PICKUP")
+        }}
+      >
+        Toggle default value: {defaultValue}
+      </Button>
+
+      <RadioGroup defaultValue={defaultValue}>
+        <Radio
+          value="SHIP"
+          label="Provide shipping address"
+          onSelect={action("onSelect")}
+        />
+        <Radio
+          value="PICKUP"
+          label="Arrange for pickup"
+          onSelect={action("onSelect")}
+        />
+      </RadioGroup>
+    </>
+  )
 }
 
 WithDefaultValue.story = {
   name: "With default value",
-}
-
-export const Deselectable = () => {
-  return (
-    <RadioGroup defaultValue="SHIP" deselectable>
-      <Radio value="SHIP" label="Provide shipping address" />
-      <Radio value="PICKUP" label="Arrange for pickup" />
-    </RadioGroup>
-  )
-}
-
-export const Disabled = () => {
-  return (
-    <RadioGroup defaultValue="SHIP" disabled disabledText="disabled text">
-      <Radio value="SHIP" label="Provide shipping address" />
-      <Radio value="PICKUP" label="Arrange for pickup" />
-    </RadioGroup>
-  )
 }

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.test.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.test.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { Radio } from "../Radio"
 import { RadioGroup } from "../RadioGroup"
 
-jest.mock("debounce", () => x => x)
+jest.mock("debounce", () => (x) => x)
 
 describe("RadioGroup", () => {
   it("renders a radio group", () => {
@@ -18,10 +18,7 @@ describe("RadioGroup", () => {
     expect(wrapper.text()).toContain("Provide shipping address")
     expect(wrapper.text()).toContain("Arrange for pickup")
 
-    wrapper
-      .find("Radio")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().simulate("click")
 
     expect(spy).toHaveBeenCalled()
   })
@@ -34,18 +31,8 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(false)
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().selected).toBe(false)
+    expect(wrapper.find("Radio").last().props().selected).toBe(true)
   })
 
   it("selects the radio that gets clicked", () => {
@@ -56,23 +43,10 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    wrapper
-      .find("Radio")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().simulate("click")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(true)
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").first().props().selected).toBe(true)
+    expect(wrapper.find("Radio").last().props().selected).toBe(false)
   })
 
   it("allows the 'disabled' prop on the Radio component to take the precedence", () => {
@@ -85,18 +59,8 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().disabled
-    ).toBe(false)
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().disabled
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().disabled).toBe(false)
+    expect(wrapper.find("Radio").last().props().disabled).toBe(true)
   })
 
   it("displays a specific text when disabled", () => {
@@ -107,7 +71,7 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    expect(wrapper.find("Sans").text()).toBe("i am disabled right now mate")
+    expect(wrapper.find("Text").text()).toBe("i am disabled right now mate")
   })
 
   it("allows Radios within the group to be deselectable", () => {
@@ -122,21 +86,11 @@ describe("RadioGroup", () => {
 
     ship.simulate("click")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().selected).toBe(true)
 
     ship.simulate("click")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").first().props().selected).toBe(false)
   })
 
   it("ignores the 'selected' prop on the Radio component", () => {
@@ -157,7 +111,7 @@ describe("RadioGroup", () => {
   })
 
   it("allows for updates to defaultValue", () => {
-    const getWrapper = defaultValue =>
+    const getWrapper = (defaultValue) =>
       mount(
         <RadioGroup defaultValue={defaultValue}>
           <Radio value="SHIP" selected>
@@ -169,35 +123,15 @@ describe("RadioGroup", () => {
 
     let wrapper = getWrapper("PICKUP")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").first().props().selected).toBe(false)
 
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").last().props().selected).toBe(true)
 
     wrapper = getWrapper("SHIP")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().selected).toBe(true)
 
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").last().props().selected).toBe(false)
   })
 
   it("allows for using the onSelect callback both on RadioGroup and Radio", () => {
@@ -213,10 +147,7 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    wrapper
-      .find("Radio")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().simulate("click")
 
     expect(spyOnRadioGroup).toHaveBeenCalled()
     expect(spyOnRadio).toHaveBeenCalled()

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.tsx
@@ -1,11 +1,15 @@
-import React from "react"
+import React, {
+  Children,
+  createRef,
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+import { useCursor } from "use-cursor"
 import { Flex, FlexProps } from "../Flex"
 import { RadioProps } from "../Radio"
-import { Sans } from "../Typography"
-
-/**
- * Spec: zpl.io/bAvnwlB
- */
+import { Text } from "../Text"
 
 export interface RadioGroupProps extends FlexProps {
   /** Ability to deselect the selection */
@@ -22,94 +26,119 @@ export interface RadioGroupProps extends FlexProps {
   children: Array<React.ReactElement<RadioProps>>
 }
 
-interface RadioGroupState {
-  selectedOption: string | null
-}
-
 /**
  * A stateful collection of Radio buttons
- *
- * Spec: zpl.io/bAvnwlB
  */
-export class RadioGroup extends React.Component<
-  RadioGroupProps,
-  RadioGroupState
-> {
-  state = {
-    selectedOption: this.props.defaultValue || null,
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.defaultValue !== this.props.defaultValue) {
-      this.setState({
-        selectedOption: this.props.defaultValue,
+export const RadioGroup: React.FC<RadioGroupProps> = ({
+  disabled,
+  disabledText,
+  defaultValue,
+  deselectable,
+  children,
+  onSelect,
+  ...rest
+}) => {
+  const nodes = Children.toArray(children)
+    .filter(isValidElement)
+    .map(
+      (
+        child: React.ReactElement<
+          RadioProps & {
+            ref?: React.Ref<HTMLButtonElement>
+          }
+        >
+      ) => ({
+        child,
+        ref: createRef<HTMLButtonElement>(),
       })
-    }
-  }
+    )
 
-  onSelect = ({ value }) => {
-    // After state update, call back up the tree with the latest state
-    const update = () => {
-      if (this.props.onSelect) {
-        this.props.onSelect(this.state.selectedOption)
-      }
-    }
+  const [selectedOption, setSelectedOption] = useState(defaultValue)
 
-    if (this.props.deselectable) {
-      if (this.state.selectedOption === value) {
-        this.setState(
-          {
-            selectedOption: null,
-          },
-          update
-        )
+  const options = nodes.map((node) => node.child.props.value)
+  const selectedIndex = options.indexOf(selectedOption)
+
+  const inputModality = useRef<"mouse" | "keyboard">("mouse")
+
+  const { index: focusIndex, handleNext, handlePrev } = useCursor({
+    max: options.length,
+    initialCursor: selectedIndex === -1 ? 0 : selectedIndex,
+  })
+
+  const handleSelect = ({ value }) => {
+    if (deselectable) {
+      if (selectedOption === value) {
+        setSelectedOption(null)
         return
       }
     }
 
-    this.setState({ selectedOption: value }, update)
+    setSelectedOption(value)
   }
 
-  renderRadioButtons() {
-    return React.Children.map(
-      this.props.children,
-      (child: React.ReactElement<RadioProps>) => {
+  const handleKeydown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    inputModality.current = "keyboard"
+
+    switch (event.key) {
+      case "ArrowDown":
+      case "ArrowRight":
+        handleNext()
+        break
+      case "ArrowUp":
+      case "ArrowLeft":
+        handlePrev()
+        break
+    }
+  }
+
+  useEffect(() => {
+    setSelectedOption(defaultValue)
+  }, [defaultValue])
+
+  useEffect(() => {
+    if (onSelect) {
+      onSelect(selectedOption)
+    }
+  }, [selectedOption])
+
+  useEffect(() => {
+    if (inputModality.current === "mouse") return
+
+    const timeout = setTimeout(() => {
+      nodes[focusIndex].ref.current?.focus()
+    }, 0)
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [nodes, focusIndex])
+
+  return (
+    <Flex flexDirection="column" role="radiogroup" {...rest}>
+      {disabled && disabledText && (
+        <Text variant="small" mb={0.3} color="black60">
+          {disabledText}
+        </Text>
+      )}
+
+      {nodes.map(({ child, ref }) => {
         return React.cloneElement(child, {
+          ref,
+          selected: selectedOption === child.props.value,
+          tabIndex: selectedOption === child.props.value ? 0 : -1,
+          onKeyDown: handleKeydown,
           disabled:
             child.props.disabled !== undefined
               ? child.props.disabled
-              : this.props.disabled,
+              : disabled,
           onSelect: child.props.onSelect
-            ? selected => {
-                this.onSelect(selected)
+            ? (selected: { selected: boolean; value: string }) => {
+                handleSelect(selected)
                 child.props.onSelect(selected)
               }
-            : this.onSelect,
-          // FIXME: Throw an error `child.props.selected' is set once we enable the dev code elimination.
-          selected: this.state.selectedOption === child.props.value,
+            : handleSelect,
         })
-      }
-    )
-  }
-
-  render() {
-    const {
-      disabled,
-      disabledText,
-      onSelect,
-      defaultValue,
-      children,
-      ...others
-    } = this.props
-    return (
-      <Flex flexDirection="column" {...others}>
-        {disabled && disabledText && (
-          <Sans size="2" my={0.3} color="black60">
-            {disabledText}
-          </Sans>
-        )}
-        {this.renderRadioButtons()}
-      </Flex>
-    )
-  }
+      })}
+    </Flex>
+  )
 }


### PR DESCRIPTION
The behavior here was more surprising than I thought.

[WAI-ARIA example](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/radio/radio-1/radio-1.html)

Just opening a draft here; few more things to button up, specs, and ensure there's no visual regressions. There was some weird margin behavior that was effecting the container that I removed but might have to put back.

![](https://static.damonzucconi.com/_capture/7fUitakM.gif)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.35.1-canary.863.15275.0
  # or 
  yarn add @artsy/palette@13.35.1-canary.863.15275.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
