### PR TITLE
fix(labeledinput): corrects tabindex

### DIFF
--- a/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
+++ b/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
@@ -28,6 +28,12 @@ export const LabeledInput: React.ForwardRefExoticComponent<
 
   return (
     <Box position="relative" {...boxProps}>
+      <Input
+        ref={forwardedRef}
+        style={{ paddingRight: `${offset + 10}px` }}
+        {...inputProps}
+      />
+
       <Box
         ref={labelRef as any}
         position="absolute"
@@ -48,12 +54,6 @@ export const LabeledInput: React.ForwardRefExoticComponent<
           label
         )}
       </Box>
-
-      <Input
-        ref={forwardedRef}
-        style={{ paddingRight: `${offset + 10}px` }}
-        {...inputProps}
-      />
     </Box>
   )
 })


### PR DESCRIPTION
OK last one 😉 

Fixes the tabindex by just moving the label into a natural order.