### PR TITLE
fix: check for empty strings in join

### DIFF
--- a/packages/palette/src/elements/Join/Join.tsx
+++ b/packages/palette/src/elements/Join/Join.tsx
@@ -27,22 +27,24 @@ interface JoinProps {
 export const Join: SFC<JoinProps> = ({ separator, children }) => {
   const childArray = React.Children.toArray(children) as any
 
-  return childArray.reduce((acc, curr, currentIndex) => {
-    acc.push(
-      React.cloneElement(curr as React.ReactElement<any>, {
-        key: `join-${currentIndex}`,
-      })
-    )
-
-    if (currentIndex !== childArray.length - 1) {
+  return childArray
+    .filter((child) => child)
+    .reduce((acc, curr, currentIndex) => {
       acc.push(
-        separator &&
-          React.cloneElement(separator, {
-            key: `join-sep-${currentIndex}`,
-          })
+        React.cloneElement(curr as React.ReactElement<any>, {
+          key: `join-${currentIndex}`,
+        })
       )
-    }
 
-    return acc
-  }, []) as any
+      if (currentIndex !== childArray.length - 1) {
+        acc.push(
+          separator &&
+            React.cloneElement(separator, {
+              key: `join-sep-${currentIndex}`,
+            })
+        )
+      }
+
+      return acc
+    }, []) as any
 }


### PR DESCRIPTION
Co-authored-by: David Sheldrick <djsheldrick@gmail.com>


It looks `_react.default.Children.toArray` is returning an array containing an empty string which is causing the UI to break. We simply added a check to make sure that the child actually exists.

<img width="660" alt="Screenshot 2021-02-25 at 13 35 26" src="https://user-images.githubusercontent.com/11945712/109154507-a5668780-776e-11eb-9964-8cbda230fe2e.png">

