### PR TITLE
fix(image): reduce generated classname count

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -6,7 +6,9 @@ import { Image, ImageProps } from "../Image"
 import { Text } from "../Text"
 import { V2_TOKENS, V3_TOKENS } from "./tokens"
 
-export interface AvatarProps extends FlexProps, Partial<ImageProps> {
+export interface AvatarProps
+  extends FlexProps,
+    Omit<Partial<ImageProps>, "width" | "height"> {
   /** If an image is missing, show initials instead */
   initials?: string
   /** The size of the Avatar */

--- a/packages/palette/src/elements/CSSGrid/CSSGrid.story.tsx
+++ b/packages/palette/src/elements/CSSGrid/CSSGrid.story.tsx
@@ -21,7 +21,7 @@ export const CssGridWithResponsiveProps = () => {
         return (
           <Image
             src="https://picsum.photos/id/1025/140/100/"
-            width={[100, 120, 140]}
+            width="100%"
             key={i}
           />
         )

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { States } from "storybook-states"
 import { Image } from "../Image"
 
 export default {
@@ -7,13 +8,15 @@ export default {
 
 export const Default = () => {
   return (
-    <Image
-      id="example"
-      className="example"
-      width="300px"
-      height="200px"
-      src="https://picsum.photos/seed/example/300/200"
-    />
+    <States states={[{}, { width: null, height: null }]}>
+      <Image
+        id="example"
+        className="example"
+        width="300px"
+        height="200px"
+        src="https://picsum.photos/seed/example/300/200"
+      />
+    </States>
   )
 }
 

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -4,23 +4,16 @@ import {
   borderRadius,
   BorderRadiusProps,
   compose,
-  height,
-  HeightProps,
   maxHeight,
   MaxHeightProps,
   space,
   SpaceProps,
-  width,
-  WidthProps,
 } from "styled-system"
-import { CleanTag } from "../CleanTag"
 import { LazyImage } from "./LazyImage"
 
 export interface ImageProps
-  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "width" | "height">,
+  extends React.ImgHTMLAttributes<HTMLImageElement>,
     SpaceProps,
-    WidthProps,
-    HeightProps,
     MaxHeightProps,
     BorderRadiusProps {
   /** Flag for if image should be lazy loaded */
@@ -29,9 +22,8 @@ export interface ImageProps
   preventRightClick?: boolean
 }
 
-// @ts-expect-error  MIGRATE_STRICT_MODE
-export const BaseImage = styled(CleanTag.as("img"))<ImageProps>`
-  ${compose(space, width, height, maxHeight, borderRadius)}
+export const BaseImage = styled.img<ImageProps>`
+  ${compose(space, maxHeight, borderRadius)}
 `
 
 /** A web-only Image component. */

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -11,8 +11,16 @@ import {
 } from "styled-system"
 import { LazyImage } from "./LazyImage"
 
+type NativeImgProps = Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  "width" | "height"
+> & {
+  width?: string | number | null
+  height?: string | number | null
+}
+
 export interface ImageProps
-  extends React.ImgHTMLAttributes<HTMLImageElement>,
+  extends NativeImgProps,
     SpaceProps,
     MaxHeightProps,
     BorderRadiusProps {

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -64,7 +64,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   return (
     <SkeletonBox
       borderRadius={borderRadius}
-      style={{ width, height }}
+      style={{ width: width ?? undefined, height: height ?? undefined }}
       {...containerProps}
     >
       <InnerLazyImage

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -4,20 +4,12 @@ import styled from "styled-components"
 import {
   borderRadius as borderRadiusStyle,
   BorderRadiusProps,
-  HeightProps,
-  WidthProps,
 } from "styled-system"
-import { CleanTag, omitProps } from "../CleanTag"
 import { SkeletonBox } from "../Skeleton"
 import { ImageProps } from "./Image"
 import { BaseImage as Image } from "./Image"
 
-const imagePropsToOmit = omitProps.filter(
-  (prop) => prop !== "width" && prop !== "height"
-)
-
-// @ts-expect-error  MIGRATE_STRICT_MODE
-const InnerLazyImage = styled(CleanTag.as(LazyLoadImage))<
+const InnerLazyImage = styled(LazyLoadImage)<
   ImageProps & {
     onLoad: () => void
     onError?: (event: React.SyntheticEvent<any, Event>) => void
@@ -25,16 +17,12 @@ const InnerLazyImage = styled(CleanTag.as(LazyLoadImage))<
 >`
   width: 100%;
   height: 100%;
-  ${borderRadiusStyle}
   transition: opacity 0.25s;
+  ${borderRadiusStyle}
 `
 InnerLazyImage.displayName = "InnerLazyImage"
 
-interface LazyImageProps
-  extends ImageProps,
-    WidthProps,
-    HeightProps,
-    BorderRadiusProps {
+interface LazyImageProps extends ImageProps, BorderRadiusProps {
   /** Eagerly load the image instead of lazy loading it */
   preload?: boolean
   style?: CSSProperties
@@ -54,16 +42,16 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   const [isImageLoaded, setImageLoaded] = useState(false)
 
   const {
+    ["aria-label"]: ariaLabel,
+    alt,
+    borderRadius,
+    height,
+    onError,
     src,
     srcSet,
-    title,
-    alt,
-    ["aria-label"]: ariaLabel,
-    width,
-    height,
-    borderRadius,
     style,
-    onError,
+    title,
+    width,
     ...containerProps
   } = props
 
@@ -75,28 +63,24 @@ export const LazyImage: React.FC<LazyImageProps> = ({
 
   return (
     <SkeletonBox
-      width={width}
-      height={height}
       borderRadius={borderRadius}
+      style={{ width, height }}
       {...containerProps}
     >
       <InnerLazyImage
-        omitFromProps={imagePropsToOmit}
-        onError={onError}
-        src={src}
-        srcSet={srcSet}
-        title={title}
         alt={alt}
         aria-label={ariaLabel}
         borderRadius={borderRadius}
-        width="100%"
         height="100%"
-        style={{
-          ...style,
-          opacity: isImageLoaded ? "1" : "0",
-        }}
+        onError={onError}
         onLoad={handleLoad}
+        src={src}
+        srcSet={srcSet}
+        style={{ ...style, opacity: isImageLoaded ? "1" : "0" }}
+        title={title}
+        width="100%"
       />
+
       <noscript>
         <ImageComponent {...props} />
       </noscript>


### PR DESCRIPTION
An attempt to reduce the number of classnames. This in particular is a problem for Shelf components where we tend to have many different sizes; each of which will have a unique classname.

The one gotcha here might be if we use responsive props for width/height anywhere. I'm going to publish a canary and take a look at the type damage and if it's not huge; make the changes.

Also removing `CleanTag` from here; if we get warnings we'll do what we did in Force which is to use `shouldForwardProp: (prop, defaultValidatorFn) => defaultValidatorFn(prop),`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette-charts@16.6.1-canary.1037.20678.0
  npm install @artsy/palette@17.6.1-canary.1037.20678.0
  # or 
  yarn add @artsy/palette-charts@16.6.1-canary.1037.20678.0
  yarn add @artsy/palette@17.6.1-canary.1037.20678.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
