### PR TITLE
fix(radio): allows for custom labels to occupy immediate container

### DIFF
--- a/packages/palette/src/elements/Radio/Radio.story.tsx
+++ b/packages/palette/src/elements/Radio/Radio.story.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { States } from "storybook-states"
+import { Flex } from "../Flex"
 import { Text } from "../Text"
 import { Radio, RadioProps } from "./Radio"
 
@@ -27,10 +28,24 @@ export const Default = () => {
             </Text>
           ),
         },
-        { label: <Text variant="subtitle">Large Custom Label</Text> },
+        { label: <Text variant="lg">Large Custom Label</Text> },
       ]}
     >
       <Radio>A label</Radio>
     </States>
+  )
+}
+
+export const SplitLabel = () => {
+  return (
+    <Radio>
+      <Flex justifyContent="space-between" flex={1}>
+        <Text variant="lg">Label</Text>
+
+        <Text variant="xs" color="black60">
+          Subtitle
+        </Text>
+      </Flex>
+    </Radio>
   )
 }

--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -98,7 +98,7 @@ export const Radio: React.FC<RadioProps> = ({
         mr={1}
       />
 
-      <Flex flexDirection="column">
+      <Flex flexDirection="column" flex={1}>
         <Flex alignItems="center" flex={1}>
           {isText(title) ? (
             <Text


### PR DESCRIPTION
This is to accommodate a situation we have on the artwork sidebar where we need to float over a price on the right hand side of the container.