### PR TITLE
feat(filterselect): Add multiselect option

### DIFF
--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
@@ -18,6 +18,7 @@ interface FilterSelectContextProps {
   filteredItems: Item[]
   initialItemsToShow: number
   isFiltered: boolean
+  multiselect: boolean
   onChange: (state: {
     items: FilterSelectContextProps["items"]
     filteredItems: FilterSelectContextProps["filteredItems"]
@@ -39,6 +40,7 @@ export type FilterSelectState = Pick<
   | "initialItemsToShow"
   | "items"
   | "isFiltered"
+  | "multiselect"
   | "onChange"
   | "order"
   | "placeholder"
@@ -82,9 +84,16 @@ const filterSelectReducer = (state: FilterSelectState, action: Action) => {
         (item) => item.value === action.payload.item.value
       )
 
-      const selectedItems = isFound
-        ? reject(state.selectedItems, { value: action.payload.item.value })
-        : [...state.selectedItems, action.payload.item]
+      let selectedItems
+      if (isFound) {
+        selectedItems = reject(state.selectedItems, {
+          value: action.payload.item.value,
+        })
+      } else {
+        selectedItems = state.multiselect
+          ? [...state.selectedItems, action.payload.item]
+          : [action.payload.item]
+      }
 
       return {
         ...state,
@@ -99,6 +108,7 @@ const initialState: FilterSelectState = {
   initialItemsToShow: INITIAL_ITEMS_TO_SHOW,
   isFiltered: false,
   items: [],
+  multiselect: true,
   onChange: (x) => x,
   order: [["label"], ["asc"]],
   placeholder: "",

--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
@@ -13,23 +13,29 @@ export interface Item {
   [key: string]: string | number | boolean
 }
 
+// In order to satisfy the Relay compilers readonly list types. This is in
+// support for passing different kinds of item types as props, like aggregations
+export type Items = ReadonlyArray<Item>
+
+export interface FilterSelectChangeState {
+  items: FilterSelectContextProps["items"]
+  filteredItems: FilterSelectContextProps["filteredItems"]
+  selectedItems: FilterSelectContextProps["selectedItems"]
+  query: FilterSelectContextProps["query"]
+}
+
 interface FilterSelectContextProps {
-  items: Item[]
-  filteredItems: Item[]
+  items: Items
+  filteredItems: Items
   initialItemsToShow: number
   isFiltered: boolean
   multiselect: boolean
-  onChange: (state: {
-    items: FilterSelectContextProps["items"]
-    filteredItems: FilterSelectContextProps["filteredItems"]
-    selectedItems: FilterSelectContextProps["selectedItems"]
-    query: FilterSelectContextProps["query"]
-  }) => void
+  onChange: (state: FilterSelectChangeState) => void
   order: [string[], Array<"asc" | "desc">] // See: https://lodash.com/docs/4.17.15#orderBy
   placeholder: string
   query: string
   renderItemLabel?: (item: any) => string
-  selectedItems: Item[]
+  selectedItems: Items
   setSelectedItems: (item: Item) => void
   setQuery: (query: string) => void
 }

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.story.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.story.tsx
@@ -14,12 +14,13 @@ export const Default = () => {
         {
           placeholder: "Filter by artist name",
           initialItemsToShow: 6,
+          multiselect: true,
           order: [
             ["country", "name"],
             ["asc", "asc"],
           ],
           renderItemLabel: (item) => {
-            return `${item.name}, ${item.country}`
+            return `${item.label}, ${item.country}`
           },
           onChange: (state) => {
             console.log(state)

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.test.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.test.tsx
@@ -72,6 +72,28 @@ describe("FilterSelect", () => {
     expect(text).toContain("Item 3")
   })
 
+  it("only selects one item if multiselect=false, and doesnt resort", () => {
+    const wrapper = getWrapper({ multiselect: false })
+    wrapper.find("Checkbox").at(1).simulate("click")
+    wrapper.update()
+    expect(wrapper.find("Checkbox").at(1).props().selected).toBe(true)
+
+    let text = wrapper.text()
+    expect(text).toContain("Item 1")
+    expect(text).toContain("Item 2")
+    expect(text).toContain("Item 3")
+
+    wrapper.find("Checkbox").at(2).simulate("click")
+    wrapper.update()
+    expect(wrapper.find("Checkbox").at(1).props().selected).not.toBe(true)
+    expect(wrapper.find("Checkbox").at(2).props().selected).toBe(true)
+
+    text = wrapper.text()
+    expect(text).toContain("Item 1")
+    expect(text).toContain("Item 2")
+    expect(text).toContain("Item 3")
+  })
+
   it("filters items", () => {
     const wrapper = getWrapper({ query: "Item 3" })
     const text = wrapper.text()
@@ -158,6 +180,7 @@ describe("FilterSelect", () => {
     })
 
     simulateTyping(wrapper, "item1")
+    wrapper.find("Checkbox").at(0).simulate("click")
     wrapper.update()
 
     expect(spy).toHaveBeenCalledWith(
@@ -168,7 +191,7 @@ describe("FilterSelect", () => {
           { label: "Item2", value: "item-2" },
         ],
         query: "item1",
-        selectedItems: [],
+        selectedItems: [{ label: "Item1", value: "item-1" }],
       })
     )
   })

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -32,6 +32,7 @@ const _FilterSelect: React.FC = () => {
     initialItemsToShow,
     isFiltered,
     items,
+    multiselect,
     onChange,
     order,
     query,
@@ -49,7 +50,7 @@ const _FilterSelect: React.FC = () => {
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query])
+  }, [selectedItems])
 
   if (items.length === 0) {
     return null
@@ -58,7 +59,10 @@ const _FilterSelect: React.FC = () => {
   const orderItems = (items) => orderBy(items, order[0], order[1])
   const itemsOrdered = orderItems(items)
   const filterdItemsOrdered = orderItems(filteredItems)
-  const itemsSorted = uniqBy(selectedItems.concat(itemsOrdered), "value") // Move selected items to the top
+  const itemsSorted = multiselect
+    ? // Move selected items to the top
+      uniqBy(selectedItems.concat(itemsOrdered), "value")
+    : itemsOrdered
   const expanded = isBelowTheFoldSelected(selectedItems, itemsSorted)
   const showNoResults = filteredItems.length === 0 && query !== ""
 

--- a/packages/palette/src/elements/FilterSelect/index.tsx
+++ b/packages/palette/src/elements/FilterSelect/index.tsx
@@ -1,1 +1,5 @@
+export {
+  FilterSelectChangeState,
+  Items as FilterSelectItems,
+} from "./Components/FilterSelectContext"
 export * from "./FilterSelect"


### PR DESCRIPTION
Adds a new multiselect prop so that we can support single select lists. Also updates a type to support dynamic relay list types from force. See "typescript readonly confusion" in google 😓   