### PR TITLE
fix(shelf): when shelf contents change; keep the scrollbar in sync

### DIFF
--- a/packages/palette/src/elements/Shelf/Shelf.story.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.story.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { States } from "storybook-states"
 import { Box } from "../Box"
 import { Text } from "../Text"
@@ -84,4 +84,28 @@ export const NavigationButtons = () => {
       <ShelfNext />
     </States>
   )
+}
+
+export const ClientSideUpdates = () => {
+  const [amount, setAmount] = useState(1)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setAmount(Math.floor(Math.random() * Math.floor(15)) + 1)
+    }, 1000)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
+
+  return (
+    <>
+      <pre>Amount: {amount}</pre>
+      <Demo amount={amount} />
+    </>
+  )
+}
+
+ClientSideUpdates.story = {
+  parameters: { chromatic: { disable: true } },
 }

--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -122,7 +122,7 @@ export const Shelf: React.FC<ShelfProps> = ({
     return () => {
       viewport.removeEventListener("scroll", handler)
     }
-  }, [pages])
+  }, [pages, setCursor])
 
   // Announce page changes
   useEffect(() => {

--- a/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
+++ b/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
@@ -1,6 +1,7 @@
 import { themeGet } from "@styled-system/theme-get"
 import React, { useEffect, useRef, useState } from "react"
 import styled from "styled-components"
+import { useMutationObserver } from "../.."
 import { Box, BoxProps } from "../Box"
 import { Clickable } from "../Clickable"
 import { useClickScroll } from "./useClickScroll"
@@ -59,12 +60,29 @@ export const ShelfScrollBar: React.FC<ShelfScrollBarProps> = React.memo(
       }
     }, [viewport])
 
-    // FIXME: Fix these ts-ignores. Added for strict type checking migration
+    useMutationObserver({
+      element: viewport,
+      onMutate: (mutations) => {
+        // Check to see if any of the mutations has either added or removed nodes
+        const hasMeaningfullyMutated = mutations.some((mutation) => {
+          return (
+            mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0
+          )
+        })
+
+        // Only update scroll state if something was added or removed
+        if (!hasMeaningfullyMutated) return
+
+        setScrollState({
+          scrollLeft: viewport?.scrollLeft ?? 0,
+          scrollWidth: viewport?.scrollWidth ?? 1,
+          clientWidth: viewport?.clientWidth ?? 1,
+        })
+      },
+    })
 
     useDragScroll({
-      // @ts-expect-error  MIGRATE_STRICT_MODE
       viewport,
-      // @ts-expect-error  MIGRATE_STRICT_MODE
       thumbRef,
       clientWidth,
       scrollWidth,
@@ -73,11 +91,8 @@ export const ShelfScrollBar: React.FC<ShelfScrollBarProps> = React.memo(
     })
 
     useClickScroll({
-      // @ts-expect-error  MIGRATE_STRICT_MODE
       viewport,
-      // @ts-expect-error  MIGRATE_STRICT_MODE
       thumbRef,
-      // @ts-expect-error  MIGRATE_STRICT_MODE
       trackRef,
       scrollWidth,
       trackWidth,

--- a/packages/palette/src/elements/Shelf/useClickScroll.ts
+++ b/packages/palette/src/elements/Shelf/useClickScroll.ts
@@ -1,9 +1,9 @@
 import { useEffect } from "react"
 
 interface UseClickScroll {
-  trackRef?: React.MutableRefObject<HTMLElement>
-  thumbRef?: React.MutableRefObject<HTMLElement>
-  viewport?: HTMLElement
+  trackRef?: React.MutableRefObject<HTMLElement | null>
+  thumbRef?: React.MutableRefObject<HTMLElement | null>
+  viewport?: HTMLElement | null
   scrollWidth: number
   trackWidth: number
 }
@@ -16,7 +16,7 @@ export const useClickScroll = ({
   trackWidth,
 }: UseClickScroll) => {
   useEffect(() => {
-    if (!trackRef?.current || !thumbRef?.current) return
+    if (!viewport || !trackRef?.current || !thumbRef?.current) return
 
     const { current: thumb } = thumbRef
     const { current: track } = trackRef
@@ -30,7 +30,7 @@ export const useClickScroll = ({
         // Then center the thumb
         thumb.clientWidth / 2
 
-      viewport!.scrollLeft = (x * scrollWidth) / trackWidth
+      viewport.scrollLeft = (x * scrollWidth) / trackWidth
     }
 
     track.addEventListener("mousedown", handleMouseDown)
@@ -38,5 +38,5 @@ export const useClickScroll = ({
     return () => {
       track.removeEventListener("mousedown", handleMouseDown)
     }
-  }, [viewport, scrollWidth, trackWidth])
+  }, [scrollWidth, thumbRef, trackRef, trackWidth, viewport])
 }

--- a/packages/palette/src/elements/Shelf/useDragScroll.ts
+++ b/packages/palette/src/elements/Shelf/useDragScroll.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react"
 
 interface UseDragScroll {
-  viewport?: HTMLElement
-  thumbRef?: React.MutableRefObject<HTMLElement>
+  viewport?: HTMLElement | null
+  thumbRef?: React.MutableRefObject<HTMLElement | null>
   scrollWidth: number
   trackWidth: number
   scrollLeft: number
@@ -53,5 +53,5 @@ export const useDragScroll = ({
       document.removeEventListener("mousemove", handleMouseMove)
       document.removeEventListener("mouseup", handleMouseUp)
     }
-  }, [viewport, clientWidth, scrollWidth, scrollLeft, trackWidth])
+  }, [viewport, clientWidth, scrollWidth, scrollLeft, trackWidth, thumbRef])
 }

--- a/packages/palette/src/utils/useMutationObserver.ts
+++ b/packages/palette/src/utils/useMutationObserver.ts
@@ -1,11 +1,13 @@
 import type { MutableRefObject } from "react"
 import { useEffect } from "react"
 
-interface UseMutationObserver {
+type UseMutationObserver = {
   onMutate: MutationCallback
   options?: MutationObserverInit
-  ref: MutableRefObject<HTMLElement | null>
-}
+} & (
+  | { ref: MutableRefObject<HTMLElement | null> }
+  | { element?: HTMLElement | null }
+)
 
 /**
  * Accepts a ref and calls the `onMutate` callback when mutations are observed.
@@ -18,18 +20,20 @@ export const useMutationObserver = ({
     childList: true,
     subtree: true,
   },
-  ref,
+  ...rest
 }: UseMutationObserver) => {
   useEffect(() => {
     if (typeof MutationObserver === "undefined") {
       return
     }
 
-    if (ref.current) {
+    const el = "ref" in rest ? rest.ref.current : rest.element
+
+    if (el) {
       const observer = new MutationObserver(onMutate)
 
       // Start observing the target node for configured mutations
-      observer.observe(ref.current, options)
+      observer.observe(el, options)
 
       return () => {
         observer.disconnect()


### PR DESCRIPTION
Closes [GRO-476](https://artsyproduct.atlassian.net/browse/GRO-476)

That mutation observer hook is coming in handy. I guess when you've got a hammer everything looks like a nail.

Going to check the canary integration before merging just incase.