### PR TITLE
Tooltip/Popover positioning

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -111,6 +111,7 @@
     "typescript-styled-plugin": "0.10.0"
   },
   "dependencies": {
+    "@seznam/compose-react-refs": "^1.0.6",
     "@styled-system/theme-get": "^5.1.2",
     "d3-interpolate": "^1.3.2",
     "d3-shape": "^1.3.5",

--- a/packages/palette/src/elements/BorderBox/BorderBox.tsx
+++ b/packages/palette/src/elements/BorderBox/BorderBox.tsx
@@ -1,5 +1,5 @@
+import { themeGet } from "@styled-system/theme-get"
 import styled, { css } from "styled-components"
-import { color } from "../../helpers"
 import { BorderBoxBase, BorderBoxProps } from "./BorderBoxBase"
 
 /**
@@ -11,7 +11,7 @@ export const BorderBox = styled(BorderBoxBase)<BorderBoxProps>`
     hover &&
     css`
       :hover {
-        border-color: ${color("black60")};
+        border-color: ${themeGet("colors.black60")};
       }
     `};
 `

--- a/packages/palette/src/elements/BorderBox/BorderBoxBase.tsx
+++ b/packages/palette/src/elements/BorderBox/BorderBoxBase.tsx
@@ -1,11 +1,5 @@
 import styled from "styled-components"
-import {
-  border,
-  BorderProps,
-  space as styledSpace,
-  SpaceProps,
-} from "styled-system"
-import { color, space } from "../../helpers"
+import { BorderProps, SpaceProps } from "styled-system"
 import { Flex, FlexProps } from "../Flex"
 
 export interface BorderBoxProps extends FlexProps, BorderProps, SpaceProps {
@@ -13,13 +7,15 @@ export interface BorderBoxProps extends FlexProps, BorderProps, SpaceProps {
 }
 
 /**
- * A `View` or `div` (depending on the platform) that has a common border
- * and padding set by default
+ * A `div` that has a common border and padding set by default
  */
 export const BorderBoxBase = styled(Flex)<BorderBoxProps>`
-  border: 1px solid ${color("black10")};
+  border-width: 1px;
+  border-style: solid;
   border-radius: 2px;
-  padding: ${space(2)}px;
-  ${border}
-  ${styledSpace}
 `
+
+BorderBoxBase.defaultProps = {
+  borderColor: "black10",
+  p: 2,
+}

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -24,10 +24,12 @@ export interface ButtonProps
 }
 
 /** A button with various size and color settings */
-export const Button: React.FC<ButtonProps> = (props) => {
+export const Button: React.ForwardRefExoticComponent<
+  ButtonProps & { ref?: React.Ref<HTMLElement> }
+> = React.forwardRef((props, forwardedRef) => {
   const Component = useThemeConfig({ v2: ButtonV2, v3: ButtonV3 })
-  return <Component {...props} />
-}
+  return <Component ref={forwardedRef} {...props} />
+})
 
 Button.defaultProps = {
   size: "medium",

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -31,6 +31,8 @@ export const Button: React.ForwardRefExoticComponent<
   return <Component ref={forwardedRef} {...props} />
 })
 
+Button.displayName = "Button"
+
 Button.defaultProps = {
   size: "medium",
   variant: "primaryBlack",

--- a/packages/palette/src/elements/Button/v2/Button.tsx
+++ b/packages/palette/src/elements/Button/v2/Button.tsx
@@ -1,3 +1,4 @@
+import composeRefs from "@seznam/compose-react-refs"
 import React, { useEffect, useRef } from "react"
 import styled, { css } from "styled-components"
 import { variant } from "styled-system"
@@ -8,52 +9,49 @@ import { Sans } from "../../Typography"
 import { ButtonProps } from "../Button"
 import { BUTTON_SIZES, BUTTON_TEXT_SIZES, BUTTON_VARIANTS } from "./tokens"
 
-export const ButtonV2: React.FC<ButtonProps> = ({
-  children,
-  loading,
-  color,
-  size,
-  onClick,
-  ...rest
-}) => {
-  const ref = useRef<HTMLButtonElement | null>(null)
+export const ButtonV2: React.ForwardRefExoticComponent<
+  ButtonProps & { ref?: React.Ref<HTMLElement> }
+> = React.forwardRef(
+  ({ children, loading, color, size, onClick, ...rest }, forwardedRef) => {
+    const ref = useRef<HTMLButtonElement | null>(null)
 
-  const handleClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
-    if (!loading && onClick) {
-      onClick(event)
+    const handleClick = (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+      if (!loading && onClick) {
+        onClick(event)
+      }
     }
-  }
 
-  useEffect(() => {
-    if (loading && ref.current !== null) {
-      ref.current.blur()
-    }
-  }, [loading])
+    useEffect(() => {
+      if (loading && ref.current !== null) {
+        ref.current.blur()
+      }
+    }, [loading])
 
-  return (
-    <Container
-      ref={ref as any}
-      onClick={handleClick}
-      size={size}
-      loading={loading}
-      tabIndex={loading ? -1 : 0}
-      {...rest}
-    >
-      {loading && <Spinner size={size} color="currentColor" />}
-
-      <Sans
-        pt="1px"
-        weight="medium"
-        size={BUTTON_TEXT_SIZES[size]}
-        opacity={loading ? 0 : 1}
+    return (
+      <Container
+        ref={composeRefs(ref, forwardedRef) as any}
+        onClick={handleClick}
+        size={size}
+        loading={loading}
+        tabIndex={loading ? -1 : 0}
+        {...rest}
       >
-        {children}
-      </Sans>
-    </Container>
-  )
-}
+        {loading && <Spinner size={size} color="currentColor" />}
+
+        <Sans
+          pt="1px"
+          weight="medium"
+          size={BUTTON_TEXT_SIZES[size]}
+          opacity={loading ? 0 : 1}
+        >
+          {children}
+        </Sans>
+      </Container>
+    )
+  }
+)
 
 ButtonV2.defaultProps = {
   size: "medium",

--- a/packages/palette/src/elements/Button/v3/Button.tsx
+++ b/packages/palette/src/elements/Button/v3/Button.tsx
@@ -1,3 +1,4 @@
+import composeRefs from "@seznam/compose-react-refs"
 import React, { useEffect, useRef } from "react"
 import styled, { css } from "styled-components"
 import { variant } from "styled-system"
@@ -8,51 +9,48 @@ import { Text } from "../../Text"
 import { ButtonProps } from "../Button"
 import { BUTTON_SIZES, BUTTON_TEXT_SIZES, BUTTON_VARIANTS } from "./tokens"
 
-export const ButtonV3: React.FC<ButtonProps> = ({
-  children,
-  loading,
-  color,
-  size,
-  onClick,
-  ...rest
-}) => {
-  const ref = useRef<HTMLButtonElement | null>(null)
+export const ButtonV3: React.ForwardRefExoticComponent<
+  ButtonProps & { ref?: React.Ref<HTMLElement> }
+> = React.forwardRef(
+  ({ children, loading, color, size, onClick, ...rest }, forwardedRef) => {
+    const ref = useRef<HTMLButtonElement | null>(null)
 
-  const handleClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => {
-    if (!loading && onClick) {
-      onClick(event)
+    const handleClick = (
+      event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+      if (!loading && onClick) {
+        onClick(event)
+      }
     }
-  }
 
-  useEffect(() => {
-    if (loading && ref.current !== null) {
-      ref.current.blur()
-    }
-  }, [loading])
+    useEffect(() => {
+      if (loading && ref.current !== null) {
+        ref.current.blur()
+      }
+    }, [loading])
 
-  return (
-    <Container
-      ref={ref as any}
-      onClick={handleClick}
-      size={size}
-      loading={loading}
-      tabIndex={loading ? -1 : 0}
-      {...rest}
-    >
-      {loading && <Spinner size={size} color="currentColor" />}
-
-      <Text
-        lineHeight={1}
-        variant={BUTTON_TEXT_SIZES[size]}
-        opacity={loading ? 0 : 1}
+    return (
+      <Container
+        ref={composeRefs(ref, forwardedRef) as any}
+        onClick={handleClick}
+        size={size}
+        loading={loading}
+        tabIndex={loading ? -1 : 0}
+        {...rest}
       >
-        {children}
-      </Text>
-    </Container>
-  )
-}
+        {loading && <Spinner size={size} color="currentColor" />}
+
+        <Text
+          lineHeight={1}
+          variant={BUTTON_TEXT_SIZES[size]}
+          opacity={loading ? 0 : 1}
+        >
+          {children}
+        </Text>
+      </Container>
+    )
+  }
+)
 
 ButtonV3.defaultProps = {
   size: "medium",

--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -1,0 +1,83 @@
+import React from "react"
+import { States } from "storybook-states"
+import { Position, POSITION } from "../../utils"
+import { Box } from "../Box"
+import { Button } from "../Button"
+import { Text } from "../Text"
+import { Popover, PopoverProps } from "./Popover"
+
+const CONTENT =
+  "Lorem ipsum dolor sit amet consectetur adipisicing elit. Modi eius autem aliquid cumque, mollitia incidunt totam. Id ut quae hic in quisquam, cupiditate iure nobis, provident minus voluptatem tenetur consequatur."
+
+export default {
+  title: "Components/Popover",
+}
+
+export const Default = () => {
+  return (
+    <States<Partial<PopoverProps>>
+      states={[{}, { title: "Example Title", visible: true }]}
+    >
+      <Popover
+        placement="bottom"
+        popover={
+          <Text variant="xs" width={300}>
+            {CONTENT}
+          </Text>
+        }
+      >
+        {({ onVisible, anchorRef }) => {
+          return (
+            <Box textAlign="center">
+              <Button
+                ref={anchorRef}
+                variant="secondaryOutline"
+                size="small"
+                onClick={onVisible}
+              >
+                Click to display popover
+              </Button>
+            </Box>
+          )
+        }}
+      </Popover>
+    </States>
+  )
+}
+
+export const Placement = () => {
+  return (
+    <States<Partial<PopoverProps>>
+      states={Object.keys(POSITION).map((placement) => ({
+        placement: placement as Position,
+      }))}
+    >
+      {(props) => {
+        return (
+          <Popover
+            popover={<Text variant="xs">{JSON.stringify(props)}</Text>}
+            visible
+            {...props}
+          >
+            {({ anchorRef }) => {
+              return (
+                <Text
+                  ref={anchorRef as any}
+                  variant="xs"
+                  textAlign="center"
+                  p={1}
+                  maxWidth="50%"
+                  mx="auto"
+                  bg="black100"
+                  color="white100"
+                >
+                  {JSON.stringify(props)}
+                </Text>
+              )
+            }}
+          </Popover>
+        )
+      }}
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -34,7 +34,7 @@ export interface PopoverProps {
  */
 export const Popover: React.FC<PopoverProps> = ({
   title,
-  placement,
+  placement = "top",
   visible: _visible = false,
   children,
   popover,

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -92,7 +92,7 @@ export const Popover: React.FC<PopoverProps> = ({
 
       {visible && (
         <Tip
-          tabIndex={1}
+          tabIndex={0}
           ref={tooltipRef as any}
           zIndex={1}
           display="inline-block"

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react"
+import styled from "styled-components"
+import { DROP_SHADOW } from "../../helpers"
+import { isText } from "../../helpers/isText"
+import { CloseIcon } from "../../svgs"
+import { Position, useClickOutside, usePosition } from "../../utils"
+import { Box } from "../Box"
+import { Clickable } from "../Clickable"
+import { Flex } from "../Flex"
+import { Spacer } from "../Spacer"
+import { Text } from "../Text"
+
+export interface PopoverActions {
+  /** Call to show popover */
+  onVisible(): void
+  /** Call to hide popover */
+  onHide(): void
+  /** Pass ref to element you want the popover to be anchored to */
+  anchorRef: React.MutableRefObject<HTMLElement>
+}
+
+export interface PopoverProps {
+  title?: React.ReactNode
+  placement?: Position
+  /** Intially visible by default? */
+  visible?: boolean
+  popover: React.ReactNode
+  children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
+}
+
+/**
+ * A `Popover` is a small model-type element which is anchored, and can be
+ * positioned relative to, another element.
+ */
+export const Popover: React.FC<PopoverProps> = ({
+  title,
+  placement,
+  visible: _visible = false,
+  children,
+  popover,
+}) => {
+  const [visible, setVisible] = useState(false)
+
+  // If prop updates/set initial visibility.
+  useEffect(() => {
+    setVisible(_visible)
+  }, [_visible])
+
+  // Yields focus back and forth between popover and anchor
+  useEffect(() => {
+    if (visible && tooltipRef.current) {
+      tooltipRef.current.focus()
+      return
+    }
+
+    if (!anchorRef.current) return
+    anchorRef.current.focus()
+  }, [visible])
+
+  const onVisible = () => setVisible(true)
+  const onHide = () => setVisible(false)
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onHide()
+      }
+    }
+
+    document.addEventListener("keydown", handleKeydown)
+    return () => {
+      document.removeEventListener("keydown", handleKeydown)
+    }
+  }, [])
+
+  const { anchorRef, tooltipRef } = usePosition({
+    position: placement,
+    offset: 10,
+    active: visible,
+  })
+
+  useClickOutside({
+    ref: tooltipRef,
+    onClickOutside: onHide,
+    when: visible,
+    type: "click",
+  })
+
+  return (
+    <>
+      {children({ anchorRef, onVisible, onHide })}
+
+      {visible && (
+        <Tip
+          tabIndex={1}
+          ref={tooltipRef as any}
+          zIndex={1}
+          display="inline-block"
+          bg="white100"
+          p={2}
+        >
+          {title && (
+            <>
+              <Flex alignItems="center" flex={1} justifyContent="space-between">
+                {isText(title) ? (
+                  <Text variant="lg" lineHeight={1}>
+                    {title}
+                  </Text>
+                ) : (
+                  title
+                )}
+
+                <Spacer ml={4} />
+              </Flex>
+
+              <Spacer mt={0.5} />
+            </>
+          )}
+
+          <Clickable
+            position="absolute"
+            right={0}
+            top={0}
+            pt={2}
+            px={1}
+            mx={0.5}
+            onClick={onHide}
+            aria-label="Close"
+          >
+            <CloseIcon fill="black100" display="block" />
+          </Clickable>
+
+          {!title && <Spacer mt={2} />}
+
+          {popover}
+        </Tip>
+      )}
+    </>
+  )
+}
+
+const Tip = styled(Box)`
+  position: fixed;
+  z-index: 1;
+  text-align: left;
+  transition: opacity 250ms ease-out;
+  box-shadow: ${DROP_SHADOW};
+`

--- a/packages/palette/src/elements/Popover/index.ts
+++ b/packages/palette/src/elements/Popover/index.ts
@@ -1,0 +1,1 @@
+export * from "./Popover"

--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { States } from "storybook-states"
 import { HelpIcon } from "../../svgs"
+import { Position, POSITION } from "../../utils/usePosition"
 import { Text } from "../Text"
 import { Tooltip, TooltipProps } from "./Tooltip"
 
@@ -15,17 +16,55 @@ export const Default = () => {
   return (
     <States<Partial<TooltipProps>>
       states={[
-        { placement: "top" },
-        { placement: "bottom" },
-        { placement: "top", width: 600 },
+        { placement: "top-start" },
+        { placement: "bottom", width: 600 },
         { placement: "bottom", visible: true },
       ]}
     >
       <Tooltip content={CONTENT} display="block">
-        <Text variant="xs" textAlign="center">
+        <Text
+          variant="xs"
+          textAlign="center"
+          p={1}
+          bg="black100"
+          color="white100"
+        >
           This text has a tooltip
         </Text>
       </Tooltip>
+    </States>
+  )
+}
+
+export const Placement = () => {
+  return (
+    <States<Partial<TooltipProps>>
+      states={Object.keys(POSITION).map((placement) => ({
+        placement: placement as Position,
+      }))}
+    >
+      {(props) => {
+        return (
+          <Tooltip
+            content={JSON.stringify(props)}
+            visible
+            display="block"
+            maxWidth="50%"
+            mx="auto"
+            {...props}
+          >
+            <Text
+              variant="xs"
+              textAlign="center"
+              p={1}
+              bg="black100"
+              color="white100"
+            >
+              {JSON.stringify(props)}
+            </Text>
+          </Tooltip>
+        )
+      }}
     </States>
   )
 }

--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { States } from "storybook-states"
 import { HelpIcon } from "../../svgs"
 import { Position, POSITION } from "../../utils/usePosition"
+import { Box } from "../Box"
 import { Text } from "../Text"
 import { Tooltip, TooltipProps } from "./Tooltip"
 
@@ -21,7 +22,7 @@ export const Default = () => {
         { placement: "bottom", visible: true },
       ]}
     >
-      <Tooltip content={CONTENT} display="block">
+      <Tooltip content={CONTENT}>
         <Text
           variant="xs"
           textAlign="center"
@@ -45,18 +46,13 @@ export const Placement = () => {
     >
       {(props) => {
         return (
-          <Tooltip
-            content={JSON.stringify(props)}
-            visible
-            display="block"
-            maxWidth="50%"
-            mx="auto"
-            {...props}
-          >
+          <Tooltip content={JSON.stringify(props)} visible {...props}>
             <Text
               variant="xs"
               textAlign="center"
               p={1}
+              maxWidth="50%"
+              mx="auto"
               bg="black100"
               color="white100"
             >
@@ -73,15 +69,11 @@ export const IconExample = () => {
   return (
     <Text variant="xs" display="flex" alignItems="center" lineHeight={1}>
       Hover (or focus) the icon to display the tooltip.{" "}
-      <Tooltip
-        content={CONTENT}
-        placement="bottom"
-        ml={0.5}
-        // In our case, if we want true vertical centering we need
-        // to zero-out the `lineHeight`
-        style={{ lineHeight: 0 }}
-      >
-        <HelpIcon />
+      <Tooltip content={CONTENT} placement="bottom">
+        {/* Icons don't forwardRefs so we have to wrap in a span */}
+        <Box as="span" style={{ lineHeight: 0 }}>
+          <HelpIcon ml={0.5} />
+        </Box>
       </Tooltip>
     </Text>
   )

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -3,17 +3,16 @@ import styled from "styled-components"
 import { DROP_SHADOW } from "../../helpers"
 import { useThemeConfig } from "../../Theme"
 import { Position, usePosition } from "../../utils/usePosition"
-import { Box, BoxProps } from "../Box"
+import { Box } from "../Box"
 import { Text, TextVariant } from "../Text"
 
-export interface TooltipProps
-  extends BoxProps,
-    React.HTMLAttributes<HTMLDivElement> {
+export interface TooltipProps {
   content: React.ReactNode
   placement?: Position
   size?: "sm" | "lg"
   width?: number
   visible?: boolean
+  children: React.ReactElement<any, string | React.JSXElementConstructor<any>>
 }
 
 /**
@@ -26,7 +25,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
   width = 230,
   placement = "bottom-end",
   visible,
-  ...rest
 }) => {
   const tooltipRef = useRef<HTMLDivElement | null>(null)
   const anchorRef = useRef<HTMLDivElement | null>(null)
@@ -61,16 +59,17 @@ export const Tooltip: React.FC<TooltipProps> = ({
   })
 
   return (
-    <Box
-      tabIndex={1}
-      onClick={handleClick}
-      onMouseOver={activate}
-      onMouseOut={deactivate}
-      onFocus={activate}
-      onBlur={deactivate}
-      display="inline-block"
-      {...rest}
-    >
+    <>
+      {React.cloneElement(children, {
+        ref: anchorRef,
+        tabIndex: 1,
+        onClick: handleClick,
+        onMouseOver: activate,
+        onMouseOut: deactivate,
+        onFocus: activate,
+        onBlur: deactivate,
+      })}
+
       <Tip
         p={size === "sm" ? 0.5 : 2}
         width={width}
@@ -87,9 +86,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
           {content}
         </Text>
       </Tip>
-
-      <Box ref={anchorRef as any}>{children}</Box>
-    </Box>
+    </>
   )
 }
 

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -51,7 +51,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
     <>
       {React.cloneElement(children, {
         ref: anchorRef,
-        tabIndex: 1,
+        tabIndex: 0,
         onClick: handleClick,
         onMouseOver: activate,
         onMouseOut: deactivate,

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -9,7 +9,7 @@ export interface TooltipProps {
   content: React.ReactNode
   placement?: Position
   size?: "sm" | "lg"
-  width?: number
+  width?: number | null
   visible?: boolean
   children: React.ReactElement<any, string | React.JSXElementConstructor<any>>
 }

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -22,7 +22,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   content: _content,
   size = "lg",
   width = 230,
-  placement = "bottom-end",
+  placement = "top",
   visible,
 }) => {
   const [active, setActive] = useState(false)

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -1,10 +1,9 @@
-import React, { useRef, useState } from "react"
+import React, { useState } from "react"
 import styled from "styled-components"
 import { DROP_SHADOW } from "../../helpers"
-import { useThemeConfig } from "../../Theme"
 import { Position, usePosition } from "../../utils/usePosition"
 import { Box } from "../Box"
-import { Text, TextVariant } from "../Text"
+import { Text } from "../Text"
 
 export interface TooltipProps {
   content: React.ReactNode
@@ -26,9 +25,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
   placement = "bottom-end",
   visible,
 }) => {
-  const tooltipRef = useRef<HTMLDivElement | null>(null)
-  const anchorRef = useRef<HTMLDivElement | null>(null)
-
   const [active, setActive] = useState(false)
 
   const handleClick = () => {
@@ -45,14 +41,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
   const content = typeof _content === "string" ? truncate(_content) : _content
 
-  const tokens = useThemeConfig({
-    v2: { variant: "small" as TextVariant },
-    v3: { variant: "xs" as TextVariant },
-  })
-
-  usePosition({
-    anchorRef,
-    tooltipRef,
+  const { anchorRef, tooltipRef } = usePosition({
     position: placement,
     offset: 10,
     active: visible ?? active,
@@ -82,9 +71,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
           : // Otherwise use the active state
             { opacity: active ? 1 : 0 })}
       >
-        <Text variant={tokens.variant} color="black60">
-          {content}
-        </Text>
+        <Text variant="xs">{content}</Text>
       </Tip>
     </>
   )

--- a/packages/palette/src/elements/index.tsx
+++ b/packages/palette/src/elements/index.tsx
@@ -1,3 +1,4 @@
+export * from "./Popover"
 export * from "./Avatar"
 export * from "./Banner"
 export * from "./BarChart"

--- a/packages/palette/src/index.tsx
+++ b/packages/palette/src/index.tsx
@@ -2,6 +2,7 @@ export * from "./elements"
 export * from "./helpers"
 export * from "./svgs"
 export * from "./Theme"
+export * from "./utils"
 
 // Helpers
 import * as _AllIcons from "./svgs"

--- a/packages/palette/src/utils/index.ts
+++ b/packages/palette/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./usePosition"

--- a/packages/palette/src/utils/index.ts
+++ b/packages/palette/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./usePosition"
+export * from "./useClickOutside"

--- a/packages/palette/src/utils/useClickOutside.ts
+++ b/packages/palette/src/utils/useClickOutside.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from "react"
+
+export interface UseClickOutside {
+  ref: React.RefObject<HTMLElement>
+  when: boolean
+  type?: keyof DocumentEventMap
+  onClickOutside: (event: Event) => void
+}
+
+export const useClickOutside = ({
+  ref,
+  type = "click",
+  when = true,
+  onClickOutside,
+}: UseClickOutside) => {
+  const savedHandler = useRef(onClickOutside)
+
+  const handleClick = useCallback((e: Event) => {
+    if (ref && ref.current && !ref.current.contains(e.target as Element)) {
+      savedHandler.current(e)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    savedHandler.current = onClickOutside
+  }, [onClickOutside])
+
+  useEffect(() => {
+    if (when) {
+      document.addEventListener(type, handleClick)
+      return () => {
+        document.removeEventListener(type, handleClick)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [when])
+}

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -1,7 +1,7 @@
 /**
  * Adapted from https://codesandbox.io/s/positioning-tooltip-rhplo
  */
-import { useEffect, useLayoutEffect, useRef } from "react"
+import { useLayoutEffect, useRef } from "react"
 
 export const POSITION = {
   "top-start": "top-start",

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -41,8 +41,8 @@ export const usePosition = ({
   /** Optionally disable for performance (default: `true`) */
   active?: boolean
 }) => {
-  const tooltipRef = useRef<HTMLDivElement | null>(null)
-  const anchorRef = useRef<HTMLDivElement | null>(null)
+  const tooltipRef = useRef<HTMLElement | null>(null)
+  const anchorRef = useRef<HTMLElement | null>(null)
 
   useLayoutEffect(() => {
     if (!tooltipRef.current || !anchorRef.current) return

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -1,0 +1,373 @@
+/**
+ * Adapted from https://codesandbox.io/s/positioning-tooltip-rhplo
+ */
+
+import React, { useEffect } from "react"
+
+export const POSITION = {
+  "top-start": "top-start",
+  top: "top",
+  "top-end": "top-end",
+  "bottom-start": "bottom-start",
+  bottom: "bottom",
+  "bottom-end": "bottom-end",
+  "left-start": "left-start",
+  left: "left",
+  "left-end": "left-end",
+  "right-start": "right-start",
+  right: "right",
+  "right-end": "right-end",
+} as const
+
+export type Position = keyof typeof POSITION
+
+interface TargetPosition {
+  x: number
+  y: number
+}
+
+/**
+ * Will position the floating element (tooltip) relative to the anchor element,
+ * using `position: fixed` and in such a way that it shouldn't ever appear
+ * partially offscreen and will move correctly when the parent is scrolled.
+ */
+export const usePosition = ({
+  anchorRef,
+  tooltipRef,
+  position,
+  offset = 0,
+  active = true,
+}: {
+  /** Element that floating element is anchored to  */
+  anchorRef: React.MutableRefObject<HTMLElement>
+  /** Element you want to position relative to the anchor */
+  tooltipRef: React.MutableRefObject<HTMLElement>
+  position: Position
+  /** Distance from anchor (default: `0`) */
+  offset?: number
+  /** Optionally disable for performance (default: `true`) */
+  active?: boolean
+}) => {
+  useEffect(() => {
+    if (!tooltipRef.current || !anchorRef.current) return
+
+    const { current: tooltip } = tooltipRef
+    const { current: anchor } = anchorRef
+
+    tooltip.style.position = "fixed"
+    tooltip.style.top = "0"
+    tooltip.style.left = "0"
+
+    const scrollableParents = getScrollableParents(anchor)
+
+    placeTooltip(anchor, tooltip, position, scrollableParents, offset)
+
+    const handlers = scrollableParents.map((scrollableParent) => {
+      return {
+        scrollableParent,
+        handlerScroll: () => {
+          if (!active) return
+          placeTooltip(anchor, tooltip, position, scrollableParents, offset)
+        },
+      }
+    })
+
+    handlers.forEach(({ scrollableParent, handlerScroll }) => {
+      if (!active) return
+      scrollableParent.addEventListener("scroll", handlerScroll, {
+        passive: true,
+      })
+    })
+
+    const handleResize = () => {
+      placeTooltip(anchor, tooltip, position, scrollableParents, offset)
+    }
+
+    window.addEventListener("resize", handleResize, { passive: true })
+
+    return () => {
+      handlers.forEach(({ scrollableParent, handlerScroll }) => {
+        scrollableParent.removeEventListener("scroll", handlerScroll)
+      })
+
+      window.removeEventListener("resize", handleResize)
+    }
+  }, [active])
+}
+
+const placeTooltip = (
+  anchor: HTMLElement,
+  tooltip: HTMLElement,
+  position: Position,
+  scrollableParents: HTMLElement[],
+  offset = 0
+) => {
+  const elementRect = anchor.getBoundingClientRect()
+  const tooltipRect = tooltip.getBoundingClientRect()
+
+  let targetPosition = getPosition(elementRect, tooltipRect, position)
+
+  // Flip to avoid edges
+  for (const scrollableParent of scrollableParents) {
+    const boundaryRect =
+      // @ts-ignore
+      scrollableParent === document
+        ? getDocumentBoundingRect()
+        : scrollableParent.getBoundingClientRect()
+    if (shouldFlip(targetPosition, position, boundaryRect, tooltipRect)) {
+      position = getOppositePosition(position)
+      targetPosition = getPosition(elementRect, tooltipRect, position)
+    }
+  }
+
+  // Clamp position within boundary
+  for (const scrollableParent of scrollableParents) {
+    const boundaryRect =
+      // @ts-ignore
+      scrollableParent === document
+        ? getDocumentBoundingRect()
+        : scrollableParent.getBoundingClientRect()
+    targetPosition.x = Math.max(boundaryRect.left, targetPosition.x)
+    targetPosition.x = Math.min(
+      boundaryRect.right - tooltipRect.width,
+      targetPosition.x
+    )
+    targetPosition.y = Math.max(boundaryRect.top, targetPosition.y)
+    targetPosition.y = Math.min(
+      boundaryRect.bottom - tooltipRect.height,
+      targetPosition.y
+    )
+  }
+
+  let shouldHide = false
+
+  for (const scrollableParent of scrollableParents) {
+    const boundaryRect =
+      // @ts-ignore
+      scrollableParent === document
+        ? getDocumentBoundingRect()
+        : scrollableParent.getBoundingClientRect()
+    if (!isWithin(elementRect, boundaryRect)) {
+      shouldHide = true
+      break
+    }
+  }
+
+  tooltip.style.display = shouldHide ? "none" : "block"
+  tooltip.style.transform = translateWithOffset(
+    targetPosition,
+    position,
+    offset
+  )
+}
+
+const getPosition = (
+  elementRect: DOMRect,
+  tooltipRect: DOMRect,
+  position: Position
+): TargetPosition => {
+  let x: number
+  let y: number
+
+  switch (position) {
+    case "top-start":
+    case "bottom-start":
+      x = elementRect.left
+      break
+    case "top":
+    case "bottom":
+      x = elementRect.left + elementRect.width / 2 - tooltipRect.width / 2
+      break
+    case "top-end":
+    case "bottom-end":
+      x = elementRect.right - tooltipRect.width
+      break
+    case "left-start":
+    case "left":
+    case "left-end":
+      // [..] {XXX}
+      x = elementRect.left - tooltipRect.width
+      break
+    case "right-start":
+    case "right":
+    case "right-end":
+      // {XXX} [...]
+      x = elementRect.right
+      break
+  }
+
+  switch (position) {
+    case "left-start":
+    case "right-start":
+      y = elementRect.top
+      break
+    case "left":
+    case "right":
+      y = elementRect.top + elementRect.height / 2 - tooltipRect.height / 2
+      break
+    case "left-end":
+    case "right-end":
+      y = elementRect.bottom - tooltipRect.height
+      break
+    case "top-start":
+    case "top":
+    case "top-end":
+      // [..]
+      // {XXX}
+      y = elementRect.top - tooltipRect.height
+      break
+    case "bottom-start":
+    case "bottom":
+    case "bottom-end":
+      // {XXX}
+      // [...]
+      y = elementRect.bottom
+      break
+  }
+
+  return { x, y }
+}
+
+const getScrollableParents = (element: HTMLElement) => {
+  let parent = element.parentElement
+  const scrollableParents = []
+
+  while (parent) {
+    const computedStyle = getComputedStyle(parent)
+    if (
+      isOverflowSet(computedStyle.overflow) ||
+      isOverflowSet(computedStyle.overflowY) ||
+      isOverflowSet(computedStyle.overflowX)
+    ) {
+      scrollableParents.push(parent)
+    }
+    parent = parent.parentElement
+  }
+
+  scrollableParents.push(document)
+
+  return scrollableParents
+}
+
+const isOverflowSet = (overflowValue: string) => {
+  return (
+    overflowValue === "auto" ||
+    overflowValue === "hidden" ||
+    overflowValue === "scroll" ||
+    overflowValue === "overlay"
+  )
+}
+
+const translateWithOffset = (
+  targetPosition: TargetPosition,
+  position: Position,
+  offset: number
+) => {
+  const [x, y] = (() => {
+    switch (position) {
+      case "top-start":
+        return [targetPosition.x, targetPosition.y - offset]
+      case "top":
+        return [targetPosition.x, targetPosition.y - offset]
+      case "top-end":
+        return [targetPosition.x, targetPosition.y - offset]
+      case "bottom-start":
+        return [targetPosition.x, targetPosition.y + offset]
+      case "bottom":
+        return [targetPosition.x, targetPosition.y + offset]
+      case "bottom-end":
+        return [targetPosition.x, targetPosition.y + offset]
+      case "left-start":
+        return [targetPosition.x - offset, targetPosition.y]
+      case "left":
+        return [targetPosition.x - offset, targetPosition.y]
+      case "left-end":
+        return [targetPosition.x - offset, targetPosition.y]
+      case "right-start":
+        return [targetPosition.x + offset, targetPosition.y]
+      case "right":
+        return [targetPosition.x + offset, targetPosition.y]
+      case "right-end":
+        return [targetPosition.x + offset, targetPosition.y]
+    }
+  })()
+
+  return `translate(${x}px, ${y}px)`
+}
+
+const getOppositePosition = (position: Position) => {
+  switch (position) {
+    case "top-start":
+      return "bottom-start"
+    case "top":
+      return "bottom"
+    case "top-end":
+      return "bottom-end"
+    case "bottom-start":
+      return "top-start"
+    case "bottom":
+      return "top"
+    case "bottom-end":
+      return "top-end"
+    case "left-start":
+      return "right-start"
+    case "left":
+      return "right"
+    case "left-end":
+      return "right-end"
+    case "right-start":
+      return "left-start"
+    case "right":
+      return "left"
+    case "right-end":
+      return "left-end"
+  }
+}
+
+const getDocumentBoundingRect = () => {
+  const width = document.body.clientWidth
+  const height = document.body.clientHeight
+  return {
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+  } as DOMRect
+}
+
+const shouldFlip = (
+  targetPosition: TargetPosition,
+  position: Position,
+  boundaryRect: DOMRect,
+  tooltipRect: DOMRect
+) => {
+  switch (position) {
+    case "top-start":
+    case "top":
+    case "top-end":
+      return targetPosition.y < boundaryRect.top
+    case "bottom-start":
+    case "bottom":
+    case "bottom-end":
+      return targetPosition.y + tooltipRect.height > boundaryRect.bottom
+    case "left-start":
+    case "left":
+    case "left-end":
+      return targetPosition.x < boundaryRect.left
+    case "right-start":
+    case "right":
+    case "right-end":
+      return targetPosition.x + tooltipRect.width > boundaryRect.right
+  }
+}
+
+const isWithin = (elementRect: DOMRect, boundaryRect: DOMRect) => {
+  return (
+    boundaryRect.top < elementRect.bottom &&
+    boundaryRect.left < elementRect.right &&
+    boundaryRect.bottom > elementRect.top &&
+    boundaryRect.right > elementRect.left
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,6 +2733,11 @@
   resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.1.0.tgz#b84b4a91cd938a688d36245b7a7db6fbc476a499"
   integrity sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg==
 
+"@seznam/compose-react-refs@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@seznam/compose-react-refs/-/compose-react-refs-1.0.6.tgz#6ec4e70bdd6e32f8e70b4100f27267cf306bd8df"
+  integrity sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==
+
 "@sideway/address@^4.1.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.1.tgz#9e321e74310963fdf8eebfbee09c7bd69972de4d"


### PR DESCRIPTION
So the goal with this PR is to introduce a hook that gives us a consistent way of doing positioning for elements that we need to popover (tooltips, popovers, dropdowns).

![](https://static.damonzucconi.com/_capture/Hm3PEdKo.gif)

![](https://camo.githubusercontent.com/a9c82970554b3ff86202af54564b26af095fa38d270eac47d4cab154d55a993d/68747470733a2f2f7374617469632e64616d6f6e7a7563636f6e692e636f6d2f5f636170747572652f6a646a6946487a6d2e706e67)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.34.1-canary.947.17606.0
  # or 
  yarn add @artsy/palette@14.34.1-canary.947.17606.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
