### PR TITLE
fix(clickable): resets margin for safari

### DIFF
--- a/packages/palette/src/elements/Clickable/Clickable.story.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.story.tsx
@@ -24,6 +24,12 @@ export const Default = () => {
             </>
           ),
         },
+        {
+          bg: "red100",
+          color: "white100",
+          m: 2,
+          p: 1,
+        },
       ]}
     >
       <Clickable onClick={action("onClick")}>Clickable</Clickable>

--- a/packages/palette/src/elements/Clickable/Clickable.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.tsx
@@ -21,6 +21,7 @@ export const Clickable = styled.button<ClickableProps>`
   appearance: none;
   padding: 0;
   border: 0;
+  margin: 0;
   background-color: transparent;
   color: inherit;
   font: inherit;


### PR DESCRIPTION
Apparently all buttons have a default 2px vertical margin in Safari. Here we reset that.