### PR TITLE
feat(input): supports inputs with custom heights

### DIFF
--- a/packages/palette/src/elements/Input/Input.story.tsx
+++ b/packages/palette/src/elements/Input/Input.story.tsx
@@ -61,3 +61,7 @@ export const Required = () => {
     </form>
   )
 }
+
+export const CustomHeight = () => {
+  return <Input height={40} placeholder="Input is 40px in height" />
+}

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -3,6 +3,7 @@ import { themeGet } from "@styled-system/theme-get"
 import React from "react"
 import styled from "styled-components"
 import { css } from "styled-components"
+import { height as systemHeight } from "styled-system"
 import { getThemeConfig, useThemeConfig } from "../../Theme"
 import { Box, BoxProps, splitBoxProps } from "../Box"
 import { Spacer } from "../Spacer"
@@ -39,6 +40,7 @@ export const Input: React.ForwardRefExoticComponent<
       focus,
       hover,
       title,
+      height,
       ...rest
     },
     ref
@@ -47,11 +49,13 @@ export const Input: React.ForwardRefExoticComponent<
 
     const tokens = useThemeConfig({
       v2: {
+        height: height ?? 40,
         titleVariant: "text" as TextVariant,
         titleTextTransform: null,
         secondaryTextVariant: "small" as TextVariant,
       },
       v3: {
+        height: height ?? 50,
         titleVariant: "xs" as TextVariant,
         titleTextTransform: "uppercase",
         secondaryTextVariant: "xs" as TextVariant,
@@ -95,6 +99,7 @@ export const Input: React.ForwardRefExoticComponent<
           hover={hover}
           error={!!error}
           required={required}
+          height={tokens.height as any}
           {...inputProps}
         />
 
@@ -122,6 +127,7 @@ const StyledInput = styled.input<StyledInputProps>`
   border-radius: 0;
   transition: border-color 0.25s;
   font-family: ${themeGet("fonts.sans")};
+  ${systemHeight};
 
   ${(props) => {
     const states = getThemeConfig(props, {

--- a/packages/palette/src/elements/Input/tokens/v2.ts
+++ b/packages/palette/src/elements/Input/tokens/v2.ts
@@ -4,7 +4,6 @@ import { State } from "./types"
 
 export const INPUT_STATES: Record<State, any> = {
   default: css`
-    height: 40px;
     font-size: ${themeGet("fontSizes.size3")};
     color: ${themeGet("colors.black100")};
     border-color: ${themeGet("colors.black10")};

--- a/packages/palette/src/elements/Input/tokens/v3.ts
+++ b/packages/palette/src/elements/Input/tokens/v3.ts
@@ -4,7 +4,6 @@ import { State } from "./types"
 
 export const INPUT_STATES: Record<State, any> = {
   default: css`
-    height: 50px;
     font-size: ${themeGet("textVariants.sm.fontSize")};
     color: ${themeGet("colors.black100")};
     border-color: ${themeGet("colors.black30")};


### PR DESCRIPTION
The use-case for this is to align the v3 inputs with the height of the Artsy logo in the global nav.

Currently (50px): 

![](https://static.damonzucconi.com/_capture/xQ6lKlYD.png)