### PR TITLE
fix(image): supports native img props

### DIFF
--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -8,6 +8,8 @@ export default {
 export const _Image = () => {
   return (
     <Image
+      id="example"
+      className="example"
       width="300px"
       height="200px"
       src="https://picsum.photos/seed/example/300/200"

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -1,8 +1,5 @@
 import React from "react"
 import styled from "styled-components"
-import { CleanTag } from "../CleanTag"
-import { LazyImage } from "./LazyImage"
-
 import {
   borderRadius,
   BorderRadiusProps,
@@ -20,17 +17,13 @@ import {
   width,
   WidthProps,
 } from "styled-system"
+import { CleanTag } from "../CleanTag"
+import { LazyImage } from "./LazyImage"
 
 /** Props for a web-only Image component. */
 export interface WebImageProps extends ImageProps {
   /** Flag for if image should be lazy loaded */
   lazyLoad?: boolean
-  /** Alternate text for image */
-  alt?: string
-  /** A11y text label */
-  ["aria-label"]?: string
-  /** The title of the image */
-  title?: string
   /** Flag indicating that right clicks should be prevented */
   preventRightClick?: boolean
 }
@@ -42,15 +35,8 @@ const ratioPadding = system({
   },
 })
 
-/** Props for web & iOS images */
-export interface BaseImageProps {
-  /** The URL for the image */
-  src: string
-  /** The URLs for the image */
-  srcSet?: string
-  /** Apply additional styles to component */
-  style?: object
-}
+export interface BaseImageProps
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "height" | "width"> {}
 
 export interface ImageProps
   extends BaseImageProps,


### PR DESCRIPTION
While although this doesn't do much in addressing [my list of grievances](https://artsyproduct.atlassian.net/browse/DSWGW-79) — I do need to put an `id` on an image so this fixes the types.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@14.43.1-canary.978.18680.0
  # or 
  yarn add @artsy/palette@14.43.1-canary.978.18680.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
