### PR TITLE
feat: add optional onClick prop to Toggle

### DIFF
--- a/packages/palette-docs/content/docs/elements/layout/Toggle.mdx
+++ b/packages/palette-docs/content/docs/elements/layout/Toggle.mdx
@@ -78,3 +78,14 @@ name: Toggle
     <Toggle label="Time period" />
   </>
 </Playground>
+
+<Playground title="With optional onClick">
+  <Toggle label="Click me and check your console!" expanded onClick={(e) => console.log(e)}>
+    <Sans size="3">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat.
+    </Sans>
+  </Toggle>
+</Playground>

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -19,6 +19,7 @@ export interface ToggleProps extends FlexProps {
   renderSecondaryAction?: (
     toggleProps: Pick<ToggleProps, "disabled" | "expanded" | "textSize">
   ) => JSX.Element
+  onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
 export interface ToggleState {
@@ -35,6 +36,7 @@ export const Toggle: React.FC<ToggleProps> = ({
   disabled,
   children,
   renderSecondaryAction,
+  onClick,
   ...rest
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded)
@@ -48,7 +50,10 @@ export const Toggle: React.FC<ToggleProps> = ({
   return (
     <Flex width="100%" flexDirection="column" pb={2} {...rest}>
       <Header
-        onClick={toggleExpand}
+        onClick={(e) => {
+          toggleExpand()
+          !(onClick === undefined) && onClick(e)
+        }}
         disabled={disabled}
         borderTop="1px solid"
         borderColor="black10"

--- a/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
@@ -56,4 +56,12 @@ describe("Toggle", () => {
     expect(wrapper.find("Sans")).toHaveLength(1)
     expect(wrapper.find("Sans").text()).toEqual("label")
   })
+
+  it("fires onClick when one is passed", () => {
+    const mockCallback = jest.fn()
+    const wrapper = mount(<Toggle onClick={mockCallback}>tab content</Toggle>)
+    wrapper.find("Header").simulate("click")
+    wrapper.find("Header").simulate("click")
+    expect(mockCallback).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
You can actually already use `<Toggle onClick={...}>`, but you'll get a type error. This PR adds it to `Toggle`'s interface. Current anticipated use case is adding a tracking event to a toggle in Volt so we can see when users interact with it.

Seem reasonable to folks?