### PR TITLE
fix(tabs): cached tabs rendering

### DIFF
--- a/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTabs.tsx
@@ -53,3 +53,5 @@ export const BaseTabs: React.ForwardRefExoticComponent<
     )
   }
 )
+
+BaseTabs.displayName = "BaseTabs"

--- a/packages/palette/src/elements/Join/Join.tsx
+++ b/packages/palette/src/elements/Join/Join.tsx
@@ -30,26 +30,18 @@ export const Join: React.FC<JoinProps> = ({ separator, children }) => {
 
   return (
     <>
-      {elements.reduce((acc, element, currentIndex) => {
-        acc.push(
-          // @ts-expect-error  MIGRATE_STRICT_MODE
-          React.cloneElement(element, {
-            key: `join-${currentIndex}`,
-          })
-        )
+      {elements.reduce((acc, element, index) => {
+        // Prefer provided child key, fallback to index
+        const key = typeof element.key !== "undefined" ? element.key : index
 
-        if (currentIndex !== elements.length - 1) {
-          acc.push(
-            // @ts-expect-error  MIGRATE_STRICT_MODE
-            separator &&
-              React.cloneElement(separator, {
-                key: `join-sep-${currentIndex}`,
-              })
-          )
+        acc.push(React.cloneElement(element, { key }))
+
+        if (index !== elements.length - 1) {
+          acc.push(separator && React.cloneElement(separator, { key }))
         }
 
         return acc
-      }, [])}
+      }, [] as typeof elements)}
     </>
   )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.story.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.story.tsx
@@ -6,6 +6,7 @@ import { Sup } from "../Sup"
 import { Tab, Tabs, TabsProps } from "./"
 import { Box } from "../Box"
 import { useCursor } from "use-cursor"
+import { Button } from "../Button"
 
 export default {
   title: "Components/Tabs",
@@ -184,4 +185,30 @@ export const InitialAutoScroll = () => {
 
 InitialAutoScroll.story = {
   parameters: { chromatic: { disable: true } },
+}
+
+// FIXME: Currently renders one step behind
+export const Cached = () => {
+  const [count, setCount] = useState(1)
+
+  return (
+    <>
+      <Button
+        variant="secondaryOutline"
+        size="small"
+        mb={1}
+        onClick={() => {
+          setCount((prevCount) => prevCount + 1)
+        }}
+      >
+        Increment count — count: {count}
+      </Button>
+
+      <Tabs>
+        <Tab name="First">First — count: {count}</Tab>
+        <Tab name="Second">Second — count: {count}</Tab>
+        <Tab name="Third">Third — count: {count}</Tab>
+      </Tabs>
+    </>
+  )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -65,7 +65,7 @@ export const useTabs = ({
   useUpdateEffect(() => {
     activeTab.current = tabs[initialTabIndex]
     setActiveTabIndex(initialTabIndex)
-  }, [initialTabIndex])
+  }, [initialTabIndex, tabs])
 
   // Ref of the tabs viewport
   const ref = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
So this is still a problem, sort of.

Currently the auction pages use the `Tabs` component to display the associated auction. We actually very rarely navigate from a given page to another page of the same type, which is why I think this was never noticed. When that happens though the children of the tabs change, the overall `Tabs` component gets reused without the re-render. Since the child re-renders the tab *should* update and re-render but it doesn't. Two reasons for that. One is that we put the active tab in a ref https://github.com/artsy/palette/pull/1070 to prevent re-rendering on mount to prevent it being scrolled to. Looking at this now I feel like I have a few different ideas on how to solve this but I'm having trouble getting a reliable reproduction of the original issue. (Which I'll come back to. I've included a story which reproduces the new issue.)

Regardless: what was extra confounding was that even giving the `Tabs` a `key` that changed when the parent sale changed prevented a re-render. This was deeply puzzling until I figured out that `Join` was actually blowing away our provided keys. So there's a bug fix for that in 4b251cdeb83a11066bc0c2630a4c6830a0e2f2b6.

So for the time being I'll at least be able to fix the immediate problem on the page and will circle back to resolving the tab issue completely.