### PR TITLE
fix(tooltip): avoids blowing away child props

### DIFF
--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -1,8 +1,10 @@
+import { action } from "@storybook/addon-actions"
 import React from "react"
 import { States } from "storybook-states"
 import { HelpIcon } from "../../svgs"
 import { Position, POSITION } from "../../utils/usePosition"
 import { Box } from "../Box"
+import { Clickable } from "../Clickable"
 import { Text } from "../Text"
 import { Tooltip, TooltipProps } from "./Tooltip"
 
@@ -32,6 +34,26 @@ export const Default = () => {
         >
           This text has a tooltip
         </Text>
+      </Tooltip>
+    </States>
+  )
+}
+
+export const _Clickable = () => {
+  return (
+    <States<Partial<TooltipProps>> states={[{}]}>
+      <Tooltip content={CONTENT}>
+        <Clickable onClick={action("onClick")}>
+          <Text
+            variant="xs"
+            textAlign="center"
+            p={1}
+            bg="black100"
+            color="white100"
+          >
+            This text has a tooltip and is clickable
+          </Text>
+        </Clickable>
       </Tooltip>
     </States>
   )

--- a/packages/palette/src/elements/Tooltip/Tooltip.test.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.test.tsx
@@ -1,0 +1,28 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Clickable } from "../Clickable"
+import { Tooltip } from "../Tooltip"
+
+describe("Tooltip", () => {
+  it("avoids blowing away child props", () => {
+    const handleClick = jest.fn()
+    const wrapper = mount(
+      <div>
+        <Tooltip content="Hello">
+          <Clickable onClick={handleClick} data-test="example">
+            World
+          </Clickable>
+        </Tooltip>
+      </div>
+    )
+
+    expect(wrapper.html()).toContain('data-test="example"')
+    expect(wrapper.text()).toEqual("WorldHello")
+
+    expect(handleClick).not.toBeCalled()
+
+    wrapper.find("button").simulate("click")
+
+    expect(handleClick).toBeCalledTimes(1)
+  })
+})

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -52,11 +52,11 @@ export const Tooltip: React.FC<TooltipProps> = ({
       {React.cloneElement(children, {
         ref: anchorRef,
         tabIndex: 0,
-        onClick: handleClick,
-        onMouseOver: activate,
-        onMouseOut: deactivate,
-        onFocus: activate,
-        onBlur: deactivate,
+        onClick: compose(handleClick, children.props?.onClick),
+        onMouseOver: compose(activate, children.props?.onMouseOver),
+        onMouseOut: compose(deactivate, children.props?.onMouseOut),
+        onFocus: compose(activate, children.props?.onFocus),
+        onBlur: compose(deactivate, children.props?.onBlur),
       })}
 
       <Tip
@@ -77,6 +77,16 @@ export const Tooltip: React.FC<TooltipProps> = ({
   )
 }
 
+const Tip = styled(Box)`
+  position: absolute;
+  z-index: 1;
+  transition: opacity 250ms ease-out;
+  text-align: left;
+  box-shadow: ${DROP_SHADOW};
+  cursor: default;
+  pointer-events: none;
+`
+
 const truncate = (tip: string): string => {
   let substring = tip.substring(0, 300)
 
@@ -87,12 +97,9 @@ const truncate = (tip: string): string => {
   return substring
 }
 
-const Tip = styled(Box)`
-  position: absolute;
-  z-index: 1;
-  transition: opacity 250ms ease-out;
-  text-align: left;
-  box-shadow: ${DROP_SHADOW};
-  cursor: default;
-  pointer-events: none;
-`
+const compose = (a?: (...args: any) => any, b?: (...args: any) => any) => {
+  return (...args) => {
+    a?.(...args)
+    b?.(...args)
+  }
+}


### PR DESCRIPTION
Another small bug fix. Always forget that it's possible to overwrite the existing props when using `cloneElement`