### PR TITLE
fix(tabs): fixes styling

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -103,6 +103,7 @@ export const Tabs: React.FC<TabsProps> = ({
               key={i}
               aria-selected={i === activeTabIndex}
               onClick={handleClick(i)}
+              flex={1}
             >
               <BaseTab active={i === activeTabIndex} variant={textVariant}>
                 <span>{cell.props.name}</span>


### PR DESCRIPTION
https://github.com/artsy/palette/pull/965 introduced a minor visual bug where the first tab wouldn't fill out the container. Chromatic caught this but after merge since it currently isn't blocking PRs (TODO). 