### PR TITLE
storybook: Rename helpers/controls > components

### DIFF
--- a/packages/palette/src/themes/Themes.story.tsx
+++ b/packages/palette/src/themes/Themes.story.tsx
@@ -339,10 +339,10 @@ export const Buttons = () => {
   )
 }
 
-export const Helpers = () => {
+export const Components = () => {
   return (
     <>
-      <Text variant="xxl">Helpers</Text>
+      <Text variant="xxl">Components</Text>
 
       <Separator color="black30" my={12} />
 
@@ -485,14 +485,6 @@ export const Helpers = () => {
           )
         })}
       </GridColumns>
-    </>
-  )
-}
-
-export const Controls = () => {
-  return (
-    <>
-      <Text variant="xxl">Controls</Text>
 
       <Separator color="black30" my={12} />
 


### PR DESCRIPTION
The category "helpers/controls" seems a bit confusing, so just renamed to catch all "Components". Thoughts? 

<img width="679" alt="Screen Shot 2021-03-23 at 11 35 56 AM" src="https://user-images.githubusercontent.com/236943/112199959-f5006d80-8bcb-11eb-96de-bb79cb5edfb7.png">


