### PR TITLE
fix(button): improves vertical centering in some situations

### DIFF
--- a/packages/palette/src/elements/Button/v3/Button.tsx
+++ b/packages/palette/src/elements/Button/v3/Button.tsx
@@ -44,7 +44,7 @@ export const ButtonV3: React.FC<ButtonProps> = ({
       {loading && <Spinner size={size} color="currentColor" />}
 
       <Text
-        pt="1px"
+        lineHeight={1}
         variant={BUTTON_TEXT_SIZES[size]}
         opacity={loading ? 0 : 1}
       >


### PR DESCRIPTION
That `1px` was a hold-over from the original implementation — I think it was a hack to fix the vertical centering in a few spots. Occasionally on 1x DPI screens the text is still 1px off (when the parent is also vertically centering, depending on its location on the page). This _should_ be the correct fix for that. We never have 2-line buttons so this should be fine to do. Publishing a canary to double check before merging.