### PR TITLE
Revert "fix(tabs): add scrollIntoView for active tab"

### DIFF
--- a/packages/palette/src/elements/Tabs/Tabs.story.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.story.tsx
@@ -1,8 +1,6 @@
 import { action } from "@storybook/addon-actions"
 import React, { useState } from "react"
 import { States } from "storybook-states"
-import { Button } from "../Button"
-import { Flex } from "../Flex"
 import { ChevronIcon } from "../../svgs"
 import { Sup } from "../Sup"
 import { Tab, Tabs, TabsProps } from "./"
@@ -100,24 +98,9 @@ export const ConditionalTabs = () => {
 }
 
 export const AutoScrolling = () => {
-  const [activeTabIndex, setActiveTabIndex] = useState(0)
-
   return (
-    <Tabs onChange={action("onChange")} initialTabIndex={activeTabIndex}>
-      <Tab name="First">
-        First
-        <Flex>
-          <Button
-            size="small"
-            marginTop={4}
-            onClick={() => {
-              setActiveTabIndex(14)
-            }}
-          >
-            Scroll to last
-          </Button>
-        </Flex>
-      </Tab>
+    <Tabs onChange={action("onChange")}>
+      <Tab name="First">First</Tab>
       <Tab name="Second">Second</Tab>
       <Tab name="Third">Third</Tab>
       <Tab name="Fourth">Fourth</Tab>
@@ -131,20 +114,7 @@ export const AutoScrolling = () => {
       <Tab name="Twelveth">Twelveth</Tab>
       <Tab name="Thirteenth">Thirteenth</Tab>
       <Tab name="Fourteenth">Fourteenth</Tab>
-      <Tab name="Fifteenth">
-        Fifteenth
-        <Flex>
-          <Button
-            size="small"
-            marginTop={4}
-            onClick={() => {
-              setActiveTabIndex(0)
-            }}
-          >
-            Scroll to first
-          </Button>
-        </Flex>
-      </Tab>
+      <Tab name="Fifteenth">Fifteenth</Tab>
     </Tabs>
   )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import { TextVariant } from "@artsy/palette-tokens/dist/typography/types"
-import React, { createRef, useCallback, useEffect, useState } from "react"
+import React, { createRef, useCallback, useState } from "react"
 import { flattenChildren } from "../../helpers/flattenChildren"
 import { useThemeConfig } from "../../Theme"
 import { useUpdateEffect } from "../../utils/useUpdateEffect"
@@ -51,17 +51,6 @@ export const useTabs = ({
     setActiveTabIndex(initialTabIndex)
   }, [initialTabIndex])
 
-  const scrollToTab = () =>
-    activeTab.ref.current?.scrollIntoView?.({
-      inline: "center",
-      block: "nearest",
-      behavior: "smooth",
-    })
-
-  useEffect(() => {
-    scrollToTab()
-  }, [tabs, activeTabIndex])
-
   const handleClick = useCallback(
     (index: number) => {
       return () => {
@@ -69,7 +58,11 @@ export const useTabs = ({
 
         setActiveTabIndex(index)
 
-        scrollToTab()
+        tabs[index].ref.current?.scrollIntoView?.({
+          inline: "center",
+          block: "nearest",
+          behavior: "smooth",
+        })
 
         if (!onChange) return
 


### PR DESCRIPTION
Reverts artsy/palette#1066

Few problems here — mainly that this causes components to auto-scroll into view when re-rendered.

Will follow this up with a more correct solution.