### PR TITLE
fix(avatar,entityheader): supports detailed image props

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.story.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.story.tsx
@@ -22,20 +22,18 @@ export const Sizes = () => {
   )
 }
 
-export const WithSrc = () => {
+export const WithImage = () => {
   return (
     <States<AvatarProps>
       states={[{ size: "xxs" }, { size: "xs" }, { size: "sm" }, { size: "md" }]}
     >
       <Avatar
         size="xs"
-        src="https://randomuser.me/api/portraits/lego/2.jpg"
+        src="https://picsum.photos/seed/example/110/110"
+        srcSet="https://picsum.photos/seed/example/110/110 1x, https://picsum.photos/seed/example/220/220 2x"
+        lazyLoad
         initials="TK"
       />
     </States>
   )
-}
-
-WithSrc.story = {
-  name: "With `src`",
 }

--- a/packages/palette/src/elements/Avatar/Avatar.test.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.test.tsx
@@ -3,11 +3,9 @@ import React from "react"
 import { Avatar } from "../Avatar"
 
 describe("Avatar", () => {
-  describe("on web", () => {
-    it("renders an image if image url provided", () => {
-      const wrapper = mount(<Avatar src="some/path.img" />)
-      expect(wrapper.find("img").length).toBe(1)
-    })
+  it("renders an image if image url provided", () => {
+    const wrapper = mount(<Avatar src="some/path.img" />)
+    expect(wrapper.find("img").length).toBe(1)
   })
 
   it("renders initials if no image url and initials provided", () => {
@@ -26,5 +24,22 @@ describe("Avatar", () => {
     expect(getWrapper("xs").html()).toContain("45")
     expect(getWrapper("sm").html()).toContain("70")
     expect(getWrapper("md").html()).toContain("100")
+  })
+
+  it("passes the props down to the image", () => {
+    const wrapper = mount(
+      <Avatar
+        initials="EX"
+        src="example1x.jpg"
+        srcSet="example1x.jpg 1x, example2x.jpg 2x"
+        lazyLoad
+      />
+    )
+
+    expect(wrapper.find("img").html()).toContain('src="example1x.jpg"')
+    expect(wrapper.find("img").html()).toContain(
+      'srcset="example1x.jpg 1x, example2x.jpg 2x"'
+    )
+    expect(wrapper.find("img").html()).toContain('alt="EX"')
   })
 })

--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -54,7 +54,14 @@ export const Avatar: React.FC<AvatarProps> = ({
 
       {src && (
         <Flex position="absolute" top={0} left={0} width="100%" height="100%">
-          <Image src={src} width="100%" height="100%" {...imageProps} />
+          <Image
+            src={src}
+            width="100%"
+            height="100%"
+            lazyLoad={lazyLoad}
+            alt={initials ?? ""}
+            {...imageProps}
+          />
         </Flex>
       )}
     </Flex>

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.story.tsx
@@ -30,6 +30,13 @@ const FollowButton = () => {
   })
 }
 
+const imageProps = {
+  src: "https://picsum.photos/seed/example/110/110",
+  srcSet:
+    "https://picsum.photos/seed/example/110/110 1x, https://picsum.photos/seed/example/220/220 2x",
+  lazyLoad: true,
+}
+
 export const Default = () => {
   return (
     <States<EntityHeaderProps>
@@ -40,29 +47,29 @@ export const Default = () => {
         {
           smallVariant: true,
           name: "Francesca DiMattio",
-          imageUrl: "https://picsum.photos/seed/example/110/110",
+          image: imageProps,
         },
         {
           name: "Francesca DiMattio",
-          imageUrl: "https://picsum.photos/seed/example/110/110",
+          image: imageProps,
         },
         {
           initials: "FD",
           name: "Francesca DiMattio",
-          imageUrl: "https://picsum.photos/seed/example/110/110",
+          image: imageProps,
           meta: "American, b. 1979",
           href: "http://www.artsy.net/artist/francesca-dimattio",
         },
         {
           smallVariant: true,
           name: "Francesca DiMattio",
-          imageUrl: "https://picsum.photos/seed/example/110/110",
+          image: imageProps,
           FollowButton: <FollowButton />,
         },
         {
           initials: "FD",
           name: "Francesca DiMattio",
-          imageUrl: "https://picsum.photos/seed/example/110/110",
+          image: imageProps,
           meta: "American, b. 1979",
           href: "http://www.artsy.net/artist/francesca-dimattio",
           FollowButton: <FollowButton />,
@@ -70,7 +77,7 @@ export const Default = () => {
         {
           initials: "FLD",
           name: "Francesca Longer DiMattio",
-          imageUrl: "https://picsum.photos/seed/example/110/110",
+          image: imageProps,
           meta: "American, b. Founded 1979",
           href: "http://www.artsy.net/artist/francesca-dimattio",
           FollowButton: <FollowButton />,

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -1,12 +1,16 @@
 import React from "react"
 import { useThemeConfig } from "../../Theme"
 import { FlexProps } from "../Flex"
+import { WebImageProps } from "../Image"
 import { EntityHeader as EntityHeaderV2 } from "./v2/EntityHeader"
 import { EntityHeader as EntityHeaderV3 } from "./v3/EntityHeader"
 
 export interface EntityHeaderProps extends FlexProps {
   href?: string
+  /** @deprecated: use `image` instead */
   imageUrl?: string
+  /** Pass props to the underlying `Image` in `Avatar` */
+  image?: Partial<WebImageProps>
   initials?: string
   meta?: string
   name: string

--- a/packages/palette/src/elements/EntityHeader/__tests__/EntityHeader.test.tsx
+++ b/packages/palette/src/elements/EntityHeader/__tests__/EntityHeader.test.tsx
@@ -1,0 +1,28 @@
+import { mount } from "enzyme"
+import React from "react"
+import { ThemeProviderV3 } from "../../../Theme"
+import { EntityHeader } from "../EntityHeader"
+
+describe("EntityHeader", () => {
+  const getWrapper = () => {
+    return mount(
+      <ThemeProviderV3>
+        <EntityHeader
+          name="Example"
+          image={{
+            src: "example1x.jpg",
+            srcSet: "example1x.jpg 1x, example2x.jpg 2x",
+          }}
+        />
+      </ThemeProviderV3>
+    )
+  }
+
+  it("renders correctly", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.html()).toContain("Example")
+    expect(wrapper.html()).toContain(
+      'srcset="example1x.jpg 1x, example2x.jpg 2x"'
+    )
+  })
+})

--- a/packages/palette/src/elements/EntityHeader/v3/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/v3/EntityHeader.tsx
@@ -10,6 +10,7 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
   meta,
   initials,
   imageUrl,
+  image,
   smallVariant,
   FollowButton,
   ...rest
@@ -22,12 +23,13 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
           ? { as: "a", href, style: { textDecoration: "none" } }
           : {})}
       >
-        {(imageUrl || initials) && (
+        {(imageUrl || image || initials) && (
           <Flex mr={1}>
             <Avatar
               size={smallVariant ? "xxs" : "xs"}
               src={imageUrl}
               initials={initials}
+              {...image}
             />
           </Flex>
         )}


### PR DESCRIPTION
Closes: [GRO-480](https://artsyproduct.atlassian.net/browse/GRO-480)

We'd like to support both `srcSet` and `lazyLoad` on images in `EntityHeaders`, this change deprecates the `imageUrl` prop and adds support for passing arbitrary image props, which get threaded into the image in `Avatar`.