### PR TITLE
feat: Add showProgress prop to Shelf

### DIFF
--- a/packages/palette/src/elements/Shelf/Shelf.story.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.story.tsx
@@ -41,3 +41,23 @@ export const Default = () => {
     </Box>
   )
 }
+
+export const CenterAlign = () => {
+  return (
+    <Box maxWidth={1920} mx="auto">
+      <Box mx={[2, 4]}>
+        <Demo alignItems="center" />
+      </Box>
+    </Box>
+  )
+}
+
+export const HideProgressBar = () => {
+  return (
+    <Box maxWidth={1920} mx="auto">
+      <Box mx={[2, 4]}>
+        <Demo showProgress={false} />
+      </Box>
+    </Box>
+  )
+}

--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -23,6 +23,7 @@ import { FullBleed } from "../FullBleed"
 /** ShelfProps */
 export type ShelfProps = BoxProps & {
   alignItems?: FlexProps["alignItems"]
+  showProgress?: boolean
   snap?: "none" | "start" | "end" | "center"
   children: JSX.Element | JSX.Element[]
   onChange?(index: number): void
@@ -33,6 +34,7 @@ export type ShelfProps = BoxProps & {
  */
 export const Shelf: React.FC<ShelfProps> = ({
   alignItems = "flex-end",
+  showProgress = true,
   snap = "none",
   children,
   onChange,
@@ -210,7 +212,7 @@ export const Shelf: React.FC<ShelfProps> = ({
         </Viewport>
       </FullBleed>
 
-      <CarouselBar mt={2} percentComplete={progress} />
+      {showProgress && <CarouselBar mt={2} percentComplete={progress} />}
     </Container>
   )
 }


### PR DESCRIPTION
Adds a new `showProgress` prop to Shelf, so that one can show / hide the progress bar. This makes shelf a more generic `Carousel` component. Also updates stories. 

![shelf](https://user-images.githubusercontent.com/236943/117377698-b88d8600-ae88-11eb-9319-e761029ddab4.gif)
