### PR TITLE
chore(image): removes responsive image; cleans up types

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -2,11 +2,11 @@ import React from "react"
 import { useThemeConfig } from "../../Theme"
 import { splitBoxProps } from "../Box"
 import { Flex, FlexProps } from "../Flex"
-import { Image, WebImageProps } from "../Image"
+import { Image, ImageProps } from "../Image"
 import { Text } from "../Text"
 import { V2_TOKENS, V3_TOKENS } from "./tokens"
 
-export interface AvatarProps extends FlexProps, Partial<WebImageProps> {
+export interface AvatarProps extends FlexProps, Partial<ImageProps> {
   /** If an image is missing, show initials instead */
   initials?: string
   /** The size of the Avatar */

--- a/packages/palette/src/elements/Cards/MediumCard.tsx
+++ b/packages/palette/src/elements/Cards/MediumCard.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
-import { Image, WebImageProps } from "../Image"
+import { Image, ImageProps } from "../Image"
 import { Text } from "../Text"
 import { CardTag } from "./CardTag"
 import { CardTagProps } from "./CardTag"
 
 export interface MediumCardProps extends BoxProps {
-  image: string | WebImageProps
+  image: string | ImageProps
   title: string
   subtitle?: string
   tag?: CardTagProps

--- a/packages/palette/src/elements/Cards/SmallCard.tsx
+++ b/packages/palette/src/elements/Cards/SmallCard.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
-import { Image, WebImageProps } from "../Image"
+import { Image, ImageProps } from "../Image"
 import { Text } from "../Text"
 import { CardTag } from "./CardTag"
 import { CardTagProps } from "./CardTag"
 
-type Images = string[] | WebImageProps[]
+type Images = string[] | ImageProps[]
 
 export interface SmallCardProps extends BoxProps {
   images: Images
@@ -30,7 +30,7 @@ export const SmallCard: React.FC<SmallCardProps> = ({
   tag,
   ...rest
 }) => {
-  const imageAttributes: WebImageProps[] = isArrayOfStrings(images)
+  const imageAttributes: ImageProps[] = isArrayOfStrings(images)
     ? images.map((src) => ({ src }))
     : images
 

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { useThemeConfig } from "../../Theme"
 import { FlexProps } from "../Flex"
-import { WebImageProps } from "../Image"
+import { ImageProps } from "../Image"
 import { EntityHeader as EntityHeaderV2 } from "./v2/EntityHeader"
 import { EntityHeader as EntityHeaderV3 } from "./v3/EntityHeader"
 
@@ -10,7 +10,7 @@ export interface EntityHeaderProps extends FlexProps {
   /** @deprecated: use `image` instead */
   imageUrl?: string
   /** Pass props to the underlying `Image` in `Avatar` */
-  image?: Partial<WebImageProps>
+  image?: Partial<ImageProps>
   initials?: string
   meta?: string
   name: string

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -5,7 +5,7 @@ export default {
   title: "Components/Image",
 }
 
-export const _Image = () => {
+export const Default = () => {
   return (
     <Image
       id="example"
@@ -15,6 +15,10 @@ export const _Image = () => {
       src="https://picsum.photos/seed/example/300/200"
     />
   )
+}
+
+Default.story = {
+  name: "Image",
 }
 
 export const ImageWSrcSet = () => {
@@ -29,10 +33,10 @@ export const ImageWSrcSet = () => {
 }
 
 ImageWSrcSet.story = {
-  name: "Image w/srcSet",
+  name: "Image + srcSet",
 }
 
-export const LazyImage = () => {
+export const ImageLazyLoad = () => {
   return (
     <>
       {Array.from(Array(100)).map((_, i) => (
@@ -48,11 +52,11 @@ export const LazyImage = () => {
   )
 }
 
-LazyImage.story = {
-  name: "LazyImage",
+ImageLazyLoad.story = {
+  name: "Image + lazyLoad",
 }
 
-export const LazyImageWSrcSet = () => {
+export const ImageLazyLoadSrcSet = () => {
   return (
     <>
       {Array.from(Array(100)).map((_, i) => (
@@ -69,6 +73,6 @@ export const LazyImageWSrcSet = () => {
   )
 }
 
-LazyImageWSrcSet.story = {
-  name: "LazyImage w/srcSet",
+ImageLazyLoadSrcSet.story = {
+  name: "Image + lazyLoad + srcSet",
 }

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -8,116 +8,43 @@ import {
   HeightProps,
   maxHeight,
   MaxHeightProps,
-  maxWidth,
-  MaxWidthProps,
-  ResponsiveValue,
   space,
   SpaceProps,
-  system,
   width,
   WidthProps,
 } from "styled-system"
 import { CleanTag } from "../CleanTag"
 import { LazyImage } from "./LazyImage"
 
-/** Props for a web-only Image component. */
-export interface WebImageProps extends ImageProps {
+export interface ImageProps
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "width" | "height">,
+    SpaceProps,
+    WidthProps,
+    HeightProps,
+    MaxHeightProps,
+    BorderRadiusProps {
   /** Flag for if image should be lazy loaded */
   lazyLoad?: boolean
   /** Flag indicating that right clicks should be prevented */
   preventRightClick?: boolean
 }
 
-const ratioPadding = system({
-  ratio: {
-    property: "paddingBottom",
-    transform: (n) => n * 100 + "%",
-  },
-})
-
-export interface BaseImageProps
-  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "height" | "width"> {}
-
-export interface ImageProps
-  extends BaseImageProps,
-    SpaceProps,
-    WidthProps,
-    HeightProps,
-    MaxHeightProps,
-    BorderRadiusProps {}
-
-/**
- * Image component with space, width and height properties
- */
 export const BaseImage = styled(CleanTag.as("img"))<ImageProps>`
   ${compose(space, width, height, maxHeight, borderRadius)}
 `
-
-export interface ResponsiveImageProps
-  extends BaseImageProps,
-    SpaceProps,
-    WidthProps,
-    MaxWidthProps {
-  ratio?: ResponsiveValue<number>
-}
-
-/**
- * An Image component that responsively resizes within its environment
- */
-export const BaseResponsiveImage = styled(CleanTag)<ResponsiveImageProps>`
-  background: url(${(props) => props.src});
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  ${compose(space, width, maxWidth)};
-  ${(props) =>
-    props.ratio
-      ? {
-          height: 0,
-          ...ratioPadding(props),
-        }
-      : null};
-`
-BaseResponsiveImage.defaultProps = {
-  width: "100%",
-  ratio: 1,
-}
 
 /** A web-only Image component. */
 export const Image = ({
   lazyLoad = false,
   preventRightClick = false,
-  ...props
-}: WebImageProps) => {
+  ...rest
+}: ImageProps) => {
   return (
     <LazyImage
       preload={!lazyLoad}
       imageComponent={BaseImage}
-      {...props}
       onContextMenu={(e) => preventRightClick && e.preventDefault()}
+      {...rest}
     />
   )
 }
-
-/** Props for a web-only ResponsiveImage component. */
-export interface WebResponsiveImageProps extends ResponsiveImageProps {
-  /** Flag for if image should be lazy loaded */
-  lazyLoad?: boolean
-}
-
-/**
- * A web-only ResponsiveImage component.
- * @deprecated See the recipe for creating a responsive image at https://palette.artsy.net/elements/images/image/
- */
-export const ResponsiveImage = ({
-  lazyLoad = false,
-  ...props
-}: WebResponsiveImageProps) => (
-  <LazyImage
-    preload={!lazyLoad}
-    imageComponent={BaseResponsiveImage}
-    {...props}
-  />
-)
-
-export { LazyImage }

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -9,7 +9,7 @@ import {
 } from "styled-system"
 import { CleanTag, omitProps } from "../CleanTag"
 import { SkeletonBox } from "../Skeleton"
-import { WebImageProps } from "./Image"
+import { ImageProps } from "./Image"
 import { BaseImage as Image } from "./Image"
 
 const imagePropsToOmit = omitProps.filter(
@@ -17,7 +17,7 @@ const imagePropsToOmit = omitProps.filter(
 )
 
 const InnerLazyImage = styled(CleanTag.as(LazyLoadImage))<
-  WebImageProps & {
+  ImageProps & {
     onLoad: () => void
     onError?: (event: React.SyntheticEvent<any, Event>) => void
   }
@@ -30,7 +30,7 @@ const InnerLazyImage = styled(CleanTag.as(LazyLoadImage))<
 InnerLazyImage.displayName = "InnerLazyImage"
 
 interface LazyImageProps
-  extends WebImageProps,
+  extends ImageProps,
     WidthProps,
     HeightProps,
     BorderRadiusProps {


### PR DESCRIPTION
This is some prep work for fixing [our issue with image width + height](https://artsyproduct.atlassian.net/browse/GRO-479). Removes the deprecated `ResponsiveImage` (work to support this has already been merged in Force: https://github.com/artsy/force/pull/8178). And cleans up some of the typings, which were an artifact from the previous React Native support.

This will be another breaking release. (Our 3rd today!)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette@15.0.1-canary.1019.20055.0
  # or 
  yarn add @artsy/palette@15.0.1-canary.1019.20055.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
