### PR TITLE
fix(PX-4326): Don't manually override background in Pill component in SavedAddresses [WIP]

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -66,6 +66,8 @@ export type PillProps = ClickableProps & {
   focus?: boolean
   /** Forces hover state */
   hover?: boolean
+  /** Swich off focus, hover  */
+  disabled?: boolean
 } & (
     | {
         variant?: Extract<PillVariant, "textRound" | "textSquare" | "filter">
@@ -97,17 +99,17 @@ const Container = styled(Clickable)<PillProps>`
 
   ${(props) => {
     return css`
-      ${props.hover && STATES.hover}
-      ${props.focus && STATES.focus}
+      ${!props.disabled && props.hover && STATES.hover}
+      ${!props.disabled && props.focus && STATES.focus}
       ${"active" in props && props.active && STATES.active}
 
       &:hover {
-        ${STATES.hover}
+        ${!props.disabled && STATES.hover}
       }
 
       &:focus {
         outline: 0;
-        ${STATES.focus}
+        ${!props.disabled && STATES.focus}
       }
     `
   }}


### PR DESCRIPTION
Jira Ticket: https://artsyproduct.atlassian.net/browse/PX-4326
Discussion: https://github.com/artsy/force/pull/7869#discussion_r669827365

It is my first PR for `Palette` so please double check

This PR  is a continuation of fixing [PX-4326](https://github.com/artsy/force/pull/8127).

In my opinion, a good option is to add a property `disabled` which will switch off hover and focus in the `Pill` component

Also, this PR resolves this ticket to:[PX-4367]( https://artsyproduct.atlassian.net/browse/PX-4367)