### PR TITLE
fix: protects against error on ssr

### DIFF
--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -10,8 +10,7 @@ export const WithCharacterCap = () => {
   return (
     <ReadMore
       maxChars={300}
-      content={
-        <div>
+      content={`<div>
           Donald Judd, widely regarded as one of the most significant American
           artists of <a href="#">the post-war period</a>, is perhaps best-known
           for the large-scale outdoor installations and long, spacious interiors
@@ -19,8 +18,7 @@ export const WithCharacterCap = () => {
           significant American artists of the post-war period, is perhaps
           best-known for the large-scale outdoor installations and long,
           spacious interiors he designed in Marfa.
-        </div>
-      }
+        </div>`}
     />
   )
 }
@@ -33,12 +31,10 @@ export const ShortContent = () => {
   return (
     <ReadMore
       maxChars={300}
-      content={
-        <div>
+      content={`<div>
           Donald Judd, widely regarded as one of the most significant American
           artists of <a href="#">the post-war period</a>.
-        </div>
-      }
+        </div>`}
     />
   )
 }
@@ -64,31 +60,27 @@ export const CharacterCapWithHtml = () => {
   return (
     <ReadMore
       maxChars={300}
-      content={
-        <>
-          <p>
-            Donald Judd, widely regarded as one of the most significant American
-            artists of <a href="#">the post-war period</a>, is perhaps
-            best-known for the large-scale outdoor installations and long,
-            spacious interiors he designed in Marfa. Donald Judd, widely
-            regarded as one of the most significant American artists of the
-            post-war period, is perhaps best-known for the large-scale outdoor
-            installations and long, spacious interiors he designed in Marfa.
-          </p>
-          <hr />
-          <p>
-            <strong>Lorem ipsum dolor</strong> sit amet consectetur adipisicing
-            elit. Ducimus eligendi obcaecati voluptate{" "}
-            <em>molestias vero nobis voluptatum</em>, tenetur dolorum assumenda.
-          </p>
-          <p>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis
-            eveniet aliquid laborum fugiat quibusdam id suscipit est temporibus
-            labore sint aliquam, laudantium tempore. Tenetur adipisci cumque
-            alias facilis animi. Illum.
-          </p>
-        </>
-      }
+      content={`<p>
+          Donald Judd, widely regarded as one of the most significant American
+          artists of <a href="#">the post-war period</a>, is perhaps
+          best-known for the large-scale outdoor installations and long,
+          spacious interiors he designed in Marfa. Donald Judd, widely
+          regarded as one of the most significant American artists of the
+          post-war period, is perhaps best-known for the large-scale outdoor
+          installations and long, spacious interiors he designed in Marfa.
+        </p>
+        <hr />
+        <p>
+          <strong>Lorem ipsum dolor</strong> sit amet consectetur adipisicing
+          elit. Ducimus eligendi obcaecati voluptate{" "}
+          <em>molestias vero nobis voluptatum</em>, tenetur dolorum assumenda.
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Debitis
+          eveniet aliquid laborum fugiat quibusdam id suscipit est temporibus
+          labore sint aliquam, laudantium tempore. Tenetur adipisci cumque
+          alias facilis animi. Illum.
+        </p>`}
     />
   )
 }
@@ -102,8 +94,7 @@ export const WithCustomizableTypography = () => {
     <HTML>
       <ReadMore
         maxChars={300}
-        content={
-          <>
+        content={`
             <p>
               Donald Judd, widely regarded as one of the most significant
               American artists of <a href="#">the post-war period</a>, is
@@ -125,9 +116,7 @@ export const WithCustomizableTypography = () => {
               eveniet aliquid laborum fugiat quibusdam id suscipit est
               temporibus labore sint aliquam, laudantium tempore. Tenetur
               adipisci cumque alias facilis animi. Illum.
-            </p>
-          </>
-        }
+            </p>`}
       />
     </HTML>
   )
@@ -142,9 +131,7 @@ export const WithCustomizableTypography2 = () => {
     <HTML variant="largeTitle">
       <ReadMore
         maxChars={300}
-        content={
-          <>
-            <p>
+        content={`<p>
               Donald Judd, widely regarded as one of the most significant
               American artists of <a href="#">the post-war period</a>, is
               perhaps best-known for the large-scale outdoor installations and
@@ -165,9 +152,7 @@ export const WithCustomizableTypography2 = () => {
               eveniet aliquid laborum fugiat quibusdam id suscipit est
               temporibus labore sint aliquam, laudantium tempore. Tenetur
               adipisci cumque alias facilis animi. Illum.
-            </p>
-          </>
-        }
+            </p>`}
       />
     </HTML>
   )
@@ -182,8 +167,7 @@ export const CharacterCapWithHtmlDisabled = () => {
     <ReadMore
       disabled
       maxChars={300}
-      content={
-        <div>
+      content={`<div>
           Donald Judd, widely regarded as one of the most significant American
           artists of <a href="#">the post-war period</a>, is perhaps best-known
           for the large-scale outdoor installations and long, spacious interiors
@@ -191,8 +175,7 @@ export const CharacterCapWithHtmlDisabled = () => {
           significant American artists of the post-war period, is perhaps
           best-known for the large-scale outdoor installations and long,
           spacious interiors he designed in Marfa.
-        </div>
-      }
+        </div>`}
     />
   )
 }

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo, useState } from "react"
-import { renderToStaticMarkup } from "react-dom/server"
+import React, { useState } from "react"
 import styled from "styled-components"
 import truncate from "trunc-html"
 import { Clickable, ClickableProps } from "../Clickable"
@@ -36,7 +35,7 @@ Container.displayName = "Container"
 const HTML_TAG_REGEX = /(<([^>]+)>)/gi
 
 export interface ReadMoreProps {
-  content: string | JSX.Element
+  content: string
   disabled?: boolean
   isExpanded?: boolean
   maxChars?: number
@@ -45,25 +44,15 @@ export interface ReadMoreProps {
 
 /** ReadMore */
 export const ReadMore: React.FC<ReadMoreProps> = ({
-  content,
+  content: expandedHTML,
   disabled,
   isExpanded,
   maxChars = Infinity,
   onReadMoreClicked,
 }) => {
-  const expandedHTML = useMemo(() => {
-    return typeof content === "string" ? content : renderToStaticMarkup(content)
-  }, [content])
+  const charCount = expandedHTML.replace(HTML_TAG_REGEX, "").length
 
-  const charCount = useMemo(
-    () => expandedHTML.replace(HTML_TAG_REGEX, "").length,
-    [expandedHTML]
-  )
-
-  const truncatedHTML = useMemo(() => truncate(expandedHTML, maxChars).html, [
-    expandedHTML,
-    maxChars,
-  ])
+  const truncatedHTML = truncate(expandedHTML, maxChars).html
 
   const [expanded, setExpanded] = useState(isExpanded || charCount < maxChars)
 


### PR DESCRIPTION
Re: https://github.com/artsy/force/pull/7289

Bug report here: https://github.com/facebook/react/issues/16416

I suspect this only surfaced when we upgraded React the other day but I'm not sure of that. Removing the memoization should fix.

We'll want to revert https://github.com/artsy/force/pull/7289 when this is released inside of Force.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.15.1-canary.901.16300.0
  # or 
  yarn add @artsy/palette@14.15.1-canary.901.16300.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
