### PR TITLE
change modal close to onMouseDown

### DIFF
--- a/packages/palette/src/elements/Modal/ModalBase.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.tsx
@@ -87,7 +87,9 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
     focusableEls[focusableIndex].focus()
   }, [focusableEls, focusableIndex])
 
-  const handleClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const handleMouseDown = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
     if (event.target === scrollIsolationEl.current) {
       onClose()
     }
@@ -148,7 +150,10 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
 
   return createPortal(
     <Container ref={containerEl as any} zIndex={zIndex} {...rest}>
-      <ScrollIsolation ref={scrollIsolationEl as any} onClick={handleClick}>
+      <ScrollIsolation
+        ref={scrollIsolationEl as any}
+        onMouseDown={handleMouseDown}
+      >
         <Dialog
           maxHeight={
             // Sets to `innerHeight` so as to simulate `100vh` on iOS


### PR DESCRIPTION
Addresses [PURCHASE-2883]

We discussed this issue briefly in [slack](https://artsy.slack.com/archives/C9XJKPY9W/p1629131314102000). @dzucconi pointed out the fact that bootstrap tried a similar approach to accidental modal closures and ended up reverting the change. After digging through the conversation around that reversion it appears that bootstrap modals were closing when the content inside the modal was scrollable, and the user tried to use the browser level scroll bar to navigate the modal. Fortunately, this makes bootstrap's issue a moot point for us. 

Palette uses an in-dialog scroll bar which is not subject to the same event tree that caused problems for bootstrap. I've tested the display in chrome, firefox and safari and this remains true in all browsers. Similarly, the change contained in this PR fixes the unexpected closures in all environments, and creates a more reliable user experience. 

[PURCHASE-2883]: https://artsyproduct.atlassian.net/browse/PURCHASE-2883