### PR TITLE
fix(text): makes variant a required prop

### DIFF
--- a/packages/palette-docs/content/docs/elements/CSSGrid.mdx
+++ b/packages/palette-docs/content/docs/elements/CSSGrid.mdx
@@ -16,10 +16,10 @@ for layouts based on a Bootstrap-style twelve column grid.
 
 <Playground>
   <CSSGrid gridTemplateColumns="repeat(2, 1fr)" gridGap={2} my={2}>
-    <Text>This grid displays...</Text>
-    <Text>...two columns...</Text>
-    <Text>...per row...</Text>
-    <Text>...with a gap of 20px.</Text>
+    <Text variant="sm">This grid displays...</Text>
+    <Text variant="sm">...two columns...</Text>
+    <Text variant="sm">...per row...</Text>
+    <Text variant="sm">...with a gap of 20px.</Text>
   </CSSGrid>
 </Playground>
 
@@ -31,9 +31,9 @@ for layouts based on a Bootstrap-style twelve column grid.
     gridGap={[2, 4]}
     my={2}
   >
-    <Text>This grid displays...</Text>
-    <Text>...two columns at xs...</Text>
-    <Text>...but 4 columns at sm or larger.</Text>
-    <Text>The gap is also different.</Text>
+    <Text variant="sm">This grid displays...</Text>
+    <Text variant="sm">...two columns at xs...</Text>
+    <Text variant="sm">...but 4 columns at sm or larger.</Text>
+    <Text variant="sm">The gap is also different.</Text>
   </CSSGrid>
 </Playground>

--- a/packages/palette-docs/content/docs/elements/Expandable.mdx
+++ b/packages/palette-docs/content/docs/elements/Expandable.mdx
@@ -6,23 +6,23 @@ source: elements/Expandable
 ### Default
 
 <Playground>
-	<Expandable label="Example">
-		<Text>Expanded content</Text>
-	</Expandable>
+  <Expandable label="Example">
+    <Text variant="sm">Expanded content</Text>
+  </Expandable>
 </Playground>
 
 ### Expanded
 
 <Playground>
-	<Expandable label="Example" expanded>
-		<Text>Expanded content</Text>
-	</Expandable>
+  <Expandable label="Example" expanded>
+    <Text variant="sm">Expanded content</Text>
+  </Expandable>
 </Playground>
 
 ### Disabled
 
 <Playground>
-	<Expandable label="Example" disabled>
-		<Text>Expanded content</Text>
-	</Expandable>
+  <Expandable label="Example" disabled>
+    <Text variant="sm">Expanded content</Text>
+  </Expandable>
 </Playground>

--- a/packages/palette-docs/content/docs/elements/GridColumns.mdx
+++ b/packages/palette-docs/content/docs/elements/GridColumns.mdx
@@ -3,43 +3,74 @@ name: GridColumns
 source: elements/GridColumns
 ---
 
-`GridColumns` implements `Box` and the common grid properties. It has a layout of 12, fluid-width columns and a default column and row gap of `space(2)` (which is configurable).
+`GridColumns` implements `Box` and the common grid properties. It has a layout
+of 12, fluid-width columns and a default column and row gap of `space(2)` (which
+is configurable).
 
-`Column` is a `Box` that sits inside of this 12-column grid layout, respecting the gutters. It accepts a `span` which will determine the width of the column. One can also optionally specify a `start` to offset where that column begins on the grid.
+`Column` is a `Box` that sits inside of this 12-column grid layout, respecting
+the gutters. It accepts a `span` which will determine the width of the column.
+One can also optionally specify a `start` to offset where that column begins on
+the grid.
 
 ### Simple grid
 
 <Playground>
-	<BorderBox>
-		<GridColumns>
-			<Column span={6}>
-				<Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
-			</Column>
-			<Column  span={6}>
-				<Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
-			</Column>
-		</GridColumns>
-	</BorderBox>
+  <BorderBox>
+    <GridColumns>
+      <Column span={6}>
+        <Text variant="sm">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+          deleniti recusandae ullam laudantium ut reiciendis, doloribus qui
+          sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat
+          eius saepe.
+        </Text>
+      </Column>
+      <Column span={6}>
+        <Text variant="sm">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+          deleniti recusandae ullam laudantium ut reiciendis, doloribus qui
+          sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat
+          eius saepe.
+        </Text>
+      </Column>
+    </GridColumns>
+  </BorderBox>
 </Playground>
 
 ### Responsive grid
 
-The columns by default collapse to a `span` of 12 on small breakpoints, but this is configurable via styled-system's responsive props syntax:
+The columns by default collapse to a `span` of 12 on small breakpoints, but this
+is configurable via styled-system's responsive props syntax:
 
 <Playground>
-	<BorderBox>
-		<GridColumns>
-			<Column span={[12, 4]}>
-				<Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
-			</Column>
-			<Column  span={[12, 4]}>
-				<Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
-			</Column>
-			<Column  span={[12, 4]}>
-				<Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
-			</Column>
-		</GridColumns>
-	</BorderBox>
+  <BorderBox>
+    <GridColumns>
+      <Column span={[12, 4]}>
+        <Text variant="sm">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+          deleniti recusandae ullam laudantium ut reiciendis, doloribus qui
+          sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat
+          eius saepe.
+        </Text>
+      </Column>
+      <Column span={[12, 4]}>
+        <Text variant="sm">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+          deleniti recusandae ullam laudantium ut reiciendis, doloribus qui
+          sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat
+          eius saepe.
+        </Text>
+      </Column>
+      <Column span={[12, 4]}>
+        <Text variant="sm">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+          deleniti recusandae ullam laudantium ut reiciendis, doloribus qui
+          sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat
+          eius saepe.
+        </Text>
+      </Column>
+    </GridColumns>
+  </BorderBox>
 </Playground>
 
 ### Kitchen sink
@@ -47,17 +78,38 @@ The columns by default collapse to a `span` of 12 on small breakpoints, but this
 <Playground>
   <GridColumns position="relative">
     <Column span={4}>
-      <Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
-    <Column  span={4}>
-      <Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+    <Column span={4}>
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
-    <Column  span={4}>
-      <Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+    <Column span={4}>
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
     <Column border="1px solid red" span={4} wrap>
-      <Text>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe. Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe. Lorem ipsum dolor sit amet consectetur adipisicing elit.
+        Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus
+        qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt,
+        quaerat eius saepe.
       </Text>
     </Column>
     <Column bg="black100" span={[6]}>
@@ -85,16 +137,36 @@ The columns by default collapse to a `span` of 12 on small breakpoints, but this
     />
     <Column height={200} bg="purple100" span={[12, 6]} start={[1, 4]} wrap />
     <Column bg="black100" start={4}>
-      <Text color="white100">Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+      <Text color="white100">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
     <Column border="1px solid red" span={4} start={1}>
-      <Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
     <Column border="1px solid red" span={4} start={6}>
-      <Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
     <Column border="1px solid red" span={2} start={11}>
-      <Text>Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius saepe.</Text>
+      <Text variant="sm">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto
+        deleniti recusandae ullam laudantium ut reiciendis, doloribus qui sequi
+        id ea, ad suscipit eos placeat magnam consequatur sunt, quaerat eius
+        saepe.
+      </Text>
     </Column>
     <Column bg="red" span={1} start={1} height={100} wrap />
     <Column bg="red" span={1} start={2} height={100} wrap />

--- a/packages/palette-docs/content/docs/elements/HTML.mdx
+++ b/packages/palette-docs/content/docs/elements/HTML.mdx
@@ -3,12 +3,12 @@ name: HTML
 source: elements/HTML
 ---
 
-`HTML` renders the given HTML string and wraps it in a `<Text>` component. All
-supported text variants can be passed in.
+`HTML` renders the given HTML string and wraps it in a `<Text variant="sm">`
+component. All supported text variants can be passed in.
 
 <Playground>
   <HTML
-		variant='sm'
+    variant="sm"
     size={4}
     html={"<h1>H1 Headline</h1><p>Paragraph tag</p><p>Paragraph tag</p>"}
   />

--- a/packages/palette-docs/content/docs/elements/ReadMore.mdx
+++ b/packages/palette-docs/content/docs/elements/ReadMore.mdx
@@ -17,22 +17,22 @@ source: elements/ReadMore
 ### Character cap with html
 
 <Playground>
-	<Text variant="md">
-		<ReadMore
-			maxChars={100}
-			content='<p>Donald Judd, widely regarded as one of the most significant American artists of <a href="#">the post-war period</a>, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa. Donald Judd, widely regarded as one of the most significant American artists of the post-war period, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa. </p>'
-		/>
-	</Text>
+  <Text variant="md">
+    <ReadMore
+      maxChars={100}
+      content='<p>Donald Judd, widely regarded as one of the most significant American artists of <a href="#">the post-war period</a>, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa. Donald Judd, widely regarded as one of the most significant American artists of the post-war period, is perhaps best-known for the large-scale outdoor installations and long, spacious interiors he designed in Marfa. </p>'
+    />
+  </Text>
 </Playground>
 
 ### With character cap
 
 <Playground>
-  <Text variant='md'>
+  <Text variant="md">
     <ReadMore
       maxChars={300}
       content={
-        <Text>
+        <Text variant="sm">
           Donald Judd, widely regarded as one of the most significant American
           artists of <a href="#">the post-war period</a>, is perhaps best-known
           for the large-scale outdoor installations and long, spacious interiors
@@ -52,7 +52,7 @@ source: elements/ReadMore
   <ReadMore
     maxChars={300}
     content={
-      <Text>
+      <Text variant="sm">
         Donald Judd, widely regarded as one of the most significant American
         artists of <a href="#">the post-war period</a>.
       </Text>

--- a/packages/palette-docs/content/docs/guides/migration.mdx
+++ b/packages/palette-docs/content/docs/guides/migration.mdx
@@ -90,18 +90,19 @@ const MyComponent = props => {
 }
 ```
 
-What we're doing in the above is defining an object with two keys -- `v2` and `v3` -- and the
-`useThemeConfig` hook will then match against the keys depending on which theme context is 
-currently being used and return the correct values. So you can see that 
+What we're doing in the above is defining an object with two keys -- `v2` and
+`v3` -- and the `useThemeConfig` hook will then match against the keys depending
+on which theme context is currently being used and return the correct values. So
+you can see that
 
 ```tsx
 <Box px={tokens.px}>
   <Text variant={tokens.variant}>Hi</Text>
 </Box>
-``` 
+```
 
-Will return dynamic values for `tokens.px` -- either `px={5}` if `v2`, or `px={2}` if `v3`.  
-
+Will return dynamic values for `tokens.px` -- either `px={5}` if `v2`, or
+`px={2}` if `v3`.
 
 (See
 [here](https://github.com/artsy/force/blob/master/src/v2/Components/Footer/Footer.tsx#L219-L226)
@@ -117,7 +118,7 @@ context-specific names (`title`, `subTitle`, etc.)
 
 If migrating from pre-v1 `<Sans>` or `<Serif>` components, note that we no
 longer use serif fonts and areas where those components are used should be
-replaced with `<Text>`.
+replaced with `<Text variant="sm">`.
 
 **Some migration examples:**
 

--- a/packages/palette/src/elements/Expandable/Expandable.story.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.story.tsx
@@ -40,7 +40,7 @@ export const Default = () => {
       ]}
     >
       <Expandable label="Example" maxWidth={350}>
-        <Text>Expanded content</Text>
+        <Text variant="sm">Expanded content</Text>
       </Expandable>
     </States>
   )

--- a/packages/palette/src/elements/GridColumns/GridColumns.story.tsx
+++ b/packages/palette/src/elements/GridColumns/GridColumns.story.tsx
@@ -41,7 +41,7 @@ export const RealWorldExample = () => {
           Page subtitle
         </Text>
 
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column span={5} start={8}>
@@ -65,19 +65,19 @@ export const KitchenSink = () => {
       <GridColumnsDebug />
 
       <Column border="1px solid red" span={4}>
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column border="1px solid red" span={4}>
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column border="1px solid green" span={4}>
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column border="1px solid red" span={4} wrap>
-        <Text>
+        <Text variant="sm">
           {IPSUM} {IPSUM}
         </Text>
       </Column>
@@ -117,15 +117,15 @@ export const KitchenSink = () => {
       </Column>
 
       <Column border="1px solid red" span={4} start={1}>
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column border="1px solid red" span={4} start={6}>
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column border="1px solid red" span={2} start={11}>
-        <Text>{IPSUM}</Text>
+        <Text variant="sm">{IPSUM}</Text>
       </Column>
 
       <Column bg="red" span={1} start={1} height={100} wrap />

--- a/packages/palette/src/elements/Join/Join.story.tsx
+++ b/packages/palette/src/elements/Join/Join.story.tsx
@@ -99,7 +99,7 @@ export const WithNestedChildren = () => {
           <Text variant="md">Are grouped</Text>
         </Box>
 
-        <Text>End of list</Text>
+        <Text variant="sm">End of list</Text>
       </>
     </Join>
   )

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.story.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.story.tsx
@@ -25,7 +25,11 @@ export const Default = () => {
         {["Visual", "Linguistic", "Spatial", "Aural", "Gestural"].map(
           (value) => {
             return (
-              <Radio key={value} value={value} label={<Text>{value}</Text>} />
+              <Radio
+                key={value}
+                value={value}
+                label={<Text variant="sm">{value}</Text>}
+              />
             )
           }
         )}

--- a/packages/palette/src/elements/Sup/Sup.story.tsx
+++ b/packages/palette/src/elements/Sup/Sup.story.tsx
@@ -18,7 +18,7 @@ export const Default = () => {
         { variant: "sm" },
       ]}
     >
-      <Text>
+      <Text variant="sm">
         Lorem Ipsum <Sup color="blue100">123</Sup>
       </Text>
     </States>

--- a/packages/palette/src/elements/Swiper/Swiper.story.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.story.tsx
@@ -48,7 +48,7 @@ export const Simple = () => {
 export const WithHorizontalMargins = () => {
   return (
     <>
-      <Text>Should be flush with horizontal edges</Text>
+      <Text variant="sm">Should be flush with horizontal edges</Text>
       <Demo mx={[-2, -4]} />
     </>
   )

--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -20,7 +20,7 @@ import { Box, BoxProps } from "../Box"
 /** BaseTextProps */
 export type BaseTextProps = TypographyProps &
   Omit<ColorProps, "color"> & {
-    variant?: ResponsiveValue<TextVariant>
+    variant: ResponsiveValue<TextVariant>
     textColor?: ResponsiveValue<Color>
     /**
      * Max number of lines before truncating the content with an ellipsis at the end of the last line.
@@ -104,5 +104,4 @@ Text.displayName = "Text"
 
 Text.defaultProps = {
   fontFamily: "sans",
-  variant: "text",
 }

--- a/packages/palette/src/elements/Toggle/Toggle.story.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.story.tsx
@@ -42,7 +42,7 @@ export const Default = () => {
       ]}
     >
       <Toggle label="Example" maxWidth={350}>
-        <Text>Expanded content</Text>
+        <Text variant="sm">Expanded content</Text>
       </Toggle>
     </States>
   )

--- a/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
+++ b/packages/palette/src/elements/Toggle/__tests__/Toggle.test.tsx
@@ -46,7 +46,7 @@ describe("Toggle", () => {
   })
 
   it("renders proper component when passed component as label", () => {
-    const component = <Text>Hello</Text>
+    const component = <Text variant="sm">Hello</Text>
     const wrapper = mount(<Toggle label={component}>tab content</Toggle>)
     expect(wrapper.find("Text")).toHaveLength(1)
   })


### PR DESCRIPTION
Closes: [DSWGW-85](https://artsyproduct.atlassian.net/browse/DSWGW-85)

So the thought here is that currently we set `"text"` as the default variant, which is v2, and this leads to some subtly broken designs. It likely makes more sense just to enforce this as a required prop since you should explicitly know what variant you want to use and I suspect that most people don't know what the default is at any given moment, let alone how that matters depending on which theme context you're in.

This will be a breaking release. I'll publish a canary and just use the type errors to drive out setting the defaults. In any v3 contexts we could safely set the variant to `"sm"` and in v2 to `"text"`