### PR TITLE
fix: removed line height from pill text

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -27,7 +27,7 @@ export type PillProps = ClickableProps & {
 } & (
     | {
         variant?: Extract<PillVariant, "textRound" | "textSquare" | "filter">
-        /** Forces active state */
+        /** Forces active state & border-color to black60 */
         active?: boolean
       }
     | {
@@ -109,7 +109,6 @@ export const Pill: React.FC<PillProps> = ({ children, ...rest }) => {
 
       <Text
         variant="xs"
-        lineHeight={1}
         {...(typeof children === "string"
           ? // Simple label — handle the text overflow
             { overflowEllipsis: true }


### PR DESCRIPTION
# Description

- Removes `lineHeight={1}` from Pill text to prevent cutting off letters like `g`, `q`, `p`
- Adds clarification about `active` prop style to be more visible

> NOTE: The text background color in the screenshots is not included

### Screenshots

|Before|After|
|--|--|
|![Screenshot 2022-03-04 at 11 56 22](https://user-images.githubusercontent.com/21178754/156752554-bf6d25d6-198e-4fdc-9ebf-c7b9980fa17f.png)|![Screenshot 2022-03-04 at 11 56 08](https://user-images.githubusercontent.com/21178754/156752550-d82e68d0-3ebc-4ea9-84e9-2eb84410135d.png)|
|![Screenshot 2022-03-04 at 12 00 51](https://user-images.githubusercontent.com/21178754/156752561-4438ddb5-8429-4758-958b-910c085f144a.png)|![Screenshot 2022-03-04 at 11 59 05](https://user-images.githubusercontent.com/21178754/156752559-b87d0a68-aaf6-4d8c-87d7-46a59322056a.png)|
||![Screenshot 2022-03-04 at 11 58 51](https://user-images.githubusercontent.com/21178754/156752556-1de5d567-eac4-4d66-954d-3b20f54f03c8.png)|


