### PR TITLE
fix(labeledinput): fixes height when title/description are present

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -32,6 +32,7 @@ export const Input: React.ForwardRefExoticComponent<
 > = React.forwardRef(
   (
     {
+      children,
       className,
       description,
       disabled,
@@ -92,16 +93,19 @@ export const Input: React.ForwardRefExoticComponent<
           </>
         )}
 
-        <StyledInput
-          ref={ref as any}
-          disabled={disabled}
-          focus={focus}
-          hover={hover}
-          error={!!error}
-          required={required}
-          height={tokens.height as any}
-          {...inputProps}
-        />
+        <Box position="relative">
+          <StyledInput
+            ref={ref as any}
+            disabled={disabled}
+            focus={focus}
+            hover={hover}
+            error={!!error}
+            required={required}
+            height={tokens.height as any}
+            {...inputProps}
+          />
+          {children}
+        </Box>
 
         {error && typeof error === "string" && (
           <Text variant={tokens.secondaryTextVariant} mt={0.5} color="red100">

--- a/packages/palette/src/elements/LabeledInput/LabeledInput.story.tsx
+++ b/packages/palette/src/elements/LabeledInput/LabeledInput.story.tsx
@@ -25,6 +25,8 @@ export const Default = () => {
             />
           ),
         },
+        { title: "Amount" },
+        { title: "Amount", description: "Currency: USD" },
       ]}
     >
       <LabeledInput label="$" />

--- a/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
+++ b/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
@@ -35,28 +35,28 @@ export const LabeledInput: React.ForwardRefExoticComponent<
         height={height}
         style={{ paddingRight: `${offset + 10}px` }}
         {...inputProps}
-      />
-
-      <Box
-        ref={labelRef as any}
-        position="absolute"
-        display="flex"
-        alignItems="center"
-        right={1}
-        top={0}
-        bottom={0}
-        style={{
-          pointerEvents: isText ? "none" : undefined,
-        }}
       >
-        {isText ? (
-          <Text variant={variant} color="black60" lineHeight={1}>
-            {label}
-          </Text>
-        ) : (
-          label
-        )}
-      </Box>
+        <Box
+          ref={labelRef as any}
+          position="absolute"
+          display="flex"
+          alignItems="center"
+          right={1}
+          top={0}
+          bottom={0}
+          style={{
+            pointerEvents: isText ? "none" : undefined,
+          }}
+        >
+          {isText ? (
+            <Text variant={variant} color="black60" lineHeight={1}>
+              {label}
+            </Text>
+          ) : (
+            label
+          )}
+        </Box>
+      </Input>
     </Box>
   )
 })


### PR DESCRIPTION
Since the title and description are contained within the input, we need to insert the children inside a wrapper around the input itself so that the label height is correct.