### PR TITLE
fix(PX-4310): get page count information from Swiper and Carousel

### DIFF
--- a/packages/palette/src/elements/Carousel/Carousel.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.tsx
@@ -182,7 +182,7 @@ export const Carousel: React.FC<CarouselProps> = ({
     onChange && onChange(index)
   }, [onChange, index])
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     onPageCountChange && onPageCountChange(pages.length)
   }, [onPageCountChange, pages.length])
 

--- a/packages/palette/src/elements/Carousel/Carousel.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.tsx
@@ -87,6 +87,7 @@ export interface CarouselProps extends BoxProps {
    */
   Cell?: React.ForwardRefExoticComponent<CarouselCellProps>
   onChange?(index: number): void
+  onPageCountChange?(count: number): void
 }
 
 /**
@@ -103,6 +104,7 @@ export const Carousel: React.FC<CarouselProps> = ({
   Rail = CarouselRail,
   Cell = CarouselCell,
   onChange,
+  onPageCountChange,
   ...rest
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -179,6 +181,10 @@ export const Carousel: React.FC<CarouselProps> = ({
   useUpdateEffect(() => {
     onChange && onChange(index)
   }, [onChange, index])
+
+  useEffect(() => {
+    onPageCountChange && onPageCountChange(pages.length)
+  }, [onPageCountChange, pages.length])
 
   const offset = `-${pages[index]}px`
 

--- a/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
+++ b/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
@@ -7,7 +7,7 @@ jest.mock("../paginate", () => ({
   paginateCarousel: () => [0, 100],
 }))
 
-const tick = () => new Promise(resolve => setTimeout(resolve, 0))
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 describe("Carousel", () => {
   it("renders correctly", () => {
@@ -41,9 +41,10 @@ describe("Carousel", () => {
 
   it("updates correctly", async () => {
     const onChange = jest.fn()
+    const onPageCountChange = jest.fn()
 
     const wrapper = mount(
-      <Carousel onChange={onChange}>
+      <Carousel onChange={onChange} onPageCountChange={onPageCountChange}>
         <Box>1</Box>
         <Box>2</Box>
         <Box>3</Box>
@@ -52,6 +53,9 @@ describe("Carousel", () => {
 
     // Does not call `onChange` on initial mount
     expect(onChange).not.toBeCalled()
+
+    // Calls onPageCountChange with the correct page count
+    expect(onPageCountChange).lastCalledWith(2)
 
     // Click next
     const next = wrapper.find("button").at(2)

--- a/packages/palette/src/elements/Swiper/Swiper.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.tsx
@@ -65,6 +65,7 @@ export type SwiperProps = BoxProps & {
    */
   Cell?: React.ForwardRefExoticComponent<SwiperCellProps>
   onChange?(index: number): void
+  onPageCountChange?(count: number): void
 }
 
 /**
@@ -80,6 +81,7 @@ export const Swiper: React.FC<SwiperProps> = ({
   Rail = SwiperRail,
   Cell = SwiperCell,
   onChange,
+  onPageCountChange,
   ...rest
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -153,6 +155,10 @@ export const Swiper: React.FC<SwiperProps> = ({
   useEffect(() => {
     onChange && onChange(index)
   }, [onChange, index])
+
+  useEffect(() => {
+    onPageCountChange && onPageCountChange(cells.length)
+  }, [onPageCountChange, cells.length])
 
   return (
     <Container ref={containerRef as any} mx={0} my={0} {...rest}>

--- a/packages/palette/src/elements/Swiper/__tests__/Swiper.test.tsx
+++ b/packages/palette/src/elements/Swiper/__tests__/Swiper.test.tsx
@@ -5,8 +5,10 @@ import { Swiper } from "../Swiper"
 
 describe("Swiper", () => {
   it("renders correctly", () => {
+    const onPageCountChange = jest.fn()
+
     const wrapper = mount(
-      <Swiper snap="center">
+      <Swiper onPageCountChange={onPageCountChange} snap="center">
         <Box>1</Box>
         <Box>2</Box>
         <Box>3</Box>
@@ -16,6 +18,7 @@ describe("Swiper", () => {
     // Renders all cells
     expect(wrapper.find(Box).length).toBe(3)
     expect(wrapper.html()).toContain("scroll-snap-align: center")
+    expect(onPageCountChange).lastCalledWith(3)
   })
 
   it("accepts a customizable Rail", () => {


### PR DESCRIPTION
This PR adds `onPageCountChange` event to be able to make dynamic data loading for the `Swiper` and `Carousel`.

I want to add batch loading for the artworks on the Artists page(PPP) and as far as I see now it's impossible to implement that without page count information. Please let me know if you have another option.

JIRA - https://artsyproduct.atlassian.net/browse/PX-4310