### PR TITLE
fix(text): exports text-transform type

### DIFF
--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -35,7 +35,7 @@ const textColor = style({
   key: "colors",
 })
 
-type TextTransform =
+export type TextTransform =
   | "none"
   | "capitalize"
   | "uppercase"


### PR DESCRIPTION
Good catch @lilyfromseattle — once this is published you can cast as this. Alternatively I could just make this a string value but we'd lose the auto-complete 🤔 