### PR TITLE
fix(tabs): attempts to fix unstyled tabs in force

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -99,16 +99,15 @@ export const Tabs: React.FC<TabsProps> = ({
       <BaseTabs {...rest}>
         {tabs.map((cell, i) => {
           return (
-            <BaseTab
-              as={Clickable}
+            <Clickable
               key={i}
               aria-selected={i === activeTabIndex}
               onClick={handleClick(i)}
-              active={i === activeTabIndex}
-              variant={textVariant}
             >
-              <span>{cell.props.name}</span>
-            </BaseTab>
+              <BaseTab active={i === activeTabIndex} variant={textVariant}>
+                <span>{cell.props.name}</span>
+              </BaseTab>
+            </Clickable>
           )
         })}
       </BaseTabs>


### PR DESCRIPTION
Closes: [WP-59](https://artsyproduct.atlassian.net/browse/WP-59)

This _should_ fix the issue. Attempted to upgrade styled-components to 5 but it didn't make a difference in Storybook. Could just be some kind of import order thing in Force itself rather than here.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.41.2-canary.965.18222.0
  # or 
  yarn add @artsy/palette@14.41.2-canary.965.18222.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
