### PR TITLE
fix(useclickoutside): wait for stack to clear before adding event

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import styled from "styled-components"
 import { DROP_SHADOW } from "../../helpers"
 import { isText } from "../../helpers/isText"
@@ -58,8 +58,13 @@ export const Popover: React.FC<PopoverProps> = ({
     anchorRef.current.focus()
   }, [visible])
 
-  const onVisible = () => setVisible(true)
-  const onHide = () => setVisible(false)
+  const onVisible = useCallback(() => {
+    setVisible(true)
+  }, [])
+
+  const onHide = useCallback(() => {
+    setVisible(false)
+  }, [])
 
   useEffect(() => {
     const handleKeydown = (event: KeyboardEvent) => {
@@ -69,10 +74,11 @@ export const Popover: React.FC<PopoverProps> = ({
     }
 
     document.addEventListener("keydown", handleKeydown)
+
     return () => {
       document.removeEventListener("keydown", handleKeydown)
     }
-  }, [])
+  }, [onHide])
 
   const { anchorRef, tooltipRef } = usePosition({
     position: placement,

--- a/packages/palette/src/utils/useClickOutside.ts
+++ b/packages/palette/src/utils/useClickOutside.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useEffect, useRef } from "react"
 
 export interface UseClickOutside {
   ref: React.RefObject<HTMLElement>
@@ -19,24 +19,25 @@ export const useClickOutside = ({
 }: UseClickOutside) => {
   const savedHandler = useRef(onClickOutside)
 
-  const handleClick = useCallback((e: Event) => {
-    if (ref && ref.current && !ref.current!.contains(e.target as Element)) {
-      savedHandler.current(e)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   useEffect(() => {
     savedHandler.current = onClickOutside
   }, [onClickOutside])
 
   useEffect(() => {
+    const handleClick = (event: Event) => {
+      if (ref.current && !ref.current.contains(event.target as Element)) {
+        savedHandler.current(event)
+      }
+    }
+
     if (when) {
-      document.addEventListener(type, handleClick)
+      setTimeout(() => {
+        document.addEventListener(type, handleClick)
+      }, 0)
+
       return () => {
         document.removeEventListener(type, handleClick)
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [when])
+  }, [ref, type, when])
 }


### PR DESCRIPTION
This is a weird one — https://github.com/artsy/palette/commit/bb715ff204d1604fb6b0d4179ff1df6e0cefcad2 introduced some state into the `usePosition` hook, which should be fine. But the re-render that state initiates causes it to compete with the click handler that `useClickOutside` registers. So you click to make the popover visible, but that click propagates to the useClickOutside handler which then hides the popover. The solution is to wait for the stack to clear after visibility changes before adding the handler.

As far as catching issues like this with tests: I think we need to add a Cypress test suite. We definitely need more fidelity for these very UI-centric specs and they would be much easier to write.