### PR TITLE
fix(filterselect): avoids calling onchange on mount

### DIFF
--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -12,7 +12,7 @@ import { FilterInput } from "./Components/FilterInput"
 import { VisuallyHidden } from "../VisuallyHidden"
 import { Text } from "../Text"
 import { INITIAL_ITEMS_TO_SHOW } from "../ShowMore"
-import { useEffect } from "react"
+import { useUpdateEffect } from "../../utils"
 
 export type FilterSelectProps = Partial<FilterSelectState>
 
@@ -38,7 +38,7 @@ const _FilterSelect: React.FC = () => {
   } = useFilterSelectContext()
 
   // Dispatch change event
-  useEffect(() => {
+  useUpdateEffect(() => {
     if (onChange) {
       onChange({
         items,
@@ -48,7 +48,7 @@ const _FilterSelect: React.FC = () => {
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedItems])
+  }, [onChange, selectedItems])
 
   if (items.length === 0) {
     return null


### PR DESCRIPTION
This actually provides a fix for the double page view logging on `/works-for-you`. Generally speaking, when you manually implement `onChange` you want to use `useUpdateEffect` so that it's not called on mount. In this case https://github.com/artsy/force/blob/bb2c444e9f555fc58817782782df2eb6232d7ea4/src/v2/Apps/WorksForYou/WorksForYouApp.tsx#L46-L54 — `onChange` was being called on mount causing a redirect to itself, which was logging a pageview since the middleware was getting executed with the referrer change.