### PR TITLE
fix: [Shelf] Dont show arrows if on touch device

### DIFF
--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -304,6 +304,10 @@ const Arrow = styled(Clickable)`
     opacity: 0;
     cursor: default;
   }
+
+  @media (hover: none) {
+    display: none;
+  }
 `
 
 const Next = styled(Arrow)`


### PR DESCRIPTION
Noticed that arrows would appear when interacting on phone 