### PR TITLE
feat: Export v2/v3 theme constants

### DIFF
--- a/packages/palette/src/Theme.tsx
+++ b/packages/palette/src/Theme.tsx
@@ -6,7 +6,9 @@ import { GridThemeProvider as StyledGridThemeProvider } from "styled-bootstrap-g
 import { ThemeContext, ThemeProvider } from "styled-components"
 import { Theme as TTheme, THEME_V2, THEME_V3, ThemeV2, ThemeV3 } from "./themes"
 
+export { THEME_V2, THEME_V3 } from "./themes"
 export * from "@artsy/palette-tokens/dist/themes/v2"
+
 export { TextVariant } from "@artsy/palette-tokens/dist/typography/types"
 
 /**


### PR DESCRIPTION
This exports our palette theme constants so that we can access static values outside of the hook 