### PR TITLE
fix: Increase scroll bar space

### DIFF
--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -212,7 +212,7 @@ export const Shelf: React.FC<ShelfProps> = ({
         </Viewport>
       </FullBleed>
 
-      {showProgress && <CarouselBar mt={2} percentComplete={progress} />}
+      {showProgress && <CarouselBar mt={6} percentComplete={progress} />}
     </Container>
   )
 }


### PR DESCRIPTION
The spacing was a bit too tight between the shelf items and the progress bar, per the comps. Increased it to a 6: 

<img width="489" alt="Screen Shot 2021-05-06 at 5 35 27 PM" src="https://user-images.githubusercontent.com/236943/117381733-9e0bda80-ae91-11eb-8853-f2763d0477a4.png">
