### PR TITLE
fix(join): supports nested children

### DIFF
--- a/packages/palette/src/elements/Join/Join.story.tsx
+++ b/packages/palette/src/elements/Join/Join.story.tsx
@@ -9,12 +9,14 @@ const BlankFunction = () => {
 }
 
 const NonBlankFunction = () => {
-  return <div>Non blank Function</div>
+  return <Text variant="md">Non-blank Function</Text>
 }
 
-const BlankSFC: React.SFC = () => null
+const BlankFC: React.FC = () => null
 
-const NonBlankSFC: React.SFC = () => <div>Non blanks stateless component</div>
+const NonBlankFC: React.FC = () => (
+  <Text variant="md">Non-blank Functional component</Text>
+)
 
 class BlankComponent extends Component {
   render() {
@@ -24,7 +26,7 @@ class BlankComponent extends Component {
 
 class NonBlankComponent extends Component {
   render() {
-    return <Box>Non Blank Component</Box>
+    return <Text variant="md">Non-Blank Class Component</Text>
   }
 }
 
@@ -32,9 +34,9 @@ export default { title: "Components/Join" }
 
 export const WithMultipleComponents = () => {
   return (
-    <Join separator={<Separator m={1} />}>
-      <Box>First in the list</Box>
-      <Box>Second in the list</Box>
+    <Join separator={<Separator my={1} />}>
+      <Text variant="md">First in the list</Text>
+      <Text variant="md">Second in the list</Text>
     </Join>
   )
 }
@@ -45,8 +47,8 @@ WithMultipleComponents.story = {
 
 export const WithOneComponent = () => {
   return (
-    <Join separator={<Separator m={1} />}>
-      <Box>Only one component here</Box>
+    <Join separator={<Separator my={1} />}>
+      <Text variant="md">Only one component here</Text>
     </Join>
   )
 }
@@ -57,18 +59,20 @@ WithOneComponent.story = {
 
 export const WithSomeOfTheChildrenEmpty = () => {
   return (
-    <Join separator={<Separator m={1} />}>
-      <Box>First in the list</Box>
+    <Join separator={<Separator my={1} />}>
+      <Text variant="md">First in the list</Text>
       <BlankFunction />
       <NonBlankFunction />
-      <BlankSFC />
-      <NonBlankSFC />
+      <BlankFC />
+      <NonBlankFC />
       <BlankComponent />
       <NonBlankComponent />
       <Box m="2" />
-      <div>Some div with the content</div>
+      <div>
+        <Text variant="md">Some div with the content</Text>
+      </div>
       <div />
-      <Box>Another box with content</Box>
+      <Text variant="md">Another box with content</Text>
       <div />
     </Join>
   )

--- a/packages/palette/src/elements/Join/Join.story.tsx
+++ b/packages/palette/src/elements/Join/Join.story.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react"
-import { Box } from "../Box/Box"
-import { Separator } from "../Separator/Separator"
+import { Box } from "../Box"
+import { Separator } from "../Separator"
+import { Text } from "../Text"
 import { Join } from "./Join"
 
 const BlankFunction = () => {
@@ -32,7 +33,7 @@ export default { title: "Components/Join" }
 export const WithMultipleComponents = () => {
   return (
     <Join separator={<Separator m={1} />}>
-      <Box>Fist in the list</Box>
+      <Box>First in the list</Box>
       <Box>Second in the list</Box>
     </Join>
   )
@@ -57,7 +58,7 @@ WithOneComponent.story = {
 export const WithSomeOfTheChildrenEmpty = () => {
   return (
     <Join separator={<Separator m={1} />}>
-      <Box>Fist in the list</Box>
+      <Box>First in the list</Box>
       <BlankFunction />
       <NonBlankFunction />
       <BlankSFC />
@@ -75,4 +76,27 @@ export const WithSomeOfTheChildrenEmpty = () => {
 
 WithSomeOfTheChildrenEmpty.story = {
   name: "with some of the children empty",
+}
+
+export const WithNestedChildren = () => {
+  return (
+    <Join separator={<Separator my={1} />}>
+      <Text variant="md">First in the list</Text>
+      <>
+        <Text variant="md">Second in the list</Text>
+        <Text variant="md">Third in the list</Text>
+        <>
+          <Text variant="md">Fourth in the list</Text>
+          <Text variant="md">Fifth in the list</Text>
+        </>
+
+        <Box>
+          <Text variant="md">These two lines</Text>
+          <Text variant="md">Are grouped</Text>
+        </Box>
+
+        <Text>End of list</Text>
+      </>
+    </Join>
+  )
 }

--- a/packages/palette/src/elements/Join/Join.tsx
+++ b/packages/palette/src/elements/Join/Join.tsx
@@ -1,4 +1,5 @@
-import React, { SFC } from "react"
+import React from "react"
+import { flattenChildren } from "../../helpers/flattenChildren"
 
 interface JoinProps {
   separator: React.ReactElement<any>
@@ -24,27 +25,29 @@ interface JoinProps {
  * <SomeComponent/>
  * <child3/>
  */
-export const Join: SFC<JoinProps> = ({ separator, children }) => {
-  const childArray = React.Children.toArray(children) as any
+export const Join: React.FC<JoinProps> = ({ separator, children }) => {
+  const elements = flattenChildren(children)
 
-  return childArray
-    .filter((child) => child)
-    .reduce((acc, curr, currentIndex) => {
-      acc.push(
-        React.cloneElement(curr as React.ReactElement<any>, {
-          key: `join-${currentIndex}`,
-        })
-      )
-
-      if (currentIndex !== childArray.length - 1) {
+  return (
+    <>
+      {elements.reduce((acc, element, currentIndex) => {
         acc.push(
-          separator &&
-            React.cloneElement(separator, {
-              key: `join-sep-${currentIndex}`,
-            })
+          React.cloneElement(element, {
+            key: `join-${currentIndex}`,
+          })
         )
-      }
 
-      return acc
-    }, []) as any
+        if (currentIndex !== elements.length - 1) {
+          acc.push(
+            separator &&
+              React.cloneElement(separator, {
+                key: `join-sep-${currentIndex}`,
+              })
+          )
+        }
+
+        return acc
+      }, [])}
+    </>
+  )
 }


### PR DESCRIPTION
Closes [WP-60](https://artsyproduct.atlassian.net/browse/WP-60)

You may want to conditionally render multiple things inside a join, which may require the use of a fragment. This change supports those cases.