### PR TITLE
fix: add white-space: nowrap to pill component

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -47,6 +47,7 @@ const Container = styled(Clickable)<PillProps>`
   justify-content: center;
   text-align: center;
   text-decoration: none;
+  white-space: nowrap;
   border: 1px solid ${themeGet("colors.black15")};
   transition: color 0.25s ease, border-color 0.25s ease,
     background-color 0.25s ease, box-shadow 0.25s ease;


### PR DESCRIPTION
# Description

This pr addresses [FX-3883](https://artsyproduct.atlassian.net/browse/FX-3883)

- adds white-space: nowrap; to Pill component

Reasoning behind this:
Noticed that in force when you visit [Search Results for 'banksy' | Artsy](https://www.artsy.net/search?term=banksy) ,
and the width of your browser is <= 1226 the Artist Series pill is displayed like this:

![55540c1e-3efd-4198-bb21-405093adb7f3](https://user-images.githubusercontent.com/21178754/162710587-a652d201-3a15-4b59-8d66-7eaaebd7bb8f.png)

