### PR TITLE
fix(image,skeleton): optimizes skeleton animations

### DIFF
--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -6,6 +6,7 @@ import { LazyImage } from "./LazyImage"
 import {
   borderRadius,
   BorderRadiusProps,
+  compose,
   height,
   HeightProps,
   maxHeight,
@@ -24,6 +25,8 @@ import {
 export interface WebImageProps extends ImageProps {
   /** Flag for if image should be lazy loaded */
   lazyLoad?: boolean
+  /** Enable loading animation */
+  enableAnimation?: boolean
   /** Alternate text for image */
   alt?: string
   /** A11y text label */
@@ -63,11 +66,7 @@ export interface ImageProps
  * Image component with space, width and height properties
  */
 export const BaseImage = styled(CleanTag.as("img"))<ImageProps>`
-  ${space};
-  ${width};
-  ${height};
-  ${maxHeight};
-  ${borderRadius}
+  ${compose(space, width, height, maxHeight, borderRadius)}
 `
 
 export interface ResponsiveImageProps
@@ -86,9 +85,7 @@ export const BaseResponsiveImage = styled(CleanTag)<ResponsiveImageProps>`
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  ${space};
-  ${width};
-  ${maxWidth};
+  ${compose(space, width, maxWidth)};
   ${(props) =>
     props.ratio
       ? {

--- a/packages/palette/src/elements/Skeleton/Skeleton.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.tsx
@@ -1,38 +1,39 @@
+import { themeGet } from "@styled-system/theme-get"
 import React from "react"
-import styled, { css, keyframes } from "styled-components"
+import styled, { keyframes } from "styled-components"
 import { border, BorderProps } from "styled-system"
-import { color } from "../../helpers"
 import { splitProps } from "../../utils/splitProps"
 import { Box, BoxProps } from "../Box"
 import { Text, TextProps } from "../Text"
-
-const PULSE = keyframes`
-  0% { background-color: ${color("black10")}; }
-  50% { background-color: ${color("black5")}; }
-  100% { background-color: ${color("black10")}; }
-`
 
 interface DoneProps {
   done?: boolean
 }
 
-const Skeleton = styled(Box)<DoneProps>`
-  ${({ done }) =>
-    done
-      ? css`
-          background-color: ${color("black10")};
-        `
-      : css`
-          animation: ${PULSE} 2s ease-in-out infinite;
-        `}
-`
-
 /** SkeletonProps */
 export type SkeletonBoxProps = BoxProps & DoneProps
 
 /** Skeleton */
-export const SkeletonBox: React.FC<SkeletonBoxProps> = ({ done, ...rest }) => {
-  return <Skeleton aria-busy={!done} done={done} borderRadius={2} {...rest} />
+export const SkeletonBox: React.FC<SkeletonBoxProps> = ({
+  done,
+  children,
+  ...rest
+}) => {
+  return (
+    <Box bg="black10" position="relative" overflow="hidden" {...rest}>
+      {!done && (
+        <SkeletonFade
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          left={0}
+        />
+      )}
+
+      {children}
+    </Box>
+  )
 }
 
 const splitBorderProps = splitProps<BorderProps>(border)
@@ -57,16 +58,11 @@ export const SkeletonText: React.FC<SkeletonTextProps> = ({
   done,
   ...rest
 }) => {
-  const [borderProps, notBorderProps] = splitBorderProps(rest)
+  const [borderProps, textProps] = splitBorderProps(rest)
 
   return (
-    <Text aria-busy={!done} color="transparent" {...notBorderProps}>
-      <Box
-        as="span"
-        display="inline-flex"
-        position="relative"
-        aria-hidden="true"
-      >
+    <Text color="transparent" {...textProps}>
+      <Box as="span" display="inline-flex" position="relative" aria-hidden>
         {children}
 
         <SkeletonTextOverlay done={done} {...borderProps} />
@@ -74,3 +70,14 @@ export const SkeletonText: React.FC<SkeletonTextProps> = ({
     </Text>
   )
 }
+
+const FADE = keyframes`
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+`
+
+const SkeletonFade = styled(Box)<DoneProps>`
+  background-color: ${themeGet("colors.black5")};
+  animation: ${FADE} 2s ease-in-out infinite;
+`


### PR DESCRIPTION
I mentioned this over Slack — but this animation never got disabled on lazy images. As a result when there are a lot of them, performance drops dramatically. The homepage rebuild I'm working on goes from basically unusable to normal 60fps when I simply disable the animation in the class.

EDIT: Trying this now with an opacity animation and disabling it once done.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.35.3-canary.950.17754.0
  # or 
  yarn add @artsy/palette@14.35.3-canary.950.17754.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
