### PR TITLE
fix(PX-4059): prevent link click if there is no next or prev page

### DIFF
--- a/packages/palette/src/elements/Pagination/SmallPagination.tsx
+++ b/packages/palette/src/elements/Pagination/SmallPagination.tsx
@@ -22,11 +22,17 @@ export const SmallPagination: React.FC<PaginationProps> = (props) => {
   const handlePrevClick = (event: React.MouseEvent) => {
     if (previous) {
       onClick(previous.cursor, previous.page, event)
+    } else {
+      event.preventDefault()
     }
   }
 
   const handleNextClick = (event: React.MouseEvent) => {
-    onNext(event, nextPage)
+    if (hasNextPage) {
+      onNext(event, nextPage)
+    } else {
+      event.preventDefault()
+    }
   }
 
   const nextPage = (previous?.page || 0) + 2

--- a/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
+++ b/packages/palette/src/elements/Pagination/__tests__/SmallPagination.test.tsx
@@ -118,10 +118,10 @@ describe("SmallPagination", () => {
       expect(onClickMock).toHaveBeenCalledWith("ABC123==", 1, expect.anything())
     })
 
-    it("renders the next button as disabled and calls the onNext function when clicked", () => {
+    it("renders the next button as disabled and does not call the onNext function when clicked", () => {
       const wrapper = mountWrapper()
       wrapper.find("NextButton Link").simulate("click")
-      expect(onNextMock).toHaveBeenCalledWith(expect.anything(), 3)
+      expect(onNextMock).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
This PR doesn't allow clicking on the next or prev button if there is no next or prev page. 

JIRA - https://artsyproduct.atlassian.net/browse/PX-4059

Before

https://user-images.githubusercontent.com/79979820/126981637-beff0abd-a7a8-48f5-b077-d7589020a10b.mov
