### PR TITLE
fix: Small card images width

### DIFF
--- a/packages/palette/src/elements/Cards/SmallCard.tsx
+++ b/packages/palette/src/elements/Cards/SmallCard.tsx
@@ -16,7 +16,7 @@ export interface SmallCardProps extends BoxProps {
 }
 
 const isArrayOfStrings = (images: Images): images is string[] =>
-  [...images].every(src => typeof src === "string")
+  [...images].every((src) => typeof src === "string")
 
 /**
  * `SmallCard` is a card with a layout one square image on the left,
@@ -31,7 +31,7 @@ export const SmallCard: React.FC<SmallCardProps> = ({
   ...rest
 }) => {
   const imageAttributes: WebImageProps[] = isArrayOfStrings(images)
-    ? images.map(src => ({ src }))
+    ? images.map((src) => ({ src }))
     : images
 
   return (
@@ -50,7 +50,7 @@ export const SmallCard: React.FC<SmallCardProps> = ({
             <Image
               alt={title}
               height="100%"
-              width="auto"
+              width="100%"
               {...imageAttributes[0]}
             />
           </Box>
@@ -76,7 +76,7 @@ export const SmallCard: React.FC<SmallCardProps> = ({
                 <Image
                   alt={title}
                   height="100%"
-                  width="auto"
+                  width={!!images[2] ? "100%" : "auto"}
                   {...imageAttributes[1]}
                 />
               </Box>
@@ -93,7 +93,7 @@ export const SmallCard: React.FC<SmallCardProps> = ({
                 <Image
                   alt={title}
                   height="100%"
-                  width="auto"
+                  width="100%"
                   {...imageAttributes[2]}
                 />
               </Box>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-2988

On Safari images were rendered with incorrect aspect ratio:

![Screen Shot 2021-06-04 at 10 37 14 AM](https://user-images.githubusercontent.com/44819355/120764752-27f6a400-c521-11eb-909c-076d403b4666.png)
![Screen Shot 2021-06-04 at 10 37 27 AM](https://user-images.githubusercontent.com/44819355/120764755-2927d100-c521-11eb-8dde-8ea3f572211e.png)
![Screen Shot 2021-06-04 at 10 37 37 AM](https://user-images.githubusercontent.com/44819355/120764759-2af19480-c521-11eb-8056-ed26e8dac2ba.png)

After fixing it looks like this:

![Screen Shot 2021-06-04 at 10 37 49 AM](https://user-images.githubusercontent.com/44819355/120764826-3cd33780-c521-11eb-8367-0c0bc4b8fc67.png)
![Screen Shot 2021-06-04 at 10 38 04 AM](https://user-images.githubusercontent.com/44819355/120764832-3e9cfb00-c521-11eb-915e-e007ba8ed76d.png)
![Screen Shot 2021-06-04 at 10 38 12 AM](https://user-images.githubusercontent.com/44819355/120764838-3fce2800-c521-11eb-9352-ff734eb64aff.png)
