### PR TITLE
fix(horizontaloverflow): ensures internal heights match external

### DIFF
--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.story.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.story.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { States } from "storybook-states"
-import { Text } from ".."
+import { Text, Box, Join, Spacer } from ".."
 import {
   HorizontalOverflow,
   HorizontalOverflowProps,
@@ -16,12 +16,36 @@ export const Default = () => {
       states={[{}, { children: <Text variant="md">Not overflowing</Text> }]}
     >
       <HorizontalOverflow bg="black10" p={2}>
-        {Array.from(Array(50)).map((_, i) => (
-          <Text key={i} variant="md" color="black100" mr={2}>
-            Example #{i}
-          </Text>
-        ))}
+        <Join separator={<Spacer mr={2} />}>
+          {Array.from(Array(50)).map((_, i) => (
+            <Text key={i} variant="md" color="black100" mr={2}>
+              Example #{i}
+            </Text>
+          ))}
+        </Join>
       </HorizontalOverflow>
     </States>
+  )
+}
+
+export const FillHeightCenteredContent = () => {
+  return (
+    <Box height={100} bg="red10">
+      <HorizontalOverflow border="1px solid" p={2} height="100%">
+        <Join separator={<Spacer mr={2} />}>
+          {Array.from(Array(50)).map((_, i) => (
+            <Text
+              key={i}
+              variant="md"
+              color="black100"
+              display="flex"
+              alignItems="center"
+            >
+              Example #{i}
+            </Text>
+          ))}
+        </Join>
+      </HorizontalOverflow>
+    </Box>
   )
 }

--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
@@ -44,6 +44,7 @@ const Overlay = styled(Box)<{ atEnd: boolean }>`
 `
 
 const Viewport = styled(Box)`
+  height: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   ${visuallyDisableScrollbar}
@@ -52,6 +53,7 @@ const Viewport = styled(Box)`
 const Rail = styled(Box)`
   white-space: nowrap;
   min-width: 100%;
+  height: 100%;
 `
 
 export type HorizontalOverflowProps = BoxProps & { children: React.ReactNode }


### PR DESCRIPTION
Small fix for this component so that we can use it in places where we want a specific height without relying on padding.