### PR TITLE
fix(divider): resets default styling when presenting as hr

### DIFF
--- a/packages/palette/src/elements/Separator/Separator.story.tsx
+++ b/packages/palette/src/elements/Separator/Separator.story.tsx
@@ -16,7 +16,7 @@ export const Default = () => {
         { borderWidth: 5, my: 2 },
       ]}
     >
-      <Separator />
+      <Separator as="hr" />
     </States>
   )
 }

--- a/packages/palette/src/elements/Separator/Separator.tsx
+++ b/packages/palette/src/elements/Separator/Separator.tsx
@@ -24,6 +24,9 @@ export const Separator = styled.div<SeparatorProps>`
   border-width: 1px;
   border-style: solid;
   border-bottom-width: 0;
+  background-color: transparent;
+  border-color: currentColor;
+  margin: 0;
   ${compose(space, width, border, color)};
 `
 


### PR DESCRIPTION
Looks like Chrome updated the default style sheet for HRs which is causing some Separators which present as hr to look greenish.

![](https://static.damonzucconi.com/_capture/1xLa8pzs.png)