### PR TITLE
security(colors.js): Lock version to 1.4 due to corruption

### DIFF
--- a/packages/palette-charts/package.json
+++ b/packages/palette-charts/package.json
@@ -35,6 +35,10 @@
     "url": "https://github.com/artsy/palette/issues"
   },
   "homepage": "https://github.com/artsy/palette#readme",
+  "resolutions": {
+    "//": "Locking colors to 1.4.0 because 1.4.4 has been deliberately corrupted",
+    "colors": "1.4.0"
+  },
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
See https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/ 

We don't import this lib directly, but it is an ephemeral dep, which still runs the risk of an automatic update. 

<img width="148" alt="Screen Shot 2022-01-09 at 12 58 45 PM" src="https://user-images.githubusercontent.com/236943/148701333-c7165766-6261-4e17-8448-4730838adaa6.png">

