### PR TITLE
fix: Remove react-spring

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -121,7 +121,6 @@
     "rc-slider": "^8.6.2",
     "react-lazy-load-image-component": "1.5.0",
     "react-remove-scroll": "^2.3.0",
-    "react-spring": "^8.0.27",
     "styled-bootstrap-grid": "3.1.0",
     "styled-system": "^5.1.5",
     "trunc-html": "^1.1.2",

--- a/packages/palette/src/elements/DonutChart/DonutChart.test.tsx
+++ b/packages/palette/src/elements/DonutChart/DonutChart.test.tsx
@@ -64,16 +64,4 @@ describe("DonutChart", () => {
     hoverArea.simulate("mouseleave")
     expect(chart.text()).not.toContain("423 views")
   })
-  it("animates", () => {
-    const chart = getWrapper()
-    let aSlice = chart.find("path").last()
-    const pathBeforeAnimation = aSlice.prop("d")
-
-    mockRaf.step({ count: 3000 })
-    chart.update()
-    aSlice = chart.find("path").last()
-    const pathAfterAnimation = aSlice.prop("d")
-
-    expect(pathBeforeAnimation).not.toEqual(pathAfterAnimation)
-  })
 })

--- a/packages/palette/src/elements/LineChart/LineChart.test.tsx
+++ b/packages/palette/src/elements/LineChart/LineChart.test.tsx
@@ -1,4 +1,4 @@
-import { mount, ReactWrapper } from "enzyme"
+import { mount } from "enzyme"
 import "jest-styled-components"
 import createMockRaf from "mock-raf"
 
@@ -58,32 +58,10 @@ describe("LineChart", () => {
 
   it("shows hover labels when you hover over the bar", () => {
     const chart = getWrapper()
-    const hoverArea = chart
-      .find(PointHoverArea)
-      .last()
-      .find("div")
-      .first()
+    const hoverArea = chart.find(PointHoverArea).last().find("div").first()
     hoverArea.simulate("mouseenter")
     expect(chart.text()).toContain("423 views")
     hoverArea.simulate("mouseleave")
     expect(chart.text()).not.toContain("423 views")
-  })
-
-  it("animates", () => {
-    const circleYSum = cs =>
-      cs.reduce(
-        (acc: number, c: ReactWrapper) => acc + parseInt(c.prop("cy"), 10),
-        0
-      )
-    const chart = getWrapper()
-    let circles = chart.find("circle")
-    const circleYBeforeAnimate = circleYSum(circles)
-    // step requestAnimationFrame 3000 times
-    mockRaf.step({ count: 3000 })
-    chart.update()
-    circles = chart.find("circle")
-    const circleYAfterAnimate = circleYSum(circles)
-    // points will have lower Y after animation because the Y axis is upside-down
-    expect(circleYBeforeAnimate).toBeGreaterThan(circleYAfterAnimate)
   })
 })

--- a/packages/palette/src/elements/LineChart/LineChart.tsx
+++ b/packages/palette/src/elements/LineChart/LineChart.tsx
@@ -5,7 +5,6 @@ import { ChartHoverTooltip } from "../DataVis/ChartHoverTooltip"
 import { coerceTooltip } from "../DataVis/ChartTooltip"
 import { ProvideMousePosition } from "../DataVis/MousePositionContext"
 import { ChartProps } from "../DataVis/utils/SharedTypes"
-import { useHasEnteredViewport } from "../DataVis/utils/useHasEnteredViewPort"
 import { useWrapperWidth } from "../DataVis/utils/useWrapperWidth"
 import { Flex } from "../Flex"
 import { Sans } from "../Typography"
@@ -29,8 +28,6 @@ export const LineChart: React.FC<LineChartProps> = ({
   const [hoverIndex, setHoverIndex] = useState(-1)
 
   const wrapperRef = useRef<HTMLDivElement>(null)
-
-  const hasEnteredViewport = useHasEnteredViewport(wrapperRef)
 
   const width = useWrapperWidth(wrapperRef)
 
@@ -57,9 +54,8 @@ export const LineChart: React.FC<LineChartProps> = ({
               margin={margin}
               points={points}
               hoverIndex={hoverIndex}
-              hasEnteredViewport={hasEnteredViewport}
             />
-            {points.filter(bar => bar.axisLabelX).length > 0 && (
+            {points.filter((bar) => bar.axisLabelX).length > 0 && (
               <Flex px="2" width={width}>
                 {points.map(({ axisLabelX }, i) => (
                   <BarAxisLabelContainer

--- a/packages/palette/src/elements/LineChart/LineChartSVG.tsx
+++ b/packages/palette/src/elements/LineChart/LineChartSVG.tsx
@@ -1,7 +1,6 @@
 import { interpolateArray } from "d3-interpolate"
 import { line as d3Line } from "d3-shape"
 import React from "react"
-import { Spring } from "react-spring/renderprops.cjs"
 import styled from "styled-components"
 import { color } from "../../helpers"
 import { PointDescriptor } from "../DataVis/utils/SharedTypes"
@@ -14,7 +13,7 @@ interface LineChartSVGProps {
   margin: number
   points: PointDescriptor[]
   hoverIndex: number
-  hasEnteredViewport: boolean
+  hasEnteredViewport?: boolean
 }
 
 /**
@@ -26,9 +25,8 @@ export const LineChartSVG: React.FC<LineChartSVGProps> = ({
   margin,
   points,
   hoverIndex,
-  hasEnteredViewport,
 }: LineChartSVGProps) => {
-  const values = points.map(d => d.value)
+  const values = points.map((d) => d.value)
   const maxValue = Math.max(...points.map(({ value }) => value))
 
   const zeros = values.map(() => 0)
@@ -38,42 +36,31 @@ export const LineChartSVG: React.FC<LineChartSVGProps> = ({
   const h = height - 2 * margin
 
   // maps value to x/y position
-  const displayYPosition = d => (maxValue ? h - (d * h) / maxValue : h)
+  const displayYPosition = (d) => (maxValue ? h - (d * h) / maxValue : h)
   const displayXPosition = (_d, i) => (i / (points.length - 1)) * w
 
-  const line = d3Line()
-    .x(displayXPosition)
-    .y(displayYPosition)
+  const line = d3Line().x(displayXPosition).y(displayYPosition)
+
+  const interpolatedValues: any = valuesInterpolator(1)
   return (
     <Svg width={width} height={height}>
       <g transform={`translate(0, ${margin})`}>
         <line stroke={color("black10")} x1="0" x2={width} y1={h} y2={h} />
         <g transform={`translate(${margin}, 0)`}>
-          <Spring
-            from={{ num: 0 }}
-            to={hasEnteredViewport ? { num: 1 } : { num: 0 }}
-            delay={500}
-          >
-            {({ num }) => {
-              const interpolatedValues: any = valuesInterpolator(num)
+          <>
+            <Line path={line(interpolatedValues as any)} />
+            {interpolatedValues.map((value, index) => {
               return (
-                <>
-                  <Line path={line(interpolatedValues as any)} />
-                  {interpolatedValues.map((value, index) => {
-                    return (
-                      <Point
-                        hovered={hoverIndex === index}
-                        key={index}
-                        opacity={num}
-                        cx={displayXPosition(value, index)}
-                        cy={displayYPosition(value)}
-                      />
-                    )
-                  })}
-                </>
+                <Point
+                  hovered={hoverIndex === index}
+                  key={index}
+                  opacity={1}
+                  cx={displayXPosition(value, index)}
+                  cy={displayYPosition(value)}
+                />
               )
-            }}
-          </Spring>
+            })}
+          </>
         </g>
       </g>
     </Svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -18726,14 +18726,6 @@ react-sizeme@^2.6.7:
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
 
-react-spring@^8.0.27:
-  version "8.0.27"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
-  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    prop-types "^15.5.8"
-
 react-style-singleton@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.1.1.tgz#ce7f90b67618be2b6b94902a30aaea152ce52e66"


### PR DESCRIPTION
This removes react spring from the app per [this thread](https://artsy.slack.com/archives/CA8SANW3W/p1624453974296000).

In short, react spring was causing a memory leak in our application. We've removed animation from the charts and replaced animation in modal with css, which additionally removes a boat load of complexity. 

![modal](https://user-images.githubusercontent.com/236943/123350195-54de1b80-d50f-11eb-8b61-39565613e4f1.gif)
