### PR TITLE
fix: apply focus styles to the button when it is active

### DIFF
--- a/packages/palette/src/elements/Button/v3/Button.tsx
+++ b/packages/palette/src/elements/Button/v3/Button.tsx
@@ -121,7 +121,7 @@ const Container = styled.button<ContainerProps>`
         }
       }
 
-      &:focus {
+      &:active {
         outline: 0;
         ${variant({ variants: BUTTON_VARIANTS.focus })}
       }


### PR DESCRIPTION
### Description
I am a user and I click on the button, the focus state remains (i.e. a blue outline around the pill) when it should disappear if I release the button

Addresses [FX-3250]

### Demo
https://user-images.githubusercontent.com/3513494/132342147-9552007b-0e8e-45ca-a904-e89c8bb5ac88.mp4



[FX-3250]: https://artsyproduct.atlassian.net/browse/FX-3250