### PR TITLE
feat(NX-3032): add space of 20px in xs breakpoint

### DIFF
--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -212,7 +212,7 @@ const ModalWrapper = styled(Flex)`
   align-items: center;
 `
 
-const ModalElement = styled(Box)<TransitionElementProps>`
+const ModalElement = styled(Flex)<TransitionElementProps>`
   position: absolute;
   height: ${(props) => (props.height ? props.height : "auto") as any};
   max-height: calc(100vh - 80px);
@@ -225,9 +225,8 @@ const ModalElement = styled(Box)<TransitionElementProps>`
 
   ${media.xs`
     max-height: 100vh;
-    height: 100vh;
-    width: 100vw;
-    border-radius: 0;
+    height: calc(100vh - ${themeGet("space.4")});
+    width: calc(100vw - ${themeGet("space.4")});
   `};
 
   transform: translateY(2000px);


### PR DESCRIPTION
[NX-3032]

This PR adds 20px of space around the modal in xs breakpoint.

![image](https://user-images.githubusercontent.com/15792853/144851387-c2ddebf1-3b4b-40b7-9360-10dcbe6b9ceb.png)


[NX-3032]: https://artsyproduct.atlassian.net/browse/NX-3032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ