### PR TITLE
chore(space,color): deprecates space & color functions

### DIFF
--- a/packages/palette-tokens/src/helpers.ts
+++ b/packages/palette-tokens/src/helpers.ts
@@ -3,6 +3,8 @@ import tokens, { Color, ColorValue, SpacingUnit } from "./index";
 /**
  * A helper to easily access space values when not in a styled-components or
  * styled-systems context.
+ *
+ * @deprecated use component spacing props, or `themeGet('space.n')`
  */
 export const space = (spaceKey: SpacingUnit): number => {
   return parseInt(tokens.space[spaceKey], 10);
@@ -11,6 +13,8 @@ export const space = (spaceKey: SpacingUnit): number => {
 /**
  * A helper to easily access colors when not in a styled-components or
  * styled-systems context.
+ *
+ * @deprecated use component `color` or `borderColor` props, or `themeGet('colors.colorName')`
  */
 export function color(colorKey: undefined): undefined;
 export function color(colorKey: Color): ColorValue;

--- a/packages/palette/src/helpers/color.ts
+++ b/packages/palette/src/helpers/color.ts
@@ -3,5 +3,7 @@ import { Color, themeProps } from "../Theme"
 /**
  * A helper to easily access colors when not in a styled-components or
  * styled-systems context.
+ *
+ * @deprecated use component `color` or `borderColor` props, or `themeGet('colors.colorName')`
  */
 export const color = (colorKey: Color) => themeProps.colors[colorKey]

--- a/packages/palette/src/helpers/space.ts
+++ b/packages/palette/src/helpers/space.ts
@@ -3,6 +3,8 @@ import { SpacingUnit, themeProps } from "../Theme"
 /**
  * A helper to easily access space values when not in a styled-components or
  * styled-systems context.
+ *
+ * @deprecated use component spacing props, or `themeGet('space.n')`
  */
 export const space = (spaceKey: SpacingUnit): number => {
   return parseInt(themeProps.space[spaceKey], 10)


### PR DESCRIPTION
Deprecates `color` and `space`