### PR TITLE
[wip]: implements shelf scrollbar

### DIFF
--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -15,10 +15,10 @@ import { visuallyDisableScrollbar } from "../../helpers/visuallyDisableScrollbar
 import { ChevronIcon } from "../../svgs"
 import { Box, BoxProps } from "../Box"
 import { CELL_GAP_PADDING_AMOUNT, paginateCarousel } from "../Carousel"
-import { CarouselBar } from "../CarouselBar"
 import { Clickable } from "../Clickable"
 import { FlexProps } from "../Flex"
 import { FullBleed } from "../FullBleed"
+import { ShelfScrollMirror } from "./ShelfScrollMirror"
 
 /** ShelfProps */
 export type ShelfProps = BoxProps & {
@@ -53,7 +53,6 @@ export const Shelf: React.FC<ShelfProps> = ({
 
   const [mounted, setMounted] = useState(false)
   const [pages, setPages] = useState([0])
-  const [progress, setProgress] = useState(0)
   const [offset, setOffset] = useState(0)
 
   const init = useCallback(() => {
@@ -117,12 +116,6 @@ export const Shelf: React.FC<ShelfProps> = ({
       })
 
       setCursor(pages.indexOf(nearestPage))
-
-      // Sets a synthetic value between 0 and 100
-      setProgress(
-        (viewport.scrollLeft / (viewport.scrollWidth - viewport.clientWidth)) *
-          100
-      )
     }
 
     viewport.addEventListener("scroll", handler, { passive: true })
@@ -200,7 +193,7 @@ export const Shelf: React.FC<ShelfProps> = ({
         {...(!mounted ? { left: null, right: null, marginLeft: null } : {})}
       >
         <Viewport ref={viewportRef as any}>
-          <Rail as="ul" position="relative" alignItems={alignItems}>
+          <Rail as="ul" position="relative" alignItems={alignItems} mb={6}>
             {cells.map(({ child, ref }, i) => {
               const isFirst = i === 0
               const isLast = i === cells.length - 1
@@ -222,9 +215,7 @@ export const Shelf: React.FC<ShelfProps> = ({
         </Viewport>
       </FullBleed>
 
-      {showProgress && (
-        <CarouselBar mt={6} transition="none" percentComplete={progress} />
-      )}
+      {showProgress && <ShelfScrollMirror viewport={viewportRef.current} />}
     </Container>
   )
 }
@@ -273,11 +264,12 @@ const Rail = styled(Box)`
   display: flex;
   width: 100%;
   height: 100%;
-  margin: 0;
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
   padding: 0;
   list-style: none;
   white-space: nowrap;
-  align-items: ${(p) => p.alignItems};
 `
 
 const Cell = styled(Box)`

--- a/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
+++ b/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
@@ -1,0 +1,68 @@
+import React, { useRef } from "react"
+import { Box, BoxProps } from "../Box"
+import { Clickable } from "../Clickable"
+
+interface ShelfScrollBarProps extends BoxProps {
+  viewport: HTMLDivElement
+}
+
+export const ShelfScrollBar: React.FC<ShelfScrollBarProps> = ({
+  viewport,
+  ...rest
+}) => {
+  const { scrollLeft, scrollWidth, clientWidth } = viewport
+
+  const trackRef = useRef<HTMLDivElement | null>(null)
+
+  const progress = (scrollLeft / (scrollWidth - clientWidth)) * 100
+
+  // Set up a scrollbar for viewport
+  const percentageVisible = clientWidth / scrollWidth
+  const thumbWidth = percentageVisible * clientWidth
+  const percentageOffset = scrollLeft / (scrollWidth - clientWidth)
+
+  // Transform it down to whatever our actual track width is as
+  // it's always smaller than the target viewport.
+  const trackWidth = trackRef.current?.clientWidth ?? 1
+  const normalizedThumbWidth = (thumbWidth * trackWidth) / clientWidth
+  const normalizedThumbOffset =
+    percentageOffset * (trackWidth - normalizedThumbWidth)
+
+  return (
+    <>
+      {/* Track */}
+      <Box
+        ref={trackRef as any}
+        height={3}
+        bg="black15"
+        width="100%"
+        role="scrollbar"
+        aria-orientation="vertical"
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={progress}
+        {...rest}
+      >
+        {/* Handle */}
+        <Box
+          position="relative"
+          bg="black60"
+          height="100%"
+          borderRadius={3}
+          width={normalizedThumbWidth}
+          style={{ transform: `translateX(${normalizedThumbOffset}px)` }}
+        >
+          {/* Hit-area */}
+          <Clickable
+            // bg="rgba(255,0,0,0.5)"
+            position="absolute"
+            top={-10}
+            bottom={-10}
+            left={0}
+            width="100%"
+          />
+        </Box>
+      </Box>
+    </>
+  )
+}

--- a/packages/palette/src/elements/Shelf/ShelfScrollMirror.tsx
+++ b/packages/palette/src/elements/Shelf/ShelfScrollMirror.tsx
@@ -1,0 +1,91 @@
+import { themeGet } from "@styled-system/theme-get"
+import React, { useEffect, useRef } from "react"
+import styled from "styled-components"
+import { Box, BoxProps } from "../Box"
+
+interface ShelfScrollMirrorProps extends BoxProps {
+  viewport?: HTMLDivElement | null
+}
+
+export const ShelfScrollMirror: React.FC<ShelfScrollMirrorProps> = ({
+  viewport,
+  ...rest
+}) => {
+  const trackRef = useRef<HTMLDivElement | null>(null)
+
+  const ignoreScrollEvents = useRef(false)
+
+  const syncScrollPosition = (scrolledNode: HTMLElement, node: HTMLElement) => {
+    const handleScroll = () => {
+      const ignore = ignoreScrollEvents.current
+      ignoreScrollEvents.current = false
+      if (ignore) return
+      ignoreScrollEvents.current = true
+
+      const { scrollLeft, scrollWidth, clientWidth } = scrolledNode
+
+      // Percentage of scrolling of the scrolledNode
+      const percentagePerWidth = scrollLeft / (scrollWidth - clientWidth)
+
+      node.scrollLeft =
+        percentagePerWidth * (node.scrollWidth - node.clientWidth)
+    }
+
+    scrolledNode.addEventListener("scroll", handleScroll)
+
+    return () => {
+      scrolledNode.removeEventListener("scroll", handleScroll)
+    }
+  }
+
+  useEffect(() => {
+    if (!viewport || !trackRef.current) return
+    const { current: track } = trackRef
+
+    const teardown1 = syncScrollPosition(viewport, track)
+    const teardown2 = syncScrollPosition(track, viewport)
+
+    return () => {
+      teardown1()
+      teardown2()
+    }
+  }, [syncScrollPosition])
+
+  return (
+    <Track
+      ref={trackRef as any}
+      width="100%"
+      height={3}
+      bg="black15"
+      overflowX="scroll"
+      {...rest}
+    >
+      {/* Overflow the track to the same width as the viewport */}
+      <Box width={viewport?.scrollWidth} height="1px" />
+    </Track>
+  )
+}
+
+const Track = styled(Box)`
+  ::-webkit-scrollbar {
+    height: 3px;
+  }
+
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-track-piece {
+    background-color: ${themeGet("colors.black15")};
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: ${themeGet("colors.black60")};
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: ${themeGet("colors.black100")};
+  }
+
+  /* TODO: Figure out how to disable this in Safari */
+  /* ::-webkit-scrollbar-corner {
+    background-color: ${themeGet("colors.black15")};
+  } */
+`


### PR DESCRIPTION
Opening a draft here to publish a canary and check this out in context and to hash out the direction.

So what `ShelfScrollMirror` does is: accepts a viewport (the parent of the rail in the carousel), then creates a new div, overflows it to the same width, then keeps the scroll positions of either in sync with one another. So when you scroll when the other moves accordingly and vice versa. The benefit of this is that it lets us decouple the scrollbar from the scrollable viewport (so that it doesn't have to be the same width). Then I'm using some CSS to customize how the scrollbar looks. This is where we start running into caveats.

* Chrome works perfectly, of course
* Firefox claims to support scrollbar CSS now but I can't get it to work yet. Need to research that a bit more. On Firefox this doesn't look terrible and at least works as a scrollbar. But it's not to spec. I've got some last resort ideas to hack around that.
* Safari works almost perfectly — there's a `scrollbar-corner` that doesn't do anything in this case occupying like ~20px on the right hand side of the scrollbar. Once you start to style it it shows up in Chrome too. My thinking is that I can style it then just offset the div to hide it.
* We probably want a bigger hit area. Can just make the scrollbar bigger then position a `pointer-events: none` cover over part of it to hide it. Transforming that could give us the animated transition you mentioned in chat @damassi.

Some of the benefits of this approach are:
* it's a native scrollbar so it works exactly how you'd expect it to
* aside from any CSS hacks; it's really simple
* since everything is happening in the DOM, no React renders need to happen

I left what I initially started with `ShelfScrollBar` in here for now. We'd have to implement the drag scrolling and click to scroll on the track etc. Probably not the worst thing in the world but before I ran into the cross-browser CSS caveats I thought I was a genius.

------

### Chrome

https://user-images.githubusercontent.com/112297/118828841-9f72d500-b88b-11eb-85db-9d5ad67ff2ae.mov

### Firefox

https://user-images.githubusercontent.com/112297/118829041-c9c49280-b88b-11eb-9d51-33e5fcb17f30.mov

### Safari

https://user-images.githubusercontent.com/112297/118829188-e4970700-b88b-11eb-91ef-9c13932b79a7.mov


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.29.1-canary.934.17174.0
  # or 
  yarn add @artsy/palette@14.29.1-canary.934.17174.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
