### PR TITLE
fix(inputs): sets font-family to sans

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -103,6 +103,7 @@ const StyledInput = styled.input<StyledInputProps>`
   border: 1px solid;
   border-radius: 0;
   transition: border-color 0.25s;
+  font-family: ${themeGet("fonts.sans")};
 
   ${(props) => {
     const states = getThemeConfig(props, {


### PR DESCRIPTION
Would anyone oppose me changing the global font-family to courier or something obvious inside of storybooks so that we can be sure to catch things like this in the future?

The default font-family in most of Force is still, regrettably, Garamond.