### PR TITLE
fix(ModalBase): Make SSR friendly

### DIFF
--- a/packages/palette/src/elements/Modal/ModalBase.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.tsx
@@ -55,7 +55,14 @@ export const DEFAULT_MODAL_Z_INDEX = 9999
  * Low-level modal that has no opinions about layout/overlay
  * Modals content using a portal, locks scroll.
  */
-export const ModalBase: React.FC<ModalBaseProps> = ({
+export const ModalBase: React.FC<ModalBaseProps> = (props) => {
+  if (typeof window === "undefined") {
+    return null
+  }
+  return <_ModalBase {...props} />
+}
+
+export const _ModalBase: React.FC<ModalBaseProps> = ({
   children,
   zIndex = DEFAULT_MODAL_Z_INDEX,
   dialogProps = {},


### PR DESCRIPTION
Noticed that pages in force were erroring out if they include the ModalDialog, but aren't guarded against on the server. 