### PR TITLE
feat(TX-255): ability to close expandable within expandable content

### DIFF
--- a/packages/palette/src/elements/Expandable/Expandable.story.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.story.tsx
@@ -5,6 +5,7 @@ import { Clickable } from "../Clickable"
 import { Flex } from "../Flex"
 import { Text } from "../Text"
 import { Expandable, ExpandableProps } from "./Expandable"
+import { Button } from "../Button"
 
 export default {
   title: "Components/Expandable",
@@ -22,7 +23,6 @@ export const Default = () => {
           label: (
             <Flex flex={1} justifyContent="space-between">
               <Text variant="md">Heading</Text>
-
               <Clickable
                 textDecoration="underline"
                 onClick={(e) => {
@@ -37,6 +37,15 @@ export const Default = () => {
         },
         { mb: 6 },
         { expanded: true, mb: 6 },
+        {
+          expanded: true,
+          children: ({ setExpanded }) => (
+            <div>
+              <Text>Expanded content</Text>
+              <Button onClick={() => setExpanded(false)}>Close</Button>
+            </div>
+          ),
+        },
       ]}
     >
       <Expandable label="Example" maxWidth={350}>

--- a/packages/palette/src/elements/Expandable/Expandable.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.tsx
@@ -81,9 +81,10 @@ export const Expandable: React.FC<ExpandableProps> = ({
         )}
       </Clickable>
 
-      {expanded && typeof children === "function"
-        ? children({ setExpanded, expanded })
-        : children}
+      {expanded &&
+        (typeof children === "function"
+          ? children({ setExpanded, expanded })
+          : children)}
     </Box>
   )
 }

--- a/packages/palette/src/elements/Expandable/Expandable.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.tsx
@@ -81,7 +81,9 @@ export const Expandable: React.FC<ExpandableProps> = ({
         )}
       </Clickable>
 
-      {expanded && children}
+      {expanded && typeof children === "function"
+        ? children({ setExpanded, expanded })
+        : children}
     </Box>
   )
 }


### PR DESCRIPTION
This PR is needed for the new payment flow for [TX-225](https://artsyproduct.atlassian.net/browse/TX-255) where we need the ability to close an expandable within the expandable content. 

I’ve added an example to the story as well:

https://user-images.githubusercontent.com/50849237/161734257-8006c607-11d2-443a-b00f-80a9b4b8cc03.mov

