### PR TITLE
fix(labeledinput): allows for clickable labels

### DIFF
--- a/packages/palette/src/elements/LabeledInput/LabeledInput.story.tsx
+++ b/packages/palette/src/elements/LabeledInput/LabeledInput.story.tsx
@@ -1,6 +1,7 @@
+import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
 import { States } from "storybook-states"
-import { Text } from "../Text"
+import { Clickable } from "../Clickable"
 import { LabeledInput, LabeledInputProps } from "./LabeledInput"
 
 export default {
@@ -11,15 +12,18 @@ export const Default = () => {
   return (
     <States<Partial<LabeledInputProps>>
       states={[
-        { label: "$", placeholder: "Min", type: "number" },
+        { label: "$USD", placeholder: "Min", type: "number" },
         {
+          placeholder: "Clickable label",
           label: (
-            <Text color="red100" lineHeight={1} variant="lg">
-              $USD
-            </Text>
+            <Clickable
+              onClick={action("onClick")}
+              bg="black60"
+              width={18}
+              height={18}
+              borderRadius="50%"
+            />
           ),
-          placeholder: "Min",
-          type: "number",
         },
       ]}
     >

--- a/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
+++ b/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
@@ -24,16 +24,23 @@ export const LabeledInput: React.FC<LabeledInputProps> = ({
 
   const variant: TextVariant = useThemeConfig({ v2: "small", v3: "xs" })
 
+  const isText = typeof label === "string" || typeof label === "number"
+
   return (
     <Box position="relative" {...boxProps}>
       <Box
         ref={labelRef as any}
         position="absolute"
+        display="flex"
+        alignItems="center"
         right={1}
-        top="50%"
-        style={{ transform: "translateY(-50%)", pointerEvents: "none" }}
+        top={0}
+        bottom={0}
+        style={{
+          pointerEvents: isText ? "none" : undefined,
+        }}
       >
-        {typeof label === "string" || typeof label === "number" ? (
+        {isText ? (
           <Text variant={variant} color="black60" lineHeight={1}>
             {label}
           </Text>


### PR DESCRIPTION
Currently have the situation where I'd like to use this label prop to insert a clear button for a filter input. I think it makes sense for textual labels to have pointer-events none and then leave it alone for custom components.