### PR TITLE
feat(button): supports `as` prop

### DIFF
--- a/packages/palette/src/elements/Button/Button.story.tsx
+++ b/packages/palette/src/elements/Button/Button.story.tsx
@@ -144,3 +144,14 @@ export const Loading = () => {
     </States>
   )
 }
+
+export const As = () => {
+  return (
+    <States states={[{}, { as: "div", children: "This is a div" }]}>
+      {/* @ts-ignore */}
+      <Button as="a" href="#example">
+        This is an anchor tag with an href
+      </Button>
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Button/v2/Button.tsx
+++ b/packages/palette/src/elements/Button/v2/Button.tsx
@@ -66,12 +66,14 @@ type ContainerProps = Pick<
 >
 
 const Container = styled.button<ContainerProps>`
-  display: inline-block;
+  display: inline-flex;
   cursor: pointer;
   position: relative;
   white-space: nowrap;
   text-decoration: none;
   align-items: center;
+  justify-content: center;
+  text-align: center;
   border: 2px solid;
   border-radius: 3px;
   transition: color 0.25s ease, border-color 0.25s ease,

--- a/packages/palette/src/elements/Button/v3/Button.tsx
+++ b/packages/palette/src/elements/Button/v3/Button.tsx
@@ -65,12 +65,14 @@ type ContainerProps = Pick<
 >
 
 const Container = styled.button<ContainerProps>`
-  display: inline-block;
+  display: inline-flex;
   cursor: pointer;
   position: relative;
   white-space: nowrap;
   text-decoration: none;
   align-items: center;
+  text-align: center;
+  justify-content: center;
   border: 1px solid;
   transition: color 0.25s ease, border-color 0.25s ease,
     background-color 0.25s ease, box-shadow 0.25s ease;


### PR DESCRIPTION
This lets us use `<Button as={RouterLink} to="/whatever">` etc. As always the typing here is a problem but since this is more of an escape hatch for a few one-offs I feel fine about that.