### PR TITLE
ci: Deploy storybooks via Circle orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,17 @@ version: 2.1
 orbs:
   yarn: artsy/yarn@5.1.3
   auto: artsy/auto@1.3.2
+  aws-s3: circleci/aws-s3@2.0.0
+
+jobs:
+  upload-docs:
+    docker:
+      - image: "cimg/python:3.9"
+    steps:
+      - aws-s3/sync:
+          arguments: --acl public-read
+          from: packages/palette/storybook-static
+          to: "s3://artsy-static-sites/artsy-palette-storybook"
 
 workflows:
   build_and_verify:
@@ -36,6 +47,8 @@ workflows:
           filters:
             branches:
               only: master
+
+      # PR Builds
       - auto/publish-canary:
           context: npm-deploy
           filters:
@@ -46,6 +59,8 @@ workflows:
             - yarn/lint
             - yarn/type-check
             - yarn/update-cache
+
+      # Releases
       - auto/publish:
           context: npm-deploy
           filters:
@@ -56,12 +71,26 @@ workflows:
             - yarn/lint
             - yarn/type-check
             - yarn/update-cache
+
+      # Docs / Storybooks
       - yarn/run:
-          name: deploy-docs
-          script: deploy-docs
-          context: palette-docs-upload
+          name: build-docs
+          script: "build-storybook"
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - packages/palette/storybook-static
+          filters:
+            branches:
+              only: master
+      - upload-docs:
+          context: static-sites-uploader
           requires:
-            - auto/publish
+            - build-docs
+          pre-steps:
+            - attach_workspace:
+                at: .
           filters:
             branches:
               only: master

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ out*
 package-lock.json
 reaction-force.js
 reaction-force.js.map
+storybook-static
 yarn-error.log
 .cache

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "palette",
   "private": true,
   "scripts": {
+    "build-storybook": "yarn workspace @artsy/palette build-storybook",
     "build-docs": "yarn compile-palette && yarn workspace artsy-palette-docs build",
     "compile-palette": "lerna run compile",
     "deploy-docs": "yarn compile-palette && yarn workspace artsy-palette-docs deploy",


### PR DESCRIPTION
This deploys our storybooks to an `artsy-palette-storybook` S3 location. 