### PR TITLE
fix(SWA): Fix onEnter in AutocompleteInput

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -125,7 +125,9 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     ref: containerRef,
     list: options,
     waitForInteractive: true,
-    onEnter: ({ element: option, index: i }) => {
+    onEnter: ({ element: option, index: i, event }) => {
+      event.preventDefault()
+      event.stopPropagation()
       handleSelect(option, i)
       resetUI()
     },


### PR DESCRIPTION
This PR stops default behavior and event propagation for the `onEnter` handler in `AutocompleteInput`

**VIDEO:clapper: :**

BEFORE: (`onEnter` triggers form submit if the user has filled valid form)

https://user-images.githubusercontent.com/55637696/147667204-b0e0273e-75da-43a5-9bd3-4eda889759fd.mov

https://user-images.githubusercontent.com/55637696/147667215-e62c4ce7-35dc-4411-aee2-203e87348dda.mov

https://user-images.githubusercontent.com/55637696/147667380-4e9e3b45-83de-4d30-bd1f-0919ce8e6f0f.mov

AFTER: