### PR TITLE
fix(select): fix type signature for deprecated exports

### DIFF
--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -235,12 +235,14 @@ const Container = styled.div<ContainerProps>`
  * Default variant of Select. In v2 contexts this is the larger select.
  * @deprecated Use` <Select />`
  */
-export const LargeSelect = styled(Select)``
-LargeSelect.defaultProps = { variant: "default" }
+export const LargeSelect: React.FC<Omit<SelectProps, "variant">> = (props) => {
+  return <Select variant="default" {...props} />
+}
 
 /**
  * Inline variant of Select. In v2 contexts this is the smaller select.
  * @deprecated Use `<Select variant="inline">`
  */
-export const SelectSmall = styled(Select)``
-SelectSmall.defaultProps = { variant: "inline" }
+export const SelectSmall: React.FC<Omit<SelectProps, "variant">> = (props) => {
+  return <Select variant="inline" {...props} />
+}

--- a/packages/palette/src/elements/Select/__tests__/Select.test.tsx
+++ b/packages/palette/src/elements/Select/__tests__/Select.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { LargeSelect, SelectSmall } from "../Select"
+import { LargeSelect, SelectSmall } from ".."
 
 const options = [
   {


### PR DESCRIPTION
Trying this for a fix for https://app.circleci.com/pipelines/github/artsy/force/12768/workflows/07ed89b4-0685-4619-ab98-96b65751eb78/jobs/90755