### PR TITLE
fix(select): adjusts padding to accommodate caret

### DIFF
--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -7,9 +7,13 @@ export default {
 }
 
 const OPTIONS = [
-  { text: "First", value: "firstValue" },
-  { text: "Middle", value: "middleValue" },
-  { text: "Last", value: "lastValue" },
+  { text: "Default", value: "-decayed_merch" },
+  { text: "Price (desc.)", value: "-has_price,-prices" },
+  { text: "Price (asc.)", value: "-has_price,prices" },
+  { text: "Recently updated", value: "-partner_updated_at" },
+  { text: "Recently added", value: "-published_at" },
+  { text: "Artwork year (desc.)", value: "-year" },
+  { text: "Artwork year (asc.)", value: "year" },
 ]
 
 export const Default = () => {
@@ -45,5 +49,17 @@ export const Default = () => {
     >
       <Select options={OPTIONS} />
     </States>
+  )
+}
+
+export const Example = () => {
+  return (
+    <Select
+      display="inline-flex"
+      variant="inline"
+      title="Sort:"
+      options={OPTIONS}
+      selected="-year"
+    />
   )
 }

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -170,7 +170,8 @@ const Container = styled.div<ContainerProps>`
   > select {
     ${resetMixin};
     width: 100%;
-    padding: 0 ${themeGet("space.1")};
+    /* 24px = space.1 + 4px-wide caret + space.1 */
+    padding: 0 24px 0 ${themeGet("space.1")};
     font-family: ${themeGet("fonts.sans")};
     border: 1px solid;
     cursor: pointer;


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C9XJKPY9W/p1616618231018200

This PR fixes a minor issue I noticed when investigating; that longer values will cut into the caret issue.

Regarding the problem mentioned in chat: I'm going to just manually pass `display="inline-flex"` to the few instances where this is a problem in Force. I don't want to change it for default `inline` variants because the current display property makes more sense when using columns for layout.