### PR TITLE
fix(theme): corrects media queries

### DIFF
--- a/packages/palette/src/themes/v2.tsx
+++ b/packages/palette/src/themes/v2.tsx
@@ -124,10 +124,10 @@ export const THEME = {
   /** Media queries to work with in web  */
   mediaQueries: {
     xl: `(min-width: ${breakpoints.xl})`,
-    lg: `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1})`,
-    md: `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1})`,
-    sm: `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1})`,
-    xs: `(max-width: ${parseInt(breakpoints.sm, 10) - 1})`,
+    lg: `(min-width: ${breakpoints.lg}) and (max-width: ${parseInt(breakpoints.xl, 10) - 1}px)`,
+    md: `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1}px)`,
+    sm: `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1}px)`,
+    xs: `(max-width: ${parseInt(breakpoints.sm, 10) - 1}px)`,
     /** Determines if the input device has the notion of hover, e.g. mouse. */
     hover: `not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)`,
   },

--- a/packages/palette/src/themes/v3.tsx
+++ b/packages/palette/src/themes/v3.tsx
@@ -83,9 +83,9 @@ export const THEME = {
   // Media queries to work with in web
   mediaQueries: {
     lg: `(min-width: ${breakpoints.lg})`,
-    md: `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1})`,
-    sm: `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1})`,
-    xs: `(max-width: ${parseInt(breakpoints.sm, 10) - 1})`,
+    md: `(min-width: ${breakpoints.md}) and (max-width: ${parseInt(breakpoints.lg, 10) - 1}px)`,
+    sm: `(min-width: ${breakpoints.sm}) and (max-width: ${parseInt(breakpoints.md, 10) - 1}px)`,
+    xs: `(max-width: ${parseInt(breakpoints.sm, 10) - 1}px)`,
     /** Determines if the input device has the notion of hover, e.g. mouse. */
     hover: `not all and (pointer: coarse), not all and (-moz-touch-enabled: 1)`,
   },


### PR DESCRIPTION
I noticed this while trying to use the `xs` media query inside of a styled-component using `themeGet`. The `media` util in Palette builds them but isn't theme-aware.

<del>Riddle me this: how is [this code working currently?](https://github.com/artsy/force/blob/5c79ce80607403c2e6e4de629500383d6ddcef59/src/v2/Components/NavBar/NavBar.tsx#L56-L57)</del> Answered my own question: it's not working currently 👅  and this should fix it.

### V2
![](https://static.damonzucconi.com/_capture/vrSEJoP6.png)

### V3
![](https://static.damonzucconi.com/_capture/PIfNZETj.png)