### PR TITLE
fix(button): ensures submit buttons are same font-weight

### DIFF
--- a/packages/palette/src/elements/Button/v2/Button.tsx
+++ b/packages/palette/src/elements/Button/v2/Button.tsx
@@ -68,6 +68,7 @@ const Container = styled.button<ContainerProps>`
   cursor: pointer;
   position: relative;
   white-space: nowrap;
+  font-weight: normal;
   text-decoration: none;
   align-items: center;
   justify-content: center;

--- a/packages/palette/src/elements/Button/v3/Button.tsx
+++ b/packages/palette/src/elements/Button/v3/Button.tsx
@@ -67,6 +67,7 @@ const Container = styled.button<ContainerProps>`
   cursor: pointer;
   position: relative;
   white-space: nowrap;
+  font-weight: normal;
   text-decoration: none;
   align-items: center;
   text-align: center;


### PR DESCRIPTION
Minor thing I noticed in the iOS15 update. Buttons with `type="submit"` are automatically bolded.