### PR TITLE
fix(shelf): smoother progress

### DIFF
--- a/packages/palette/src/elements/ProgressBar/ProgressBar.tsx
+++ b/packages/palette/src/elements/ProgressBar/ProgressBar.tsx
@@ -42,6 +42,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
         style={{
           transition,
           transform: `translateX(-${100 - percentComplete}%)`,
+          backfaceVisibility: "hidden",
         }}
       />
     </Box>

--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -120,7 +120,8 @@ export const Shelf: React.FC<ShelfProps> = ({
 
       // Sets a synthetic value between 0 and 100
       setProgress(
-        Math.ceil((viewport.scrollLeft * 100) / (pages[pages.length - 1] - 1))
+        (viewport.scrollLeft / (viewport.scrollWidth - viewport.clientWidth)) *
+          100
       )
     }
 
@@ -212,7 +213,9 @@ export const Shelf: React.FC<ShelfProps> = ({
         </Viewport>
       </FullBleed>
 
-      {showProgress && <CarouselBar mt={6} percentComplete={progress} />}
+      {showProgress && (
+        <CarouselBar mt={6} transition="none" percentComplete={progress} />
+      )}
     </Container>
   )
 }


### PR DESCRIPTION
Quick little fix to just tie the progress directly to scroll. I think I was stuck in thinking about this from the cell-based older components.