### PR TITLE
bugfix: Ensure read more only operates on strings

### DIFF
--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -50,6 +50,9 @@ export const ReadMore: React.FC<ReadMoreProps> = ({
   maxChars = Infinity,
   onReadMoreClicked,
 }) => {
+  if (typeof expandedHTML !== "string") {
+    return null
+  }
   const charCount = expandedHTML.replace(HTML_TAG_REGEX, "").length
 
   const truncatedHTML = truncate(expandedHTML, maxChars).html

--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -9,15 +9,20 @@ describe("ReadMore", () => {
   const htmlCopy =
     "<p>Donald Judd <a>regarded as one of the most</a> significant American artists</p>"
 
+  it("returns null if no content provided", () => {
+    const wrapper = render(<ReadMore content={null} />)
+    expect(wrapper.html()).toBe(null)
+  })
+
   it("it truncates text", () => {
-    const wrapper = cap => render(<ReadMore maxChars={cap} content={copy} />)
+    const wrapper = (cap) => render(<ReadMore maxChars={cap} content={copy} />)
     expect(wrapper(20).html()).toContain(">Donald Judd …<")
     expect(wrapper(Infinity).html()).toContain(copy)
     expect(wrapper(undefined).html()).toContain(copy)
   })
 
   it("handles html including nested tags", () => {
-    const wrapper = cap =>
+    const wrapper = (cap) =>
       render(<ReadMore maxChars={cap} content={htmlCopy} />)
     expect(wrapper(30).html()).toContain(
       "<p>Donald Judd <a>regarded as one …</a></p>"


### PR DESCRIPTION
Makes it a little safer as we noticed it was blowing up in force when operating on null data. 