### PR TITLE
fix(horizontaloverflow): attempts to fix scrollbar disable

### DIFF
--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
@@ -45,6 +45,7 @@ const Overlay = styled(Box)<{ atEnd: boolean }>`
 
 const Viewport = styled(Box)`
   height: 100%;
+  overflow-y: hidden;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   ${visuallyDisableScrollbar}


### PR DESCRIPTION
Trying to figure out why Force in particular is filtering out the `visuallyDisableScrollbar` mixin, in this one, specific component (Shelf and friends obviously work fine).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/palette-charts@16.7.6-canary.1050.21001.0
  npm install @artsy/palette@17.7.6-canary.1050.21001.0
  # or 
  yarn add @artsy/palette-charts@16.7.6-canary.1050.21001.0
  yarn add @artsy/palette@17.7.6-canary.1050.21001.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
