### PR TITLE
feat(NX02486): adjusts the modal to the new design

### DIFF
--- a/packages/palette/src/elements/Modal/Modal.story.tsx
+++ b/packages/palette/src/elements/Modal/Modal.story.tsx
@@ -6,10 +6,18 @@ export default {
   title: "Components/Modal",
 }
 
+const content = `
+  Chicharrones marfa tumeric squid four loko flexitarian celiac hell of hot chicken 
+  jianbing salvia enamel pin woke. Migas you probably haven't heard of them church-key 
+  pok pok banh mi yr ennui ethical subway tile authentic. Sartorial retro roof party, 
+  gastropub bicycle rights drinking vinegar microdosing swag DIY deep v. Viral hella pop-up, 
+  banh mi squid poke chambray yuccie biodiesel occupy scenester.
+`
+
 export const Default = () => {
   return (
     <Modal show onClose={() => null}>
-      Some example content
+      {content}
     </Modal>
   )
 }
@@ -18,33 +26,100 @@ Default.story = {
   parameters: { chromatic: { delay: 500 } },
 }
 
-export const WithTitle = () => {
+export const Title = () => {
   return (
     <Modal show title="Modal Title" onClose={() => null}>
-      Some example content
+      {content}
     </Modal>
   )
 }
 
-WithTitle.story = {
-  name: "With title",
+Title.story = {
+  name: "Title",
   parameters: { chromatic: { delay: 500 } },
 }
 
-export const WithLogo = () => {
+export const LongTitle = () => {
   return (
-    <Modal show title="Modal Title" hasLogo onClose={() => null}>
-      Some example content
+    <Modal
+      show
+      title="Modal Title with a longer title or headline text that runs on for mutliple lines"
+      onClose={() => null}
+    >
+      {content}
     </Modal>
   )
 }
 
-WithLogo.story = {
-  name: "With logo",
+LongTitle.story = {
+  name: "Long title",
   parameters: { chromatic: { delay: 500 } },
 }
 
-export const ModalWithFixedButton = () => {
+export const Logo = () => {
+  return (
+    <Modal show hasLogo onClose={() => null}>
+      {content}
+    </Modal>
+  )
+}
+
+Logo.story = {
+  name: "Logo",
+  parameters: { chromatic: { delay: 500 } },
+}
+
+export const LogoAndTitle = () => {
+  return (
+    <Modal show hasLogo title="Modal Title" onClose={() => null}>
+      {content}
+    </Modal>
+  )
+}
+
+LogoAndTitle.story = {
+  name: "Logo and title",
+  parameters: { chromatic: { delay: 500 } },
+}
+
+export const FixedButton = () => {
+  return (
+    <Modal
+      show
+      title="Modal Title"
+      hasLogo
+      onClose={() => null}
+      FixedButton={<Button width="100%">Click me</Button>}
+    >
+      {content.repeat(5)}
+    </Modal>
+  )
+}
+
+FixedButton.story = {
+  name: "Fixed button",
+  parameters: { chromatic: { delay: 500 } },
+}
+
+export const FixedButtonNoTitle = () => {
+  return (
+    <Modal
+      show
+      hasLogo
+      onClose={() => null}
+      FixedButton={<Button width="100%">Click me</Button>}
+    >
+      {content.repeat(5)}
+    </Modal>
+  )
+}
+
+FixedButtonNoTitle.story = {
+  name: "Fixed button no title",
+  parameters: { chromatic: { delay: 500 } },
+}
+
+export const FixedButtonNoLogo = () => {
   return (
     <Modal
       show
@@ -52,25 +127,25 @@ export const ModalWithFixedButton = () => {
       onClose={() => null}
       FixedButton={<Button width="100%">Click me</Button>}
     >
-      Some example content
+      {content.repeat(5)}
     </Modal>
   )
 }
 
-ModalWithFixedButton.story = {
-  name: "Modal with fixed button",
+FixedButtonNoLogo.story = {
+  name: "Fixed button no logo",
   parameters: { chromatic: { delay: 500 } },
 }
 
-export const WideModal = () => {
+export const Wide = () => {
   return (
     <Modal show title="Modal Title" isWide onClose={() => null}>
-      Some example content
+      {content}
     </Modal>
   )
 }
 
-WideModal.story = {
-  name: "Wide modal",
+Wide.story = {
+  name: "Wide",
   parameters: { chromatic: { delay: 500 } },
 }

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -64,9 +64,8 @@ export const Modal: FC<ModalProps> = ({
   hideCloseButton,
 }) => {
   const wrapperRef = useRef(null)
-  const sentinelRef = useRef(null)
   const [fadeIn, setFadeIn] = useState(false)
-  const { isScrolled } = useOnScroll(sentinelRef)
+  const { isScrolled, elementRef } = useOnScroll()
 
   const handleEscapeKey = (event) => {
     if (event && event.key === "Escape") {
@@ -158,7 +157,7 @@ export const Modal: FC<ModalProps> = ({
                 pb={2}
               >
                 <>
-                  <Sentinel ref={sentinelRef} />
+                  <Sentinel ref={elementRef} />
                   {children}
                 </>
               </ModalScrollContent>

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -64,9 +64,9 @@ export const Modal: FC<ModalProps> = ({
   hideCloseButton,
 }) => {
   const wrapperRef = useRef(null)
-  const contentRef = useRef(null)
+  const sentinelRef = useRef(null)
   const [fadeIn, setFadeIn] = useState(false)
-  const { isScrolled } = useOnScroll(contentRef)
+  const { isScrolled } = useOnScroll(sentinelRef)
 
   const handleEscapeKey = (event) => {
     if (event && event.key === "Escape") {
@@ -121,7 +121,7 @@ export const Modal: FC<ModalProps> = ({
                 display="flex"
                 justifyContent="center"
                 flexDirection="column"
-                isScrolling={isScrolled}
+                isScrolled={isScrolled}
                 px={2}
               >
                 <Spacer my={1} />
@@ -151,18 +151,20 @@ export const Modal: FC<ModalProps> = ({
               </ModalStickyHeader>
 
               <ModalScrollContent
-                ref={contentRef}
                 hasLogo={hasLogo}
                 modalWidth={modalWidth}
                 px={2}
                 py={1}
                 pb={2}
               >
-                {children}
+                <>
+                  <Sentinel ref={sentinelRef} />
+                  {children}
+                </>
               </ModalScrollContent>
 
               {FixedButton && (
-                <FixedButtonWrapper isScrolling={isScrolled} p={2}>
+                <FixedButtonWrapper isScrolled={isScrolled} p={2}>
                   {FixedButton}
                 </FixedButtonWrapper>
               )}
@@ -175,11 +177,11 @@ export const Modal: FC<ModalProps> = ({
 }
 
 interface ShadowOnScroll {
-  isScrolling?: boolean
+  isScrolled?: boolean
 }
 
 const FixedButtonWrapper = styled(Flex)<ShadowOnScroll>`
-  box-shadow: ${({ isScrolling }) => (isScrolling ? DROP_SHADOW : "none")};
+  box-shadow: ${({ isScrolled }) => (isScrolled ? DROP_SHADOW : "none")};
   flex: 0 0 auto;
   transition: box-shadow 250ms ease-in-out;
 `
@@ -249,7 +251,7 @@ const ModalFlexContent = styled(Flex)<ModalScrollContentProps>`
 `
 
 const ModalStickyHeader = styled(Box)<ModalScrollContentProps & ShadowOnScroll>`
-  box-shadow: ${({ isScrolling }) => (isScrolling ? DROP_SHADOW : "none")};
+  box-shadow: ${({ isScrolled }) => (isScrolled ? DROP_SHADOW : "none")};
   transition: box-shadow 250ms ease-in-out;
 `
 
@@ -264,6 +266,15 @@ const CloseIconWrapper = styled(Flex)`
 
 const Logo = styled(ArtsyLogoBlackIcon)`
   width: 78px;
+`
+
+// This <div> is positioned such that when it leaves the top of
+// the ModalScrollContent we use IntersectionObserver within the hook
+// to switch on and of the shadows of the sticky elements
+const Sentinel = styled(Box)`
+  position: relative;
+  width: 100%;
+  height: 0;
 `
 
 Modal.displayName = "Modal"

--- a/packages/palette/src/utils/useOnScroll.ts
+++ b/packages/palette/src/utils/useOnScroll.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState, RefObject } from "react"
+
+/**
+ * useOnScroll is used to track if an element is scrolled vertically or not
+ */
+export const useOnScroll = (ref: RefObject<HTMLElement>) => {
+  const [isScrolled, setIsScrolled] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (node) {
+      const onScroll = () => {
+        if (node.scrollTop > 0) {
+          !isScrolled && setIsScrolled(true)
+        } else {
+          isScrolled && setIsScrolled(false)
+        }
+      }
+
+      node.addEventListener("scroll", onScroll, false)
+
+      return () => {
+        node.removeEventListener("scroll", onScroll, false)
+      }
+    }
+  }, [ref, isScrolled])
+
+  return { isScrolled }
+}

--- a/packages/palette/src/utils/useOnScroll.ts
+++ b/packages/palette/src/utils/useOnScroll.ts
@@ -7,21 +7,26 @@ export const useOnScroll = (ref: RefObject<HTMLElement>) => {
   const [isScrolled, setIsScrolled] = useState(false)
 
   useEffect(() => {
+    if (!("IntersectionObserver" in window)) return
+
     const node = ref.current
-    if (node) {
-      const onScroll = () => {
-        if (node.scrollTop > 0) {
-          !isScrolled && setIsScrolled(true)
-        } else {
-          isScrolled && setIsScrolled(false)
-        }
-      }
+    if (!node) return
 
-      node.addEventListener("scroll", onScroll, false)
-
-      return () => {
-        node.removeEventListener("scroll", onScroll, false)
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsScrolled(!entry.isIntersecting)
+      },
+      {
+        root: null,
+        rootMargin: "0px",
+        threshold: 1.0,
       }
+    )
+
+    observer.observe(ref.current)
+
+    return () => {
+      observer.unobserve(node)
     }
   }, [ref, isScrolled])
 

--- a/packages/palette/src/utils/useOnScroll.ts
+++ b/packages/palette/src/utils/useOnScroll.ts
@@ -6,11 +6,10 @@ import { useEffect, useState, useRef } from "react"
 export const useOnScroll = () => {
   const [isScrolled, setIsScrolled] = useState(false)
   const elementRef = useRef(null)
+  const node = elementRef.current
 
   useEffect(() => {
     if (!("IntersectionObserver" in window)) return
-
-    const node = elementRef.current
     if (!node) return
 
     const observer = new IntersectionObserver(
@@ -29,7 +28,7 @@ export const useOnScroll = () => {
     return () => {
       observer.unobserve(node)
     }
-  }, [elementRef, isScrolled])
+  }, [node, isScrolled])
 
   return { isScrolled, elementRef }
 }

--- a/packages/palette/src/utils/useOnScroll.ts
+++ b/packages/palette/src/utils/useOnScroll.ts
@@ -1,15 +1,16 @@
-import { useEffect, useState, RefObject } from "react"
+import { useEffect, useState, useRef } from "react"
 
 /**
  * useOnScroll is used to track if an element is scrolled vertically or not
  */
-export const useOnScroll = (ref: RefObject<HTMLElement>) => {
+export const useOnScroll = () => {
   const [isScrolled, setIsScrolled] = useState(false)
+  const elementRef = useRef(null)
 
   useEffect(() => {
     if (!("IntersectionObserver" in window)) return
 
-    const node = ref.current
+    const node = elementRef.current
     if (!node) return
 
     const observer = new IntersectionObserver(
@@ -23,12 +24,12 @@ export const useOnScroll = (ref: RefObject<HTMLElement>) => {
       }
     )
 
-    observer.observe(ref.current)
+    observer.observe(node)
 
     return () => {
       observer.unobserve(node)
     }
-  }, [ref, isScrolled])
+  }, [elementRef, isScrolled])
 
-  return { isScrolled }
+  return { isScrolled, elementRef }
 }


### PR DESCRIPTION
[NX-2486]

This PR updates the Modal to the latest changes from Design. Also implements a new idea, the shadow over sticky elements only when the content it's scrolled, getting back to scrollTop 0, doesn't show the shadow.

I kept the old narrow behavior and didn't create any breaking changes, only styling things happened here.

I wanted to create unit tests for this new hook but with Enzyme and the use case was tricky to be done, I wonder if we're going to extend RTL to Palette too, my vote is YES, definitely facilitates some neat stuff to test like hooks over Enzyme.

<details>
<summary>Desktop</summary>

https://user-images.githubusercontent.com/15792853/142894439-6844b8e7-c5cf-45d5-873d-5ccc51444b61.mov

</details>

<details>
<summary>Mobile</summary>

https://user-images.githubusercontent.com/15792853/142894425-5973efd5-6172-4a95-8055-32fbcd6f8ed3.mov

</details>

<details>
<summary>Hook in action Desktop/Mobile</summary>

https://user-images.githubusercontent.com/15792853/142894612-872bbad8-32f2-4872-9a70-36f52e6e10e4.mov

</details>

[NX-2486]: https://artsyproduct.atlassian.net/browse/NX-2486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@17.7.0-canary.1076.21932.0
  npm install @artsy/palette@18.7.0-canary.1076.21932.0
  # or 
  yarn add @artsy/palette-charts@17.7.0-canary.1076.21932.0
  yarn add @artsy/palette@18.7.0-canary.1076.21932.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
