### PR TITLE
fix(docs): Update broken edit docs link to point at main branch

### DIFF
--- a/packages/palette-docs/content/docs/atoms/Spacing.mdx
+++ b/packages/palette-docs/content/docs/atoms/Spacing.mdx
@@ -4,7 +4,7 @@ subNavOrder: 1
 ---
 
 When building layouts and components, palette hooks into a handful of
-[reusable base-10 spacing units](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx#L98-L112).
+[reusable base-10 spacing units](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx#L98-L112).
 With ten pixels as the base, `1` equals `10px`, `2` equals `20px`, `.5` equals
 `5px` (and so on). This allows us to constrain the possibilities available to a
 component to only what's defined in our spacing system and thus reduce drift.

--- a/packages/palette-docs/content/docs/atoms/Spacing.mdx
+++ b/packages/palette-docs/content/docs/atoms/Spacing.mdx
@@ -37,6 +37,11 @@ as seen below.
   {JSON.stringify(THEME_V3.space, null, 2)}
 </Box>
 
+Note that these spacing values don't apply to `height` and `width`. Why? Imagine
+an image. On a page it can have whatever height or width, as `height` and
+`width` are properties intrinsic to it and have no bearing on how that image
+_behaves_ on a page with other elements.
+
 ### Styled System API
 
 If you'd like to read more about how this to use this form of spacing, check out

--- a/packages/palette-docs/content/docs/guides/development.mdx
+++ b/packages/palette-docs/content/docs/guides/development.mdx
@@ -9,17 +9,17 @@ how it's done.
 ### Overview
 
 \- During development most of your time will be spent in
-[`packages/palette`](https://github.com/artsy/palette/tree/master/packages/palette),
+[`packages/palette`](https://github.com/artsy/palette/tree/main/packages/palette),
 the main Palette library. Here you'll write new components inside of the
 `elements` folder, add tests, and define
-[storybook stories](https://github.com/artsy/palette/blob/master/packages/palette/src/elements/Avatar/Avatar.story.tsx)
+[storybook stories](https://github.com/artsy/palette/blob/main/packages/palette/src/elements/Avatar/Avatar.story.tsx)
 for each.
 
 \- If adding or changing a component, make sure to update the docs in
-[`packages/palette-docs`](https://github.com/artsy/palette/tree/master/packages/palette-docs).
+[`packages/palette-docs`](https://github.com/artsy/palette/tree/main/packages/palette-docs).
 
 \- If needing to modify the theme, see
-[`packages/palette-tokens`](https://github.com/artsy/palette/tree/master/packages/palette-docs).
+[`packages/palette-tokens`](https://github.com/artsy/palette/tree/main/packages/palette-docs).
 
 \- New package versions are published by attaching appropriate semver github
 labels to PRs; by default, all PRs have `minor` automatically assigned. When a
@@ -81,7 +81,7 @@ sub-packages:
 ### palette-tokens
 
 Starting at `palette-tokens`, we can see the
-[theme](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx)
+[theme](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx)
 that powers all of Palette. This is a simple object with keys such as
 `breakpoints`, `space` and `color`, and is read in by the main `palette` lib as
 well as [Eigen](https://github.com/artsy/eigen), our React Native mobile app.
@@ -89,7 +89,7 @@ well as [Eigen](https://github.com/artsy/eigen), our React Native mobile app.
 ### palette
 
 The `palette` package is where all of our components are defined. See the
-[elements](https://github.com/artsy/palette/tree/master/packages/palette/src/elements)
+[elements](https://github.com/artsy/palette/tree/main/packages/palette/src/elements)
 folder for the complete list.
 
 ### palette-docs

--- a/packages/palette-docs/content/docs/guides/migration.mdx
+++ b/packages/palette-docs/content/docs/guides/migration.mdx
@@ -12,10 +12,10 @@ of.
 **For reference, check out the difference between our v2 and v3 themes below:**
 
 **v2**:
-[palette-tokens/v2](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v2.tsx)
+[palette-tokens/v2](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v2.tsx)
 
 **v3**:
-[palette-tokens/v3](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx)
+[palette-tokens/v3](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx)
 
 ### How to Migrate
 
@@ -58,7 +58,7 @@ This is useful if you're programmatically setting things, as we do in Force
 
 Once the component tree is wrapped in the correct provider you should be able to
 access our
-[v3 theme](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx).
+[v3 theme](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx).
 
 ### Using the `useThemeConfig` hook
 

--- a/packages/palette-docs/content/docs/guides/storybooks.mdx
+++ b/packages/palette-docs/content/docs/guides/storybooks.mdx
@@ -1,0 +1,16 @@
+---
+name: React Storybooks
+---
+
+When developing new components we use [Storybooks](https://storybook.js.org/).
+This allows us to rapidly iterate in a self-contained environment, while
+additionally allowing for a quick overview of a components full API.
+
+See: [Palette Storybooks](https://palette-storybook.artsy.net/)
+
+While we strive to keep things aligned between Storybooks and our docs, be aware
+that sometimes things can be out of sync! If you see something that's missing in
+the docs but is present in Storybooks, please file
+[a ticket in JIRA](https://artsyproduct.atlassian.net/jira/software/projects/WP/boards/97).
+
+For more information, check out our [Development Guide](/guides/development/).

--- a/packages/palette-docs/content/docs/index.mdx
+++ b/packages/palette-docs/content/docs/index.mdx
@@ -46,7 +46,7 @@ export const App = (props) => {
 ```
 
 From there you should be able to access the values from Palette's
-[Theme.tsx](https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx)
+[Theme.tsx](https://github.com/artsy/palette/blob/main/packages/palette/src/Theme.tsx)
 file:
 
 ```tsx

--- a/packages/palette-docs/src/layouts/MainLayout.tsx
+++ b/packages/palette-docs/src/layouts/MainLayout.tsx
@@ -160,7 +160,7 @@ const EditButton = ({ editUrl }) => {
 
 export const ViewSourceButton = ({ source }) => {
   const BASE_URL =
-    "https://github.com/artsy/palette/tree/master/packages/palette/src"
+    "https://github.com/artsy/palette/tree/main/packages/palette/src"
 
   return (
     <a

--- a/packages/palette-docs/src/utils/getEditUrl.ts
+++ b/packages/palette-docs/src/utils/getEditUrl.ts
@@ -1,7 +1,7 @@
 import { takeRight } from "lodash"
 
 const BASE_EDIT_URL =
-  "https://github.com/artsy/palette/edit/master/packages/palette-docs/content/"
+  "https://github.com/artsy/palette/edit/main/packages/palette-docs/content/"
 
 export function getEditUrl(fileAbsolutePath) {
   const pathParts = fileAbsolutePath.split("/")


### PR DESCRIPTION
This was overlooked with the master -> main switch. Thanks @lilyfromseattle for calling that out and the suggestion to update the docs with a note about height and width in regards to spacing. 

Also added a guides page on Storybooks so that folks know it exists. 