### PR TITLE
fix(DSWGW-99): Autocomplete Q/A

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -116,7 +116,6 @@
     "@artsy/palette-tokens": "^2.6.0",
     "@seznam/compose-react-refs": "^1.0.6",
     "@styled-system/theme-get": "^5.1.2",
-    "debounce": "^1.2.0",
     "luxon": "^1.15",
     "proportional-scale": "^4.0.0",
     "react-lazy-load-image-component": "1.5.0",
@@ -125,7 +124,7 @@
     "styled-system": "^5.1.5",
     "trunc-html": "^1.1.2",
     "use-cursor": "^1.2.3",
-    "use-keyboard-list-navigation": "2.4.1"
+    "use-keyboard-list-navigation": "2.4.2"
   },
   "husky": {
     "hooks": {

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -80,6 +80,7 @@ export const Demo = () => {
       onChange={handleChange}
       onSelect={action("onSelect")}
       onSubmit={action("onSubmit")}
+      onClose={action("onClose")}
       renderOption={(option, i) => {
         const displayQuery = i === 0 && query !== ""
 

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -1,5 +1,12 @@
 import composeRefs from "@seznam/compose-react-refs"
-import React, { createRef, useEffect, useMemo, useReducer, useRef } from "react"
+import React, {
+  createRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+} from "react"
 import styled from "styled-components"
 import { useKeyboardListNavigation } from "use-keyboard-list-navigation"
 import { Spinner } from ".."
@@ -187,14 +194,17 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     option?.ref?.current?.focus()
   }, [index, optionsWithRefs])
 
+  const handleFocusChange = useCallback((focused: boolean) => {
+    if (focused) return
+    dispatch({ type: "CLOSE" })
+    reset()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Handle closing the dropdown when clicking outside of the input
   // or when focus leaves the input completely
   const { ref: containsFocusRef } = useContainsFocus({
-    onChange: (focused) => {
-      if (focused) return
-      dispatch({ type: "CLOSE" })
-      reset()
-    },
+    onChange: handleFocusChange,
   })
 
   const handleInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -313,6 +313,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
                   onMouseDown={handleMouseDown(option, i)}
                   onMouseEnter={handleMouseEnter(i)}
                   selected={i === index}
+                  tabIndex={-1}
                 >
                   {renderOption(option, i)}
                 </AutocompleteInputOption>

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -5,7 +5,7 @@ import { useKeyboardListNavigation } from "use-keyboard-list-navigation"
 import { Spinner } from ".."
 import { DROP_SHADOW } from "../../helpers"
 import { CloseIcon, MagnifyingGlassIcon } from "../../svgs"
-import { useClickOutside, usePosition } from "../../utils"
+import { usePosition, useContainsFocus } from "../../utils"
 import { useWidthOf } from "../../utils/useWidthOf"
 import { Box, splitBoxProps } from "../Box"
 import { Clickable } from "../Clickable"
@@ -58,6 +58,8 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
   onSelect?(option: T, index: number): void
   /** on <click> of the 'x' (clear) button */
   onClear?(): void
+  /** Callback that runs when options are hidden */
+  onClose?(): void
   renderOption?(
     option: T,
     i: number
@@ -74,6 +76,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   onSelect,
   onChange,
   onClear,
+  onClose,
   onKeyDown,
   height,
   renderOption = (option) => <AutocompleteInputOptionLabel {...option} />,
@@ -123,17 +126,18 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
 
   const isDropdownVisible = state.open && options.length > 0
 
+  useEffect(() => {
+    if (!isDropdownVisible) onClose?.()
+  }, [isDropdownVisible, onClose])
+
   // Reset keyboard navigation when options change
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(reset, [options])
 
   // Reset keyboard navigation when query is empty
   useEffect(() => {
-    if (state.query === "") {
-      reset()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.query])
+    if (state.query === "") reset()
+  }, [reset, state.query])
 
   const { anchorRef, tooltipRef } = usePosition({
     position: "bottom",
@@ -183,11 +187,11 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     option?.ref?.current?.focus()
   }, [index, optionsWithRefs])
 
-  // Handle closing the dropdown
-  useClickOutside({
-    ref: containerRef,
-    when: isDropdownVisible,
-    onClickOutside: () => {
+  // Handle closing the dropdown when clicking outside of the input
+  // or when focus leaves the input completely
+  const { ref: containsFocusRef } = useContainsFocus({
+    onChange: (focused) => {
+      if (focused) return
       dispatch({ type: "CLOSE" })
       reset()
     },
@@ -256,7 +260,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
 
   return (
     <Box
-      ref={containerRef as any}
+      ref={composeRefs(containerRef, containsFocusRef) as any}
       onKeyDown={handleContainerKeydown}
       {...boxProps}
     >
@@ -295,32 +299,30 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
       />
 
       {isDropdownVisible && (
-        <>
-          <AutocompleteInputDropdown
-            ref={tooltipRef as any}
-            role="listbox"
-            width={width}
-          >
-            {optionsWithRefs.map(({ option, ref }, i) => {
-              return (
-                <AutocompleteInputOption
-                  key={i}
-                  ref={ref}
-                  role="option"
-                  aria-selected={i === index}
-                  aria-posinset={i + 1}
-                  aria-setsize={options.length}
-                  onMouseDown={handleMouseDown(option, i)}
-                  onMouseEnter={handleMouseEnter(i)}
-                  selected={i === index}
-                  tabIndex={-1}
-                >
-                  {renderOption(option, i)}
-                </AutocompleteInputOption>
-              )
-            })}
-          </AutocompleteInputDropdown>
-        </>
+        <AutocompleteInputDropdown
+          ref={tooltipRef as any}
+          role="listbox"
+          width={width}
+        >
+          {optionsWithRefs.map(({ option, ref }, i) => {
+            return (
+              <AutocompleteInputOption
+                key={i}
+                ref={ref}
+                role="option"
+                aria-selected={i === index}
+                aria-posinset={i + 1}
+                aria-setsize={options.length}
+                onMouseDown={handleMouseDown(option, i)}
+                onMouseEnter={handleMouseEnter(i)}
+                selected={i === index}
+                tabIndex={-1}
+              >
+                {renderOption(option, i)}
+              </AutocompleteInputOption>
+            )
+          })}
+        </AutocompleteInputDropdown>
       )}
 
       <VisuallyHidden {...(id ? { id: `${id}__assistiveHint` } : {})}>

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -189,6 +189,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     when: isDropdownVisible,
     onClickOutside: () => {
       dispatch({ type: "CLOSE" })
+      reset()
     },
   })
 

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.test.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.test.tsx
@@ -3,8 +3,6 @@ import React from "react"
 import { Radio } from "../Radio"
 import { RadioGroup } from "../RadioGroup"
 
-jest.mock("debounce", () => x => x)
-
 describe("RadioGroup", () => {
   it("renders a radio group", () => {
     const spy = jest.fn()
@@ -18,10 +16,7 @@ describe("RadioGroup", () => {
     expect(wrapper.text()).toContain("Provide shipping address")
     expect(wrapper.text()).toContain("Arrange for pickup")
 
-    wrapper
-      .find("Radio")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().simulate("click")
 
     expect(spy).toHaveBeenCalled()
   })
@@ -34,18 +29,8 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(false)
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().selected).toBe(false)
+    expect(wrapper.find("Radio").last().props().selected).toBe(true)
   })
 
   it("selects the radio that gets clicked", () => {
@@ -56,23 +41,10 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    wrapper
-      .find("Radio")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().simulate("click")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(true)
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").first().props().selected).toBe(true)
+    expect(wrapper.find("Radio").last().props().selected).toBe(false)
   })
 
   it("allows the 'disabled' prop on the Radio component to take the precedence", () => {
@@ -85,18 +57,8 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().disabled
-    ).toBe(false)
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().disabled
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().disabled).toBe(false)
+    expect(wrapper.find("Radio").last().props().disabled).toBe(true)
   })
 
   it("displays a specific text when disabled", () => {
@@ -122,21 +84,11 @@ describe("RadioGroup", () => {
 
     ship.simulate("click")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().selected).toBe(true)
 
     ship.simulate("click")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").first().props().selected).toBe(false)
   })
 
   it("ignores the 'selected' prop on the Radio component", () => {
@@ -157,7 +109,7 @@ describe("RadioGroup", () => {
   })
 
   it("allows for updates to defaultValue", () => {
-    const getWrapper = defaultValue =>
+    const getWrapper = (defaultValue) =>
       mount(
         <RadioGroup defaultValue={defaultValue}>
           <Radio value="SHIP" selected>
@@ -169,35 +121,15 @@ describe("RadioGroup", () => {
 
     let wrapper = getWrapper("PICKUP")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").first().props().selected).toBe(false)
 
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").last().props().selected).toBe(true)
 
     wrapper = getWrapper("SHIP")
 
-    expect(
-      wrapper
-        .find("Radio")
-        .first()
-        .props().selected
-    ).toBe(true)
+    expect(wrapper.find("Radio").first().props().selected).toBe(true)
 
-    expect(
-      wrapper
-        .find("Radio")
-        .last()
-        .props().selected
-    ).toBe(false)
+    expect(wrapper.find("Radio").last().props().selected).toBe(false)
   })
 
   it("allows for using the onSelect callback both on RadioGroup and Radio", () => {
@@ -213,10 +145,7 @@ describe("RadioGroup", () => {
       </RadioGroup>
     )
 
-    wrapper
-      .find("Radio")
-      .first()
-      .simulate("click")
+    wrapper.find("Radio").first().simulate("click")
 
     expect(spyOnRadioGroup).toHaveBeenCalled()
     expect(spyOnRadio).toHaveBeenCalled()

--- a/packages/palette/src/utils/index.ts
+++ b/packages/palette/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./useClickOutside"
+export * from "./useContainsFocus"
 export * from "./useFocusLock"
 export * from "./useIsomorphicLayoutEffect"
 export * from "./useMutationObserver"

--- a/packages/palette/src/utils/useContainsFocus.ts
+++ b/packages/palette/src/utils/useContainsFocus.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react"
+
+export const useContainsFocus = ({
+  onChange,
+}: {
+  onChange(focused: boolean): void
+}) => {
+  const ref = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const handleFocus = debounce(() => {
+      if (!ref.current) return
+
+      onChange(
+        ref.current === document.activeElement ||
+          ref.current.contains(document.activeElement)
+      )
+    })
+
+    document.addEventListener("focus", handleFocus, true)
+    document.addEventListener("blur", handleFocus, true)
+
+    return () => {
+      document.removeEventListener("focus", handleFocus)
+      document.removeEventListener("blur", handleFocus)
+    }
+  }, [onChange])
+
+  return { ref }
+}
+
+/**
+ * A simplified debounce that just executes the last function if multiple
+ * functions are called within the same tick. Since frequently a blur and a focus
+ * will happen concurrently: the last function (the focus) will be executed.
+ * If travelling from two elements within the same focus group, `focused` will remain `true`.
+ */
+const debounce = (callback: () => void) => {
+  let timer: ReturnType<typeof setTimeout>
+
+  return () => {
+    clearTimeout(timer)
+
+    timer = setTimeout(() => {
+      callback()
+    }, 0)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10354,11 +10354,6 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
-
 debug@2, debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -25311,10 +25306,10 @@ use-isomorphic-layout-effect@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
   integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
 
-use-keyboard-list-navigation@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/use-keyboard-list-navigation/-/use-keyboard-list-navigation-2.4.1.tgz#e6d2ee6188da005deebf443356f1dfbb20d86030"
-  integrity sha512-ghycnT+Hp86CUS780pp+ZcPhffYMUQvcofMq3US7kzNZCZ5eAL+vs+vR6BaTBcbSPJklIcEKvwJUcajeny/YkQ==
+use-keyboard-list-navigation@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/use-keyboard-list-navigation/-/use-keyboard-list-navigation-2.4.2.tgz#d237e6cc35886c0f541d9e65eb5b3d2a65e6498d"
+  integrity sha512-PCoIDKsEmYaoce6pOwgU5xsqBjrRuUwcNNdIP1ZTmxyz9716zOAFJJHAp44QE74Zmnxc1VvgYxAfIkaCbq105A==
   dependencies:
     map-cursor-to-max "^1.0.0"
 


### PR DESCRIPTION
This should take care of [DSWGW-99](https://artsyproduct.atlassian.net/browse/DSWGW-99)

A small note is that instead of altering the native `onBlur`, I've added an `onClose` prop that will run after the options are closed (when focus leaves the component group).

Install the canary once it publishes and let me know if I've missed anything.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@17.7.2-canary.1075.21847.0
  npm install @artsy/palette@18.7.2-canary.1075.21847.0
  # or 
  yarn add @artsy/palette-charts@17.7.2-canary.1075.21847.0
  yarn add @artsy/palette@18.7.2-canary.1075.21847.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
