### PR TITLE
fix(autocomplete): display options if they are present regardless of query

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -76,29 +76,35 @@ export const Demo = () => {
   return (
     <AutocompleteInput
       placeholder="Begin typing..."
-      options={[{ text: query, value: query }, ...OPTIONS]}
+      options={[...(query ? [{ text: query, value: query }] : []), ...OPTIONS]}
       onChange={handleChange}
       onSelect={action("onSelect")}
       onSubmit={action("onSubmit")}
-      renderOption={(option, i) => (
-        <Box
-          px={2}
-          py={1}
-          {...(i === 0
-            ? { borderBottom: "1px solid", borderColor: "black10" }
-            : {})}
-        >
-          <Text variant="md">
-            {i === 0 ? `See full results for “${option.text}”` : option.text}
-          </Text>
+      renderOption={(option, i) => {
+        const displayQuery = i === 0 && query !== ""
 
-          {"subtitle" in option && (
-            <Text variant="xs" color="black60">
-              {option.subtitle}
+        return (
+          <Box
+            px={2}
+            py={1}
+            {...(displayQuery
+              ? { borderBottom: "1px solid", borderColor: "black10" }
+              : {})}
+          >
+            <Text variant="md">
+              {displayQuery
+                ? `See full results for “${option.text}”`
+                : option.text}
             </Text>
-          )}
-        </Box>
-      )}
+
+            {"subtitle" in option && (
+              <Text variant="xs" color="black60">
+                {option.subtitle}
+              </Text>
+            )}
+          </Box>
+        )
+      }}
     />
   )
 }

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -83,9 +83,10 @@ export const AutocompleteInput = <T extends AutoCompleteInputOption>({
     },
   })
 
-  const isDropdownVisible = open && query !== "" && options.length > 0
+  const isDropdownVisible = open && options.length > 0
 
   // Reset keyboard navigation when options change
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(reset, [options])
 
   // Reset keyboard navigation when query is empty
@@ -93,6 +94,7 @@ export const AutocompleteInput = <T extends AutoCompleteInputOption>({
     if (query === "") {
       reset()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query])
 
   const { anchorRef, tooltipRef } = usePosition({
@@ -199,7 +201,7 @@ export const AutocompleteInput = <T extends AutoCompleteInputOption>({
         role="combobox"
         aria-expanded={isDropdownVisible}
         aria-autocomplete="list"
-        {...(!!id ? { id, "aria-describedby": `${id}__assistiveHint` } : {})}
+        {...(id ? { id, "aria-describedby": `${id}__assistiveHint` } : {})}
         label={
           loading ? (
             <Box width={18}>
@@ -256,7 +258,7 @@ export const AutocompleteInput = <T extends AutoCompleteInputOption>({
         </>
       )}
 
-      <VisuallyHidden {...(!!id ? { id: `${id}__assistiveHint` } : {})}>
+      <VisuallyHidden {...(id ? { id: `${id}__assistiveHint` } : {})}>
         When autocomplete results are available use up and down arrows to review
         and enter to select. Touch device users, explore by touch or with swipe
         gestures.


### PR DESCRIPTION
This makes more sense since the component is expecting any options passed into be pre-filtered. If you wanted to disable them for some query length you'd simply do so `{query.length !== 0 ? options : []}`