### PR TITLE
Loosen tab types to allow null, undefined

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -22,7 +22,7 @@ export interface TabInfo extends TabProps {
 }
 
 export interface TabsProps extends BaseTabsProps {
-  children: TabLike[]
+  children: Array<TabLike | null | undefined>
   /** Space or visual divider between tabs */
   separator?: JSX.Element
   /** Index of the Tab that should be pre-selected */


### PR DESCRIPTION
In trying to get https://github.com/artsy/force/pull/7514 over the finish line, I'm running up against some frustrating type failures. 

```
src/v2/Apps/Artwork/Components/ArtworkDetails/index.tsx:72:11 - error TS2322: Type 'undefined' is not assignable to type 'TabLike & ReactNode'.

72           {/* @ts-expect-error STRICT_NULL_CHECK */}
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Evidently JSX comments can be interpreted as undefined. Also, statements that don't correctly evaluate could return null-ish which is its own issue. 

Loosening the types here will hopefully help resolve that. 