### PR TITLE
chore(docs): Super minor fixes

### DIFF
--- a/packages/palette-docs/content/docs/index.mdx
+++ b/packages/palette-docs/content/docs/index.mdx
@@ -5,7 +5,7 @@ type: page
 hideInNav: true
 ---
 
-<ArtsyLogoIcon height={80} />
+<ArtsyLogoIcon height={80} mt={0.5} />
 
 Palette is Artsy's design system. This is a collection of primitive,
 product-agnostic elements that help ensure consistency and quality across

--- a/packages/palette-docs/src/components/Sidebar/NavTree.tsx
+++ b/packages/palette-docs/src/components/Sidebar/NavTree.tsx
@@ -63,7 +63,6 @@ function renderNavTree(tree: TreeNode[], treeDepth: number = 0) {
         pl: 2,
         py: 0.5,
         variant: "md",
-        borderLeft: "1px solid",
         borderColor: "black10",
       }
     } else {

--- a/packages/palette-docs/src/components/TableOfContents.tsx
+++ b/packages/palette-docs/src/components/TableOfContents.tsx
@@ -25,7 +25,7 @@ export const TableOfContents = ({ headings }) => {
 
   return (
     <>
-      <Text variant="xs" textTransform="uppercase" color="black80" mb={1}>
+      <Text variant="xs" textTransform="uppercase" color="black80" my={1}>
         On this page
       </Text>
       {headings.map(({ value }, idx) => {


### PR DESCRIPTION
Realized that my main issue was that the two logos on the home page (and the far right column header) were all top aligned, but are difference sizes. I made everything vertically centered (just about), and now it looks right. Also removed the vertical lines in the left sidebar: 

<img width="1218" alt="Screen Shot 2022-02-04 at 11 17 57 AM" src="https://user-images.githubusercontent.com/236943/152589877-9abd8bbb-ab6e-40da-9199-8668da5b186e.png">

looks A+ now 

