### PR TITLE
fix: remove permanent transparency from DonutChart labels

### DIFF
--- a/packages/palette-charts/src/elements/DonutChart/DonutChart.tsx
+++ b/packages/palette-charts/src/elements/DonutChart/DonutChart.tsx
@@ -28,7 +28,6 @@ export const DonutChart: React.FC<DonutChartProps> = ({
   margin = space(3),
 }) => {
   const [hoverIndex, setHoverIndex] = useState(-1)
-  const [labelFadeIn] = useState(false)
 
   const wrapperRef = useRef<HTMLDivElement>(null)
 
@@ -77,7 +76,6 @@ export const DonutChart: React.FC<DonutChartProps> = ({
       axisLabelX && (
         <DonutLabelContainer
           key={index}
-          opacity={labelFadeIn ? 1 : 0}
           x={x + centerX}
           y={y + centerY}
           center={centerX}
@@ -147,7 +145,6 @@ interface DonutLabelContainerProps {
   x: number
   y: number
   center?: number
-  opacity: number
 }
 
 // to create a float:right effect for labels that are on left side (also top)
@@ -172,6 +169,4 @@ const DonutLabelContainer = styled.div<DonutLabelContainerProps>`
     ${({ y, center }) => computeLabelTranslate(y, center)}
   );
   white-space: nowrap;
-  transition: opacity 0.4s ease-in;
-  opacity: ${({ opacity }) => opacity};
 `


### PR DESCRIPTION
Addresses [PX-4907]

In #956, we removed react-spring, and as part of this work we removed logic that was setting the opacity of DonutChart labels from 0 to 1. The effect of this was that the labels remained at `opacity:0`, and never appeared. 

This PR removes opacity from the DonutChart. Since the previous PR removed the "flourish" from this component, I don't personally think it is worth preserving the fading-in effect on the labels. Instead, they are now permanently visible. 

It's been a while since I contributed here in palette so please let me know if I interpreted incorrectly and need to manually generate a changelog entry 😅 

## Before this PR vs After this PR

![image](https://user-images.githubusercontent.com/1627089/154567393-4c4efb6a-1107-42a5-b5b8-6591ad5cadc9.png)

cc @artsy/px-devs 

[PX-4907]: https://artsyproduct.atlassian.net/browse/PX-4907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ