### PR TITLE
fix(usefocuslock): skips -1 tabindex elements

### DIFF
--- a/packages/palette/src/utils/useFocusLock.story.tsx
+++ b/packages/palette/src/utils/useFocusLock.story.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react"
 import { useFocusLock } from "./useFocusLock"
 import { Input } from "../elements/Input"
 import { Button } from "../elements/Button"
-import { AutocompleteInput } from ".."
+import { AutocompleteInput } from "../elements/AutocompleteInput"
 
 export default {
   title: "Hooks/useFocusLock",
@@ -19,7 +19,14 @@ export const Default = () => {
       <div ref={ref}>
         <Input placeholder="Focusable" />
         <Input placeholder="Focusable" />
-        <Button>Focusable</Button>
+        <a href="#" tabIndex={-1}>
+          Skipped
+        </a>
+        <a href="#">Focusable</a>
+        <Button variant="secondaryGray" tabIndex={-1}>
+          Skipped
+        </Button>
+        <Button variant="secondaryGray">Focusable</Button>
       </div>
       <Input placeholder="Not focusable" />
     </>

--- a/packages/palette/src/utils/useFocusLock.ts
+++ b/packages/palette/src/utils/useFocusLock.ts
@@ -3,12 +3,12 @@ import { useCursor } from "use-cursor"
 import { useMutationObserver } from "./useMutationObserver"
 
 const FOCUSABLE_SELECTOR = [
-  "a[href]",
-  "area[href]",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  "button:not([disabled])",
+  "a[href]:not([tabindex='-1'])",
+  "area[href]:not([tabindex='-1'])",
+  "input:not([disabled]):not([tabindex='-1'])",
+  "select:not([disabled]):not([tabindex='-1'])",
+  "textarea:not([disabled]):not([tabindex='-1'])",
+  "button:not([disabled]):not([tabindex='-1'])",
   '[tabindex="0"]',
 ].join(", ")
 


### PR DESCRIPTION
Nodes with `tabIndex="-1"` shouldn't be focusable.