### PR TITLE
fix(tabs): avoids scrolling on mount

### DIFF
--- a/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React, { forwardRef, useMemo } from "react"
 import { flattenChildren } from "../../helpers/flattenChildren"
 import { useThemeConfig } from "../../Theme"
 import { Box, BoxProps } from "../Box"
@@ -17,39 +17,39 @@ export type BaseTabsProps = BoxProps & {
 }
 
 /** Extends `Box`, provides configurable gutter */
-export const BaseTabs: React.FC<BaseTabsProps> = ({
-  fill,
-  separator: defaultSeparator,
-  children,
-  ...rest
-}) => {
-  const separator = useThemeConfig({
-    v2: defaultSeparator ?? <Box mx={1} />,
-    v3: defaultSeparator,
-  })
+export const BaseTabs: React.ForwardRefExoticComponent<
+  BaseTabsProps & React.RefAttributes<HTMLDivElement>
+> = forwardRef(
+  ({ fill, separator: defaultSeparator, children, ...rest }, forwardedRef) => {
+    const separator = useThemeConfig({
+      v2: defaultSeparator ?? <Box mx={1} />,
+      v3: defaultSeparator,
+    })
 
-  const cells = useMemo(() => flattenChildren(children), [children])
+    const cells = useMemo(() => flattenChildren(children), [children])
 
-  return (
-    <HorizontalOverflow
-      borderBottom="1px solid"
-      borderBottomColor="black10"
-      {...rest}
-    >
-      <Join separator={separator!}>
-        {cells.map((child, i) => {
-          return (
-            <Box
-              key={i}
-              display="inline-flex"
-              textAlign="center"
-              flex={fill ? 1 : undefined}
-            >
-              {child}
-            </Box>
-          )
-        })}
-      </Join>
-    </HorizontalOverflow>
-  )
-}
+    return (
+      <HorizontalOverflow
+        ref={forwardedRef}
+        borderBottom="1px solid"
+        borderBottomColor="black10"
+        {...rest}
+      >
+        <Join separator={separator!}>
+          {cells.map((child, i) => {
+            return (
+              <Box
+                key={i}
+                display="inline-flex"
+                textAlign="center"
+                flex={fill ? 1 : undefined}
+              >
+                {child}
+              </Box>
+            )
+          })}
+        </Join>
+      </HorizontalOverflow>
+    )
+  }
+)

--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
@@ -1,5 +1,6 @@
+import composeRefs from "@seznam/compose-react-refs"
 import { themeGet } from "@styled-system/theme-get"
-import React, { useEffect, useRef, useState } from "react"
+import React, { forwardRef, useEffect, useRef, useState } from "react"
 import styled from "styled-components"
 import {
   border,
@@ -58,10 +59,9 @@ const Rail = styled(Box)`
 
 export type HorizontalOverflowProps = BoxProps & { children: React.ReactNode }
 
-export const HorizontalOverflow: React.FC<HorizontalOverflowProps> = ({
-  children,
-  ...rest
-}) => {
+export const HorizontalOverflow: React.ForwardRefExoticComponent<
+  HorizontalOverflowProps & React.RefAttributes<HTMLDivElement>
+> = forwardRef(({ children, ref: _ref, ...rest }, forwardedRef) => {
   const ref = useRef<HTMLDivElement | null>()
 
   useEffect(() => {
@@ -93,11 +93,16 @@ export const HorizontalOverflow: React.FC<HorizontalOverflowProps> = ({
 
   return (
     <Overlay atEnd={atEnd} {...boxProps}>
-      <Viewport ref={ref as any} onScroll={updateAtEnd}>
+      <Viewport
+        ref={composeRefs(ref, forwardedRef) as any}
+        onScroll={updateAtEnd}
+      >
         <Rail display="inline-flex" verticalAlign="top" {...railProps}>
           {children}
         </Rail>
       </Viewport>
     </Overlay>
   )
-}
+})
+
+HorizontalOverflow.displayName = "HorizontalOverflow"

--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
@@ -61,7 +61,7 @@ export type HorizontalOverflowProps = BoxProps & { children: React.ReactNode }
 
 export const HorizontalOverflow: React.ForwardRefExoticComponent<
   HorizontalOverflowProps & React.RefAttributes<HTMLDivElement>
-> = forwardRef(({ children, ref: _ref, ...rest }, forwardedRef) => {
+> = forwardRef(({ children, ...rest }, forwardedRef) => {
   const ref = useRef<HTMLDivElement | null>()
 
   useEffect(() => {
@@ -92,6 +92,7 @@ export const HorizontalOverflow: React.ForwardRefExoticComponent<
   }
 
   return (
+    // @ts-ignore
     <Overlay atEnd={atEnd} {...boxProps}>
       <Viewport
         ref={composeRefs(ref, forwardedRef) as any}

--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -46,14 +46,19 @@ export const Stepper: React.FC<StepperProps> = ({
     },
   })
 
-  const { tabs, activeTab, activeTabIndex, handleClick } = useTabs({
+  const { tabs, activeTab, activeTabIndex, handleClick, ref } = useTabs({
     children,
     initialTabIndex,
   })
 
   return (
     <>
-      <BaseTabs separator={tokens.joinSeparator!} fill={tokens.fill} {...rest}>
+      <BaseTabs
+        ref={ref}
+        separator={tokens.joinSeparator!}
+        fill={tokens.fill}
+        {...rest}
+      >
         {tabs.map((tab, i) => {
           return (
             <BaseTab
@@ -99,7 +104,7 @@ export const Stepper: React.FC<StepperProps> = ({
         })}
       </BaseTabs>
 
-      {activeTab.child}
+      {activeTab.current.child}
     </>
   )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.story.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.story.tsx
@@ -1,11 +1,11 @@
 import { action } from "@storybook/addon-actions"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { States } from "storybook-states"
-import { Button } from "../Button"
-import { Flex } from "../Flex"
 import { ChevronIcon } from "../../svgs"
 import { Sup } from "../Sup"
 import { Tab, Tabs, TabsProps } from "./"
+import { Box } from "../Box"
+import { useCursor } from "use-cursor"
 
 export default {
   title: "Components/Tabs",
@@ -100,51 +100,88 @@ export const ConditionalTabs = () => {
 }
 
 export const AutoScrolling = () => {
-  const [activeTabIndex, setActiveTabIndex] = useState(0)
+  const { index: initialTabIndex, handleNext } = useCursor({ max: 15 })
+
+  useEffect(() => {
+    const interval = setInterval(handleNext, 500)
+    return () => clearInterval(interval)
+  }, [handleNext])
 
   return (
-    <Tabs onChange={action("onChange")} initialTabIndex={activeTabIndex}>
-      <Tab name="First">
-        First
-        <Flex>
-          <Button
-            size="small"
-            marginTop={4}
-            onClick={() => {
-              setActiveTabIndex(14)
-            }}
-          >
-            Scroll to last
-          </Button>
-        </Flex>
-      </Tab>
-      <Tab name="Second">Second</Tab>
-      <Tab name="Third">Third</Tab>
-      <Tab name="Fourth">Fourth</Tab>
-      <Tab name="Fifth">Fifth</Tab>
-      <Tab name="Sixth">Sixth</Tab>
-      <Tab name="Seventh">Seventh</Tab>
-      <Tab name="Eighth">Eighth</Tab>
-      <Tab name="Nineth">Nineth</Tab>
-      <Tab name="Tenth">Tenth</Tab>
-      <Tab name="Eleventh">Eleventh</Tab>
-      <Tab name="Twelveth">Twelveth</Tab>
-      <Tab name="Thirteenth">Thirteenth</Tab>
-      <Tab name="Fourteenth">Fourteenth</Tab>
-      <Tab name="Fifteenth">
-        Fifteenth
-        <Flex>
-          <Button
-            size="small"
-            marginTop={4}
-            onClick={() => {
-              setActiveTabIndex(0)
-            }}
-          >
-            Scroll to first
-          </Button>
-        </Flex>
-      </Tab>
-    </Tabs>
+    <>
+      <Tabs initialTabIndex={initialTabIndex} onChange={action("onChange")}>
+        <Tab name="First">First</Tab>
+        <Tab name="Second">Second</Tab>
+        <Tab name="Third">Third</Tab>
+        <Tab name="Fourth">Fourth</Tab>
+        <Tab name="Fifth">Fifth</Tab>
+        <Tab name="Sixth">Sixth</Tab>
+        <Tab name="Seventh">Seventh</Tab>
+        <Tab name="Eighth">Eighth</Tab>
+        <Tab name="Nineth">Nineth</Tab>
+        <Tab name="Tenth">Tenth</Tab>
+        <Tab name="Eleventh">Eleventh</Tab>
+        <Tab name="Twelveth">Twelveth</Tab>
+        <Tab name="Thirteenth">Thirteenth</Tab>
+        <Tab name="Fourteenth">Fourteenth</Tab>
+        <Tab name="Fifteenth">Fifteenth</Tab>
+      </Tabs>
+
+      <pre>{JSON.stringify({ initialTabIndex })}</pre>
+    </>
   )
+}
+
+AutoScrolling.story = {
+  parameters: { chromatic: { disable: true } },
+}
+
+export const InitialAutoScroll = () => {
+  const [key, setKey] = useState(1)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setKey((key) => key + 1)
+    }, 500)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <>
+      <Box bg="black10" height={1000} p={2}>
+        The vertical scroll of this page should be at the top.
+        <br />
+        Scroll down to see the tabs.
+        <br />
+        Render: #{key}
+      </Box>
+
+      <Tabs onChange={action("onChange")} initialTabIndex={14}>
+        <Tab name="First">First</Tab>
+        <Tab name="Second">Second</Tab>
+        <Tab name="Third">Third</Tab>
+        <Tab name="Fourth">Fourth</Tab>
+        <Tab name="Fifth">Fifth</Tab>
+        <Tab name="Sixth">Sixth</Tab>
+        <Tab name="Seventh">Seventh</Tab>
+        <Tab name="Eighth">Eighth</Tab>
+        <Tab name="Nineth">Nineth</Tab>
+        <Tab name="Tenth">Tenth</Tab>
+        <Tab name="Eleventh">Eleventh</Tab>
+        <Tab name="Twelveth">Twelveth</Tab>
+        <Tab name="Thirteenth">Thirteenth</Tab>
+        <Tab name="Fourteenth">Fourteenth</Tab>
+        <Tab name="Fifteenth">
+          This tab should be active &amp; visible on mount.
+        </Tab>
+      </Tabs>
+
+      <Box bg="black10" height={1000} />
+    </>
+  )
+}
+
+InitialAutoScroll.story = {
+  parameters: { chromatic: { disable: true } },
 }


### PR DESCRIPTION
So — the problem was that `scrollIntoView` was working — meaning it _was_ scrolling the active tab into view horizontally _as well as_ vertically.  This isn't really a problem when triggered via a click since to click something it's always going to be in the viewport. But this became a problem when we started using the prop to drive the active index since the initial mount is going to force the `scrollIntoView` as well.

Initially my thought was that we could use `useUpdateEffect` to skip the initial mount, but that has a few problems: one is that Force pages re-render _a lot_. Another is that if you set the initial index to something something that was off-screen it wouldn't be scrolled to initially.

Two things needed to happen:
* We need to manually scroll by getting a handle on the viewport ref and manipulating it's `scrollLeft` instead of just using `scrollIntoView`.
* We need to prevent scrolls from triggering on normal re-renders that don't change the index.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@17.6.1-canary.1070.21704.0
  npm install @artsy/palette@18.6.1-canary.1070.21704.0
  # or 
  yarn add @artsy/palette-charts@17.6.1-canary.1070.21704.0
  yarn add @artsy/palette@18.6.1-canary.1070.21704.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
