### PR TITLE
feat(tabs): supports autoscrolling on tab selection

### DIFF
--- a/packages/palette/src/elements/BaseTabs/BaseTab.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTab.tsx
@@ -73,4 +73,5 @@ BaseTab.displayName = "BaseTab"
  * by simply including a Clickable here.
  */
 // @ts-expect-error  MIGRATE_STRICT_MODE
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const __Ignore__ = Clickable

--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -54,11 +54,12 @@ export const Stepper: React.FC<StepperProps> = ({
   return (
     <>
       <BaseTabs separator={tokens.joinSeparator!} fill={tokens.fill} {...rest}>
-        {tabs.map((cell, i) => {
+        {tabs.map((tab, i) => {
           return (
             <BaseTab
               key={i}
               as={Clickable}
+              ref={tab.ref as any}
               aria-selected={i === activeTabIndex}
               disabled={disableNavigation || i > currentStepIndex}
               onClick={handleClick(i)}
@@ -77,7 +78,7 @@ export const Stepper: React.FC<StepperProps> = ({
                   )}
 
                   <Box color={i > currentStepIndex ? "black30" : undefined}>
-                    {cell.props.name}
+                    {tab.child.props.name}
                   </Box>
 
                   {currentStepIndex > i &&
@@ -98,7 +99,7 @@ export const Stepper: React.FC<StepperProps> = ({
         })}
       </BaseTabs>
 
-      {activeTab}
+      {activeTab.child}
     </>
   )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.story.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.story.tsx
@@ -96,3 +96,25 @@ export const ConditionalTabs = () => {
     </Tabs>
   )
 }
+
+export const AutoScrolling = () => {
+  return (
+    <Tabs onChange={action("onChange")}>
+      <Tab name="First">First</Tab>
+      <Tab name="Second">Second</Tab>
+      <Tab name="Third">Third</Tab>
+      <Tab name="Fourth">Fourth</Tab>
+      <Tab name="Fifth">Fifth</Tab>
+      <Tab name="Sixth">Sixth</Tab>
+      <Tab name="Seventh">Seventh</Tab>
+      <Tab name="Eighth">Eighth</Tab>
+      <Tab name="Nineth">Nineth</Tab>
+      <Tab name="Tenth">Tenth</Tab>
+      <Tab name="Eleventh">Eleventh</Tab>
+      <Tab name="Twelveth">Twelveth</Tab>
+      <Tab name="Thirteenth">Thirteenth</Tab>
+      <Tab name="Fourteenth">Fourteenth</Tab>
+      <Tab name="Fifteenth">Fifteenth</Tab>
+    </Tabs>
+  )
+}


### PR DESCRIPTION
Closes: [DSWGW-96](https://artsyproduct.atlassian.net/browse/DSWGW-96)

`scrollIntoView` makes this nice and simple. This should just be on by default and there's no need to trigger it via prop.

![](https://static.damonzucconi.com/_capture/gyhbrDmV.gif)