### PR TITLE
[v3] Pagination

### DIFF
--- a/packages/palette/src/elements/Link/Link.tsx
+++ b/packages/palette/src/elements/Link/Link.tsx
@@ -1,19 +1,11 @@
 import styled from "styled-components"
-import {
-  color as styledColor,
-  display,
-  DisplayProps,
-  position,
-  PositionProps,
-  space,
-  SpaceProps,
-} from "styled-system"
 import { color } from "../../helpers"
 import { Color } from "../../Theme"
+import { boxMixin, BoxProps } from "../Box"
 
 type UnderlineBehaviors = "default" | "hover" | "none"
 
-export interface LinkProps extends DisplayProps, PositionProps, SpaceProps {
+export interface LinkProps extends BoxProps {
   color?: Color
   hoverColor?: Color
   noUnderline?: boolean
@@ -37,21 +29,17 @@ const backwardsCompatCompute = (state: string, props: LinkProps) => {
 
 /**
  * Basic <a> tag styled with additional LinkProps
- * Spec: https://zpl.io/2Gm6D3d
  */
 export const Link = styled.a<LinkProps>`
   color: ${color("black100")};
   transition: color 0.25s;
-  text-decoration: ${props => backwardsCompatCompute("normal", props)};
+  text-decoration: ${(props) => backwardsCompatCompute("normal", props)};
   &:hover {
-    text-decoration: ${props => backwardsCompatCompute("hover", props)};
-    color: ${props =>
+    text-decoration: ${(props) => backwardsCompatCompute("hover", props)};
+    color: ${(props) =>
       props.hoverColor ? color(props.hoverColor) : color("black100")};
   }
-  ${display};
-  ${position};
-  ${space};
-  ${styledColor};
+  ${boxMixin};
 `
 
 Link.displayName = "Link"

--- a/packages/palette/src/elements/Link/Link.tsx
+++ b/packages/palette/src/elements/Link/Link.tsx
@@ -6,7 +6,6 @@ import { boxMixin, BoxProps } from "../Box"
 type UnderlineBehaviors = "default" | "hover" | "none"
 
 export interface LinkProps extends BoxProps {
-  color?: Color
   hoverColor?: Color
   noUnderline?: boolean
   underlineBehavior?: UnderlineBehaviors

--- a/packages/palette/src/elements/Pagination/Pagination.story.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.story.tsx
@@ -1,15 +1,14 @@
 import { action } from "@storybook/addon-actions"
 import React from "react"
-import { LargePagination } from "./LargePagination"
-import { SmallPagination } from "./SmallPagination"
+import { Pagination } from "./Pagination"
 
 export default {
   title: "Components/Pagination",
 }
 
-export const _LargePagination = () => {
+export const Default = () => {
   return (
-    <LargePagination
+    <Pagination
       hasNextPage
       pageCursors={{
         first: { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false },
@@ -34,37 +33,6 @@ export const _LargePagination = () => {
   )
 }
 
-_LargePagination.story = {
-  name: "LargePagination",
-}
-
-export const _SmallPagination = () => {
-  return (
-    <SmallPagination
-      hasNextPage
-      pageCursors={{
-        first: { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false },
-        last: { page: 20, cursor: "Y3Vyc29yMw==", isCurrent: false },
-        around: [
-          { page: 6, cursor: "Y3Vyc29yMw==", isCurrent: true },
-          { page: 7, cursor: "Y3Vyc29yMg==", isCurrent: false },
-          { page: 8, cursor: "Y3Vyc29yMw==", isCurrent: false },
-          { page: 9, cursor: "Y3Vyc29yMw==", isCurrent: false },
-        ],
-        previous: { page: 5, cursor: "Y3Vyc29yMw==", isCurrent: false },
-      }}
-      onClick={(cursor, page, event) => {
-        event.preventDefault()
-        action("onClick")(cursor, page, event)
-      }}
-      onNext={(event, ...rest) => {
-        event.preventDefault()
-        action("onNext")(event, ...rest)
-      }}
-    />
-  )
-}
-
-_SmallPagination.story = {
-  name: "SmallPagination",
+Default.story = {
+  name: "Pagination",
 }

--- a/packages/palette/src/elements/Pagination/Pagination.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.tsx
@@ -1,10 +1,9 @@
 import React from "react"
 import { ChevronIcon } from "../../svgs/ChevronIcon"
 import { useThemeConfig } from "../../Theme"
-import { Box, BoxProps } from "../Box"
 import { Flex, FlexProps } from "../Flex"
 import { Link, LinkProps } from "../Link"
-import { Text } from "../Text"
+import { Text, TextVariant } from "../Text"
 
 interface PageCursor {
   cursor: string
@@ -28,8 +27,8 @@ export interface PaginationProps extends FlexProps {
   scrollTo?: string
 }
 
-/** LargePagination */
-export const LargePagination: React.FC<PaginationProps> = ({
+/** Pagination */
+export const Pagination: React.FC<PaginationProps> = ({
   getHref,
   hasNextPage,
   onClick,
@@ -37,6 +36,27 @@ export const LargePagination: React.FC<PaginationProps> = ({
   pageCursors: { around, first, last, previous },
   ...rest
 }) => {
+  const tokens = useThemeConfig({
+    v2: {
+      order: { pages: 1, prev: 2, next: 3 },
+      textVariant: "mediumText" as TextVariant,
+      containerProps: {
+        flexDirection: "row",
+        justifyContent: "flex-end",
+        mr: -1,
+      } as FlexProps,
+      pagesProps: { pr: 4 },
+      ellipsisProps: { color: "black30" },
+    },
+    v3: {
+      order: { prev: 1, pages: 2, next: 3 },
+      textVariant: "sm" as TextVariant,
+      containerProps: { justifyContent: "space-between" },
+      pagesProps: {},
+      ellipsisProps: { color: "black60" },
+    },
+  })
+
   const handlePrevClick = (event: React.MouseEvent) => {
     if (previous) {
       onClick(previous.cursor, previous.page, event)
@@ -49,38 +69,22 @@ export const LargePagination: React.FC<PaginationProps> = ({
 
   const nextPage = (previous?.page || 0) + 2
 
-  const tokens = useThemeConfig({
-    v2: {
-      flexProps: {
-        flexDirection: "row",
-        justifyContent: "flex-end",
-        mr: -1,
-      } as FlexProps,
-      order: {
-        pages: 1,
-        prev: 2,
-        next: 3,
-      },
-    },
-    v3: {
-      flexProps: {
-        justifyContent: "space-between",
-      },
-      order: {
-        prev: 1,
-        pages: 2,
-        next: 3,
-      },
-    },
-  })
-
   return (
-    <Flex alignItems="center" {...tokens.flexProps} {...rest}>
-      <Flex order={tokens.order.pages}>
+    <Text
+      display="flex"
+      variant={tokens.textVariant}
+      lineHeight={1}
+      alignItems="center"
+      {...tokens.containerProps}
+      {...rest}
+    >
+      <Flex order={tokens.order.pages} {...tokens.pagesProps}>
         {first && (
           <>
             <Page onClick={onClick} pageCursor={first} getHref={getHref} />
-            <Ellipsis />
+            <Flex alignItems="center" p={0.5} {...tokens.ellipsisProps}>
+              …
+            </Flex>
           </>
         )}
 
@@ -97,28 +101,40 @@ export const LargePagination: React.FC<PaginationProps> = ({
 
         {last && (
           <>
-            <Ellipsis />
+            <Flex alignItems="center" p={0.5} {...tokens.ellipsisProps}>
+              …
+            </Flex>
             <Page onClick={onClick} pageCursor={last} getHref={getHref} />
           </>
         )}
       </Flex>
 
-      <PrevButton
+      <NextPrevButton
+        data-testid="prev"
         order={tokens.order.prev}
         enabled={!!previous}
         getHref={getHref}
         onClick={handlePrevClick}
         page={previous?.page}
-      />
+      >
+        <ChevronIcon pr={0.5} direction="left" height={12} />
 
-      <NextButton
+        <span>Previous</span>
+      </NextPrevButton>
+
+      <NextPrevButton
+        data-testid="next"
         order={tokens.order.next}
         enabled={hasNextPage}
         getHref={getHref}
         onClick={handleNextClick}
         page={nextPage}
-      />
-    </Flex>
+      >
+        <span>Next</span>
+
+        <ChevronIcon pl={0.5} direction="right" height={12} />
+      </NextPrevButton>
+    </Text>
   )
 }
 
@@ -134,6 +150,21 @@ const Page: React.FC<PageProps> = ({
   pageCursor: { cursor, isCurrent, page },
   ...rest
 }) => {
+  const tokens = useThemeConfig({
+    v2: {
+      states: {
+        inactive: { bg: "transparent" },
+        active: { bg: "black5" },
+      },
+    },
+    v3: {
+      states: {
+        inactive: { color: "black60" },
+        active: { color: "black100" },
+      },
+    },
+  })
+
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
@@ -148,31 +179,30 @@ const Page: React.FC<PageProps> = ({
       onClick={handleClick}
       underlineBehavior="hover"
       borderRadius={2}
-      px={0.5}
       display="flex"
       alignItems="center"
-      bg={isCurrent ? "black5" : "white100"}
+      p={0.5}
+      {...(isCurrent ? tokens.states.active : tokens.states.inactive)}
       {...rest}
     >
-      <Text lineHeight={1} variant="mediumText">
-        {page}
-      </Text>
+      {page}
     </Link>
   )
 }
 
-export interface PageButtonProps extends LinkProps {
+export interface NextPrevButtonProps extends LinkProps {
   enabled: boolean
   getHref?: (page: number) => string
   onClick: (event: React.MouseEvent) => void
   page?: number
 }
 
-const PrevButton: React.FC<PageButtonProps> = ({
+const NextPrevButton: React.FC<NextPrevButtonProps> = ({
   enabled,
   getHref,
   onClick,
   page,
+  children,
   ...rest
 }) => {
   const href =
@@ -185,6 +215,7 @@ const PrevButton: React.FC<PageButtonProps> = ({
       underlineBehavior="hover"
       display="flex"
       alignItems="center"
+      p={0.5}
       style={
         enabled
           ? {
@@ -198,58 +229,13 @@ const PrevButton: React.FC<PageButtonProps> = ({
       }
       {...rest}
     >
-      <ChevronIcon direction="left" height={12} />
-
-      <Text lineHeight={1} px={0.5} variant="mediumText">
-        Prev
-      </Text>
+      {children}
     </Link>
   )
 }
 
-const NextButton: React.FC<PageButtonProps> = ({
-  enabled,
-  getHref,
-  onClick,
-  page,
-  ...rest
-}) => {
-  const href =
-    enabled && page && typeof getHref !== "undefined" ? getHref(page) : ""
-
-  return (
-    <Link
-      href={href}
-      onClick={onClick}
-      underlineBehavior="hover"
-      display="flex"
-      alignItems="center"
-      style={
-        enabled
-          ? {
-              opacity: 1,
-              pointerEvents: "inherit",
-            }
-          : {
-              opacity: 0.1,
-              pointerEvents: "none",
-            }
-      }
-      {...rest}
-    >
-      <Text lineHeight={1} px={0.5} variant="mediumText">
-        Next
-      </Text>
-
-      <ChevronIcon direction="right" height={12} />
-    </Link>
-  )
-}
-
-const Ellipsis: React.FC = () => {
-  return (
-    <Text lineHeight={1} color="black30" mx={0.5} variant="mediumText">
-      …
-    </Text>
-  )
-}
+/**
+ * Alias of Pagination
+ * @deprecated Use `Pagination`
+ */
+export const LargePagination = Pagination

--- a/packages/palette/src/elements/Pagination/SmallPagination.tsx
+++ b/packages/palette/src/elements/Pagination/SmallPagination.tsx
@@ -4,10 +4,12 @@ import { ChevronIcon } from "../../svgs/ChevronIcon"
 import { BorderBox } from "../BorderBox"
 import { Flex } from "../Flex"
 import { Link } from "../Link"
+import { NextPrevButtonProps, PaginationProps } from "./Pagination"
 
-import { PageButton, PaginationProps } from "./LargePagination"
-
-/** SmallPagination */
+/**
+ * SmallPagination
+ * @deprecated Use Pagination
+ */
 export const SmallPagination: React.FC<PaginationProps> = (props) => {
   const {
     pageCursors: { previous },
@@ -64,7 +66,7 @@ const Wrapper = styled(BorderBox)`
   }
 `
 
-const PrevButton: React.FC<PageButton> = (props) => {
+const PrevButton: React.FC<NextPrevButtonProps> = (props) => {
   const { enabled, getHref, onClick, page } = props
   const opacity = enabled ? 1 : 0.1
   let href = ""
@@ -84,7 +86,7 @@ const PrevButton: React.FC<PageButton> = (props) => {
   )
 }
 
-const NextButton: React.FC<PageButton> = (props) => {
+const NextButton: React.FC<NextPrevButtonProps> = (props) => {
   const { enabled, getHref, onClick, page } = props
   const opacity = enabled ? 1 : 0.1
   let href = ""

--- a/packages/palette/src/elements/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/Pagination.test.tsx
@@ -1,9 +1,9 @@
 import { mount } from "enzyme"
 import React from "react"
 import { Theme } from "../../../Theme"
-import { LargePagination } from "../LargePagination"
+import { Pagination } from "../Pagination"
 
-const mockGetHref = page => {
+const mockGetHref = (page) => {
   const baseUrl = "http://www.example.com"
 
   if (page > 1) {
@@ -13,7 +13,7 @@ const mockGetHref = page => {
   }
 }
 
-describe("LargePagination", () => {
+describe("Pagination", () => {
   const first = { page: 1, cursor: "Y3Vyc29yMg==", isCurrent: false }
   const last = { page: 20, cursor: "Y3Vyc29yMw==", isCurrent: false }
   const around = [
@@ -37,13 +37,13 @@ describe("LargePagination", () => {
     onClick: onClickMock,
     onNext: onNextMock,
     pageCursors,
-    getHref: x => x,
+    getHref: (x) => x,
   }
 
   const mountWrapper = (passedProps = {}) => {
     const wrapper = mount(
       <Theme>
-        <LargePagination {...props} {...passedProps} />
+        <Pagination {...props} {...passedProps} />
       </Theme>
     )
 
@@ -72,10 +72,10 @@ describe("LargePagination", () => {
         },
       })
 
-      const prevButton = wrapper.find("PrevButton")
+      const prevButton = wrapper.find("[data-testid='prev']").first()
       expect(prevButton.find("Link").prop("href")).toEqual("")
 
-      const nextButton = wrapper.find("NextButton")
+      const nextButton = wrapper.find("[data-testid='next']").first()
       expect(nextButton.find("Link").prop("href")).toMatch("page=2")
     })
 
@@ -89,12 +89,12 @@ describe("LargePagination", () => {
         },
       })
 
-      const prevButton = wrapper.find("PrevButton")
+      const prevButton = wrapper.find("[data-testid='prev']").first()
       expect(prevButton.find("Link").prop("href")).toEqual(
         "http://www.example.com"
       )
 
-      const nextButton = wrapper.find("NextButton")
+      const nextButton = wrapper.find("[data-testid='next']").first()
       expect(nextButton.find("Link").prop("href")).toMatch("page=3")
     })
 
@@ -108,10 +108,10 @@ describe("LargePagination", () => {
         },
       })
 
-      const prevButton = wrapper.find("PrevButton")
+      const prevButton = wrapper.find("[data-testid='prev']").first()
       expect(prevButton.find("Link").prop("href")).toMatch("page=2")
 
-      const nextButton = wrapper.find("NextButton")
+      const nextButton = wrapper.find("[data-testid='next']").first()
       expect(nextButton.prop("enabled")).toEqual(false)
       expect(nextButton.find("Link").prop("href")).toEqual("")
     })
@@ -129,13 +129,10 @@ describe("LargePagination", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
         const pages = ["6", "7", "8", "9"]
-        pages.forEach(page => {
+        pages.forEach((page) => {
           expect(html).toContain(`>${page}<`)
         })
-        wrapper
-          .find("Link")
-          .first()
-          .simulate("click")
+        wrapper.find("Link").first().simulate("click")
         expect(onClickMock).toHaveBeenCalled()
       })
     })
@@ -150,8 +147,8 @@ describe("LargePagination", () => {
       it("skips rendering the first page and dot dot dot", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
-        const pages = ["6", "7", "8", "9", "...", "20"]
-        pages.forEach(page => {
+        const pages = ["6", "7", "8", "9", "…", "20"]
+        pages.forEach((page) => {
           expect(html).toContain(`>${page}<`)
         })
       })
@@ -167,8 +164,8 @@ describe("LargePagination", () => {
       it("skips rendering the last page and dot dot dot", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
-        const pages = ["1", "...", "6", "7", "8", "9"]
-        pages.forEach(page => {
+        const pages = ["1", "…", "6", "7", "8", "9"]
+        pages.forEach((page) => {
           expect(html).toContain(`>${page}<`)
         })
       })
@@ -184,8 +181,8 @@ describe("LargePagination", () => {
       it("renders the first, last and dot dot dots plus around pages", () => {
         const wrapper = mountWrapper()
         const html = wrapper.html()
-        const pages = ["1", "...", "6", "7", "8", "9", "...", "20"]
-        pages.forEach(page => {
+        const pages = ["1", "…", "6", "7", "8", "9", "…", "20"]
+        pages.forEach((page) => {
           expect(html).toContain(`>${page}<`)
         })
       })
@@ -201,7 +198,7 @@ describe("LargePagination", () => {
 
       it("renders the previous button and calls the onClick function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("PrevButton").simulate("click")
+        wrapper.find("[data-testid='prev']").first().simulate("click")
         expect(onClickMock).toHaveBeenCalled()
         expect(onClickMock).toHaveBeenCalledWith(
           "Y3Vyc29yMw==",
@@ -212,7 +209,7 @@ describe("LargePagination", () => {
 
       it("renders the next button as disabled and calls the onNext function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("NextButton").simulate("click")
+        wrapper.find("[data-testid='next']").first().simulate("click")
         expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 7)
       })
     })
@@ -225,13 +222,13 @@ describe("LargePagination", () => {
 
       it("renders the previous button as disabled and does not call the onClick function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("PrevButton").simulate("click")
+        wrapper.find("[data-testid='prev']").first().simulate("click")
         expect(onClickMock).not.toHaveBeenCalled()
       })
 
       it("renders the next button and calls the onNext function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("NextButton").simulate("click")
+        wrapper.find("[data-testid='next']").first().simulate("click")
         expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 2)
       })
     })
@@ -244,7 +241,7 @@ describe("LargePagination", () => {
 
       it("renders the previous button and calls the onClick function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("PrevButton").simulate("click")
+        wrapper.find("[data-testid='prev']").first().simulate("click")
         expect(onClickMock).toHaveBeenCalledWith(
           "Y3Vyc29yMw==",
           5,
@@ -254,7 +251,7 @@ describe("LargePagination", () => {
 
       it("renders the next button and calls the onNext function when clicked", () => {
         const wrapper = mountWrapper()
-        wrapper.find("NextButton").simulate("click")
+        wrapper.find("[data-testid='next']").first().simulate("click")
         expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 7)
       })
     })

--- a/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
@@ -1,10 +1,10 @@
 import { mount } from "enzyme"
 import React from "react"
 import { Theme } from "../../../Theme"
-import { PageCursors } from "../LargePagination"
+import { PageCursors } from "../Pagination"
 import { SmallPagination } from "../SmallPagination"
 
-const mockGetHref = page => {
+const mockGetHref = (page) => {
   const baseUrl = "http://www.example.com"
 
   if (page > 1) {

--- a/packages/palette/src/elements/Pagination/index.tsx
+++ b/packages/palette/src/elements/Pagination/index.tsx
@@ -1,2 +1,2 @@
-export * from "./LargePagination"
+export * from "./Pagination"
 export * from "./SmallPagination"


### PR DESCRIPTION
V2 remains basically the same. I cleaned up some alignment issues and deprecated `SmallPagination` — moved `LargePagination` to just `Pagination` and deprecated the alias. Shouldn't be any breaking changes unless some specs reach into the buttons (possible...) — Will check that out with the canary before merging.

### V2
![](https://static.damonzucconi.com/_capture/WxiPwxaQ.png)

### V3
![](https://static.damonzucconi.com/_capture/Loe5vEPx.png)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.17.2-canary.906.16421.0
  # or 
  yarn add @artsy/palette@14.17.2-canary.906.16421.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
