### PR TITLE
docs(types): Improve DX on Button/Text variants

### DIFF
--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -9,7 +9,16 @@ import { ButtonV3 } from "./v3/Button"
 export interface ButtonProps
   extends BoxProps,
     React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /** The theme of the button */
+  /**
+   * @description
+   * The theme of the button. It's possible to pass an array that
+   * behaves accordingly to the media breakpoints ["sm", "md", "lg", "xl"]
+   * @example
+   * "primaryBlack"
+   * "primaryWhite"
+   * ["secondaryGray", "secondaryOutline"]
+   * @see {@link ButtonVariant}
+   */
   variant?: ResponsiveValue<ButtonVariant>
   /** Size of the button */
   size?: ButtonSize

--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -20,6 +20,16 @@ import { Box, BoxProps } from "../Box"
 /** BaseTextProps */
 export type BaseTextProps = TypographyProps &
   Omit<ColorProps, "color"> & {
+    /**
+     * @description
+     * Variants of the text. Possible to pass an array that
+     * behaves accordingly to the media breakpoints ["sm", "md", "lg", "xl"]
+     * @example
+     * "sm"
+     * "md"
+     * ["md", "sm"]
+     * @see {@link TextVariant}
+     */
     variant?: ResponsiveValue<TextVariant>
     textColor?: ResponsiveValue<Color>
     /**


### PR DESCRIPTION
During my onboarding, I made some questions that could be easily answered with enhanced documentation of the `variants` of a few components.

This PR improves the Button and Text `variant` property document.

<img src="https://user-images.githubusercontent.com/15792853/136399070-e4a747ee-c306-4924-98ea-272c0598a6ef.png" width=300 />

<img src="https://user-images.githubusercontent.com/15792853/136399327-e13e7943-4bd5-4735-a0b4-061af5ae6b1a.png" width=300 />

