### PR TITLE
fix(text): increases text styles specificity

### DIFF
--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -65,37 +65,39 @@ export type TextProps = BaseTextProps &
 
 /** Text */
 export const Text = styled(Box)<TextProps>`
-  ${(props) => {
-    return getThemeConfig(props, {
-      v2: css`
-        ${variant({ variants: V2_TEXT_VARIANTS.small })}
-        ${textMixin}
+  && {
+    ${(props) => {
+      return getThemeConfig(props, {
+        v2: css`
+          ${variant({ variants: V2_TEXT_VARIANTS.small })}
+          ${textMixin}
 
         @media (min-width: ${themeGet("breakpoints.0")}) {
-          ${variant({ variants: V2_TEXT_VARIANTS.large })}
+            ${variant({ variants: V2_TEXT_VARIANTS.large })}
+            ${textMixin}
+          }
+        `,
+        v3: css`
+          ${variant({ variants: V3_TEXT_VARIANTS })}
           ${textMixin}
-        }
-      `,
-      v3: css`
-        ${variant({ variants: V3_TEXT_VARIANTS })}
-        ${textMixin}
-      `,
-    })
-  }}
+        `,
+      })
+    }}
 
-  ${(props) => {
-    return css`
-      ${props.overflowEllipsis && overflowEllipsisMixin}
-      ${props.lineClamp &&
-      css`
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: ${props.lineClamp};
-        line-clamp: ${props.lineClamp};
-        overflow: hidden;
-      `}
-    `
-  }}
+    ${(props) => {
+      return css`
+        ${props.overflowEllipsis && overflowEllipsisMixin}
+        ${props.lineClamp &&
+        css`
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: ${props.lineClamp};
+          line-clamp: ${props.lineClamp};
+          overflow: hidden;
+        `}
+      `
+    }}
+  }
 `
 
 Text.displayName = "Text"


### PR DESCRIPTION
I just paired with @rajsam003 to figure this one out... working off https://github.com/artsy/palette/pull/1006

The way `BaseTab` is set up is that it expects to be a button, potentially. So rather than altering those styles, it'd be good to just be able to use `as={Clickable}` and have it work as you'd expect.

We can [use this recommendation from styled-components](https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity) to increase the specificity of the `Text` styles and that way we can use `Clickable` again without too much worry.