### PR TITLE
fix: modalDialog width

### DIFF
--- a/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
@@ -31,7 +31,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = ({
             }
           : { backgroundColor: "transparent" }
       }
-      dialogProps={{ width: width ?? 440 }}
+      dialogProps={{ width: width ?? 480 }}
       {...modalProps}
     >
       <ModalDialogContent


### PR DESCRIPTION
We have a difference of 40px of width in the modal that's is caused by extra padding from left and right, 20px each side; the width should be 440px but the padding are eating 40px. This PR fixes the width of the modal to make it consistent with Figma.

Before
![Screenshot 2022-03-07 at 14 53 38](https://user-images.githubusercontent.com/15792853/157051301-72299ab2-bbf2-472a-bb61-0b752878e861.png)

After
![image](https://user-images.githubusercontent.com/15792853/157051436-e0c438c4-5ef2-45b8-93a5-460fd620344f.png)


