### PR TITLE
feat(text): adds line-clamp

### DIFF
--- a/packages/palette/src/elements/Text/Text.story.tsx
+++ b/packages/palette/src/elements/Text/Text.story.tsx
@@ -220,21 +220,19 @@ export const CustomTypography = () => {
   )
 }
 
-export const OverflowEllipsis = () => {
+export const Truncation = () => {
   return (
-    <Text variant="text" overflowEllipsis>
-      All their equipment and instruments are alive. All their equipment and
-      instruments are alive. All their equipment and instruments are alive. All
-      their equipment and instruments are alive. All their equipment and
-      instruments are alive. All their equipment and instruments are alive. All
-      their equipment and instruments are alive. All their equipment and
-      instruments are alive. All their equipment and instruments are alive.
-    </Text>
+    <States<TextProps> states={[{ overflowEllipsis: true }, { lineClamp: 2 }]}>
+      <Text variant="text">
+        All their equipment and instruments are alive. All their equipment and
+        instruments are alive. All their equipment and instruments are alive.
+        All their equipment and instruments are alive. All their equipment and
+        instruments are alive. All their equipment and instruments are alive.
+        All their equipment and instruments are alive. All their equipment and
+        instruments are alive. All their equipment and instruments are alive.
+      </Text>
+    </States>
   )
-}
-
-OverflowEllipsis.story = {
-  name: "overflowEllipsis",
 }
 
 export const Caps = () => {

--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -22,6 +22,11 @@ export type BaseTextProps = TypographyProps &
   Omit<ColorProps, "color"> & {
     variant?: ResponsiveValue<TextVariant>
     textColor?: ResponsiveValue<Color>
+    /**
+     * Max number of lines before truncating the content with an ellipsis at the end of the last line.
+     * Overwriting display is required for this.
+     */
+    lineClamp?: number
   }
 
 const textColor = style({
@@ -55,6 +60,7 @@ export type TextProps = BaseTextProps &
   BoxProps & {
     overflowEllipsis?: boolean
     textTransform?: ResponsiveValue<TextTransform>
+    lineClamp?: ResponsiveValue<number>
   }
 
 /** Text */
@@ -77,7 +83,19 @@ export const Text = styled(Box)<TextProps>`
     })
   }}
 
-  ${({ overflowEllipsis }) => overflowEllipsis && overflowEllipsisMixin}
+  ${(props) => {
+    return css`
+      ${props.overflowEllipsis && overflowEllipsisMixin}
+      ${props.lineClamp &&
+      css`
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: ${props.lineClamp};
+        line-clamp: ${props.lineClamp};
+        overflow: hidden;
+      `}
+    `
+  }}
 `
 
 Text.displayName = "Text"


### PR DESCRIPTION
This is more of a nice-to-have / progressive enhancement. [It's reasonably well supported with all the evergreens.](https://caniuse.com/css-line-clamp)

![](https://static.damonzucconi.com/_capture/uj5ej4ow.png)