### PR TITLE
fix(tabs): avoids scrolling on mount

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import { TextVariant } from "@artsy/palette-tokens/dist/typography/types"
-import React, { createRef, useCallback, useEffect, useState } from "react"
+import React, { createRef, useCallback, useState } from "react"
 import { flattenChildren } from "../../helpers/flattenChildren"
 import { useThemeConfig } from "../../Theme"
 import { useUpdateEffect } from "../../utils/useUpdateEffect"
@@ -51,16 +51,15 @@ export const useTabs = ({
     setActiveTabIndex(initialTabIndex)
   }, [initialTabIndex])
 
-  const scrollToTab = () =>
+  const scrollToTab = useCallback(() => {
     activeTab.ref.current?.scrollIntoView?.({
       inline: "center",
       block: "nearest",
       behavior: "smooth",
     })
+  }, [activeTab.ref])
 
-  useEffect(() => {
-    scrollToTab()
-  }, [tabs, activeTabIndex])
+  useUpdateEffect(scrollToTab, [scrollToTab])
 
   const handleClick = useCallback(
     (index: number) => {
@@ -80,7 +79,7 @@ export const useTabs = ({
         })
       }
     },
-    [tabs, onChange, activeTabIndex]
+    [activeTabIndex, onChange, scrollToTab, tabs]
   )
 
   return {


### PR DESCRIPTION
Trying to fix autoscrolling showing up on route changes.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@17.6.1-canary.1067.21660.0
  npm install @artsy/palette@18.6.1-canary.1067.21660.0
  # or 
  yarn add @artsy/palette-charts@17.6.1-canary.1067.21660.0
  yarn add @artsy/palette@18.6.1-canary.1067.21660.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
