### PR TITLE
fix(autocomplete): improves onclose; fixes memory leak

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -133,10 +133,6 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
 
   const isDropdownVisible = state.open && options.length > 0
 
-  useEffect(() => {
-    if (!isDropdownVisible) onClose?.()
-  }, [isDropdownVisible, onClose])
-
   // Reset keyboard navigation when options change
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(reset, [options])
@@ -194,12 +190,16 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     option?.ref?.current?.focus()
   }, [index, optionsWithRefs])
 
-  const handleFocusChange = useCallback((focused: boolean) => {
-    if (focused) return
-    dispatch({ type: "CLOSE" })
-    reset()
+  const handleFocusChange = useCallback(
+    (focused: boolean) => {
+      if (focused) return
+      dispatch({ type: "CLOSE" })
+      reset()
+      onClose?.()
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    [onClose]
+  )
 
   // Handle closing the dropdown when clicking outside of the input
   // or when focus leaves the input completely

--- a/packages/palette/src/utils/useContainsFocus.ts
+++ b/packages/palette/src/utils/useContainsFocus.ts
@@ -21,8 +21,8 @@ export const useContainsFocus = ({
     document.addEventListener("blur", handleFocus, true)
 
     return () => {
-      document.removeEventListener("focus", handleFocus)
-      document.removeEventListener("blur", handleFocus)
+      document.removeEventListener("focus", handleFocus, true)
+      document.removeEventListener("blur", handleFocus, true)
     }
   }, [onChange])
 


### PR DESCRIPTION
Moves onClose to the focus leave hook. Also (!) fixes a memory leak in that hook.