### PR TITLE
[v3] Banner/Message

### DIFF
--- a/packages/palette/src/elements/Banner/Banner.story.tsx
+++ b/packages/palette/src/elements/Banner/Banner.story.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { States } from "storybook-states"
+import { Banner, BannerProps } from "./Banner"
+
+export default {
+  title: "Components/Banner",
+}
+
+export const Default = () => {
+  return (
+    <States<BannerProps>
+      states={[
+        { dismissable: false },
+        { variant: "defaultLight" },
+        { variant: "defaultDark" },
+        { variant: "success" },
+        { variant: "error" },
+        { variant: "brand" },
+      ]}
+    >
+      <Banner dismissable>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis quae
+        natus assumenda distinctio, voluptatum magni. autem sunt.
+      </Banner>
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Banner/Banner.test.tsx
+++ b/packages/palette/src/elements/Banner/Banner.test.tsx
@@ -1,41 +1,35 @@
 import { mount } from "enzyme"
 import "jest-styled-components"
 import React from "react"
+import { Theme } from "../../Theme"
 import { Banner } from "../Banner"
 
 describe("Button", () => {
-  it("pass a custom color to Banner", () => {
-    const message = "There was an error."
+  it("has default black10 background to Banner", () => {
     const wrapper = mount(
-      <Banner message={message} backgroundColor="purple100" />
+      <Theme>
+        <Banner />
+      </Theme>
     )
-    expect(wrapper.debug()).toContain("purple100")
-  })
-
-  it("has default red background to Banner", () => {
-    const message = "There was an error."
-    const wrapper = mount(<Banner message={message} />)
-    expect(wrapper.debug()).toContain("red100")
+    expect(wrapper).toHaveStyleRule("background-color", "#E5E5E5")
   })
 
   it("displays the message", () => {
     const message = "There was an error."
-    const wrapper = mount(<Banner message={message} />)
+    const wrapper = mount(<Banner>There was an error.</Banner>)
     expect(wrapper.text()).toEqual(message)
-    expect(wrapper.find("CloseButton")).toHaveLength(0)
+    expect(wrapper.find("Clickable")).toHaveLength(0)
   })
 
   it("is dismissable", () => {
-    const message = "There was an error."
-    const wrapper = mount(<Banner dismissable message={message} />)
-    expect(wrapper.find("CloseButton")).toHaveLength(1)
+    const wrapper = mount(<Banner dismissable>There was an error.</Banner>)
+    expect(wrapper.find("Clickable")).toHaveLength(1)
   })
 
   it("disappears when dismissed", () => {
-    const message = "There was an error."
-    const wrapper = mount(<Banner dismissable message={message} />)
-    expect(wrapper.find("CloseButton")).toHaveLength(1)
-    wrapper.find("CloseButton").simulate("click")
-    expect(wrapper.find("CloseButton")).toHaveLength(0)
+    const wrapper = mount(<Banner dismissable>There was an error.</Banner>)
+    expect(wrapper.find("Clickable")).toHaveLength(1)
+    wrapper.find("Clickable").simulate("click")
+    expect(wrapper.find("Clickable")).toHaveLength(0)
   })
 })

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -1,79 +1,81 @@
-import React from "react"
+import React, { useState } from "react"
 import styled from "styled-components"
+import { variant } from "styled-system"
 import { CloseIcon } from "../../svgs/CloseIcon"
-import { Box } from "../Box"
-import { Flex } from "../Flex"
-import { Sans } from "../Typography"
+import { useThemeConfig } from "../../Theme"
+import { Clickable } from "../Clickable"
+import { Flex, FlexProps } from "../Flex"
+import { Text, TextVariant } from "../Text"
 
-const Target = styled(Flex)`
-  padding-left: 10px;
-  cursor: pointer;
+const VARIANTS = {
+  defaultLight: {
+    backgroundColor: "black10",
+    color: "black100",
+  },
+  defaultDark: {
+    backgroundColor: "black100",
+    color: "white100",
+  },
+  success: {
+    backgroundColor: "green100",
+    color: "white100",
+  },
+  error: {
+    backgroundColor: "red100",
+    color: "white100",
+  },
+  brand: {
+    backgroundColor: "brand",
+    color: "white100",
+  },
+}
 
-  svg {
-    display: block;
+const Container = styled(Flex)`
+  ${variant({ variants: VARIANTS })}
+`
+
+export interface BannerProps extends FlexProps {
+  variant?: keyof typeof VARIANTS
+  dismissable?: boolean
+}
+
+/** A banner */
+export const Banner: React.FC<BannerProps> = ({
+  dismissable = false,
+  children,
+  ...rest
+}) => {
+  const size: TextVariant = useThemeConfig({ v2: "small", v3: "sm" })
+
+  const [dismissed, setDismissed] = useState(false)
+
+  const handleClick = () => {
+    setDismissed(true)
   }
-`
 
-const Wrapper = styled(Box)`
-  transition: background-color 250ms linear;
-  display: flex;
-`
+  if (dismissed) return null
 
-const TextWrapper = styled(Flex)`
-  width: 100%;
-  text-align: center;
-  align-items: center;
-  justify-content: center;
-`
-
-const CloseButton = ({ onClick }) => {
   return (
-    <Target onClick={onClick} alignItems="center">
-      <CloseIcon fill="white100" />
-    </Target>
+    <Container p={1} {...rest}>
+      <Text variant={size} textAlign="center" flex="1">
+        {children}
+      </Text>
+
+      {dismissable && (
+        <Clickable
+          pl={1}
+          display="flex"
+          alignItems="center"
+          color="currentColor"
+          onClick={handleClick}
+        >
+          <CloseIcon style={{ fill: "currentcolor" }} />
+        </Clickable>
+      )}
+    </Container>
   )
 }
 
-export interface BannerProps {
-  dismissable: boolean
-  message?: string
-  backgroundColor: string
-  textColor: string
-}
-
-/**
- * A banner
- */
-export class Banner extends React.Component<BannerProps> {
-  static defaultProps = {
-    dismissable: false,
-    backgroundColor: "red100",
-    textColor: "white100",
-  }
-
-  state = {
-    dismissed: false,
-  }
-
-  handleCloseClick = () => {
-    this.setState({ dismissed: true })
-  }
-
-  render() {
-    if (this.state.dismissed) return null
-    const showCloseButton = this.props.dismissable
-
-    return (
-      <Wrapper
-        bg={this.props.backgroundColor}
-        color={this.props.textColor}
-        p={1}
-      >
-        <TextWrapper>
-          <Sans size="2">{this.props.children || this.props.message}</Sans>
-        </TextWrapper>
-        {showCloseButton && <CloseButton onClick={this.handleCloseClick} />}
-      </Wrapper>
-    )
-  }
+Banner.defaultProps = {
+  variant: "defaultLight",
 }

--- a/packages/palette/src/elements/Message/Message.story.tsx
+++ b/packages/palette/src/elements/Message/Message.story.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { States } from "storybook-states"
+import { Text } from "../Text"
+import { Message, MessageProps } from "./Message"
+
+export default {
+  title: "Components/Message",
+}
+
+export const Default = () => {
+  return (
+    <States<MessageProps>
+      states={[
+        { title: "Message Title" },
+        { variant: "info", title: "Message Title" },
+        { variant: "warning", title: "Message Title" },
+        { variant: "error", title: "Message Title" },
+        {},
+        { variant: "info" },
+        { variant: "warning" },
+        { variant: "error" },
+        {
+          children: (
+            <Text variant="lg" color="red100">
+              custom children
+            </Text>
+          ),
+        },
+      ]}
+    >
+      <Message>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Reiciendis quae
+        natus assumenda distinctio, voluptatum magni. Natus, aliquam neque odio
+        debitis totam labore maiores, corrupti mollitia repudiandae optio illo,
+        autem sunt.
+      </Message>
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Message/Message.tsx
+++ b/packages/palette/src/elements/Message/Message.tsx
@@ -1,55 +1,61 @@
-import React, { FC } from "react"
+import React from "react"
 import styled from "styled-components"
-import { color } from "../../helpers"
-import { SansSize } from "../../Theme"
+import { variant } from "styled-system"
+import { useThemeConfig } from "../../Theme"
 import { Flex, FlexProps } from "../Flex"
-import { Sans } from "../Typography"
+import { Text, TextVariant } from "../Text"
 
-/**
- * Spec: zpl.io/2Zg4Rdq
- */
-
-interface MessageProps extends FlexProps {
-  children: React.ReactNode | null
-  /**
-   * Size of text to display in message window
-   */
-  textSize?: SansSize
-  /**
-   * Determines the background color. Variants are "info" (blue) and "warning"
-   * (copper). No value will default to light grey
-   */
-  variant?: "info" | "warning"
+const VARIANTS = {
+  default: {
+    backgroundColor: "black10",
+    color: "black100",
+  },
+  info: {
+    backgroundColor: "blue10",
+    color: "blue100",
+  },
+  warning: {
+    backgroundColor: "copper10",
+    color: "copper100",
+  },
+  error: {
+    backgroundColor: "red10",
+    color: "red100",
+  },
 }
 
-const StyledFlex = styled(Flex)<MessageProps>`
-  background-color: ${({ variant }) => {
-    if (variant === "info") {
-      return color("blue10")
-    } else if (variant === "warning") {
-      return color("copper10")
-    } else {
-      return color("black5")
-    }
-  }};
-  border-radius: 2px;
+export interface MessageProps extends FlexProps {
+  variant?: keyof typeof VARIANTS
+  title?: string
+  children?: React.ReactNode
+}
+
+const Container = styled(Flex)<MessageProps>`
+  ${variant({ variants: VARIANTS })}
+  flex-direction: column;
 `
 
-/**
- * A generic message window for displaying ZerStates, notices, errors, etc.
- *
- * Spec: zpl.io/2Zg4Rdq
- */
-export const Message: FC<MessageProps> = ({
+/** A generic message window for displaying ZerStates, notices, errors, etc. */
+export const Message: React.FC<MessageProps> = ({
   children,
-  textSize = "3t",
-  ...others
+  title,
+  ...rest
 }) => {
+  const size: TextVariant = useThemeConfig({ v2: "text", v3: "sm" })
+
   return (
-    <StyledFlex p={2} {...others}>
-      <Sans size={textSize} color={color("black100")} weight="regular">
+    <Container p={2} {...rest}>
+      <Text variant={size} color="currentColor">
+        {title}
+      </Text>
+
+      <Text variant={size} color="black100">
         {children}
-      </Sans>
-    </StyledFlex>
+      </Text>
+    </Container>
   )
+}
+
+Message.defaultProps = {
+  variant: "default",
 }

--- a/packages/palette/src/themes/v2.tsx
+++ b/packages/palette/src/themes/v2.tsx
@@ -93,6 +93,8 @@ export const THEME = {
     green10: "#E9F2EC",
     /** Full purple, secondary brand color. Should only used in time/transitions (on hover, active state), for highlighting vital text, and links.   */
     purple100: "#6E1EFF",
+    /** Alias of purple100 */
+    brand: "#6E1EFF",
     /** 30 purple (light purple), avoid usage  */
     purple30: "#D3BBFF",
     /* 5 purple, highlight, accent */

--- a/packages/palette/src/themes/v3.tsx
+++ b/packages/palette/src/themes/v3.tsx
@@ -57,6 +57,8 @@ export const THEME = {
     black5: "#D8D8D8",
     /** Full Blue. Calls to action, highlights, edits */
     blue100: "#1023D7",
+    /** Alias of blue100 */
+    brand: "#1023D7",
     /** 10% of blue100 on white. Backgrounds */
     blue10: "#E6E7F5",
     /** Full copper. In consideration, transition, temporary */


### PR DESCRIPTION
So: I made some breaking changes here in order to improve/restrict the API.
* Removed `textSize` in Message because you can just use custom children if you really need to
* Removed `textColor` and `backgroundColor` because we don't want or need that.

There are a few changes to Volt and Force. I'm going to probably be doing this a few more times: cutting a breaking release and then updating Volt/Force. If you think I should include some other apps in this cycle then point them out; but those seem like the main to be concerned with.

![](https://static.damonzucconi.com/_capture/ZbWSo2M2.gif)

![](https://static.damonzucconi.com/_capture/ab8xKjnv.gif)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@13.36.2-canary.869.15447.0
  # or 
  yarn add @artsy/palette@13.36.2-canary.869.15447.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
