### PR TITLE
fix(autocomplete): only closes when options are visible

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -61,6 +61,7 @@ export const Default = () => {
         options={OPTIONS}
         onSelect={action("onSelect")}
         onSubmit={action("onSubmit")}
+        onClose={action("onClose")}
       />
     </States>
   )

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -192,13 +192,14 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
 
   const handleFocusChange = useCallback(
     (focused: boolean) => {
-      if (focused) return
+      if (focused || !isDropdownVisible) return
+
       dispatch({ type: "CLOSE" })
       reset()
       onClose?.()
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [onClose]
+    [onClose, isDropdownVisible]
   )
 
   // Handle closing the dropdown when clicking outside of the input


### PR DESCRIPTION
Will only try to close and execute callback if options are visible.