### PR TITLE
docs(message): Add missing <Message> component to docs

### DIFF
--- a/packages/palette-docs/content/docs/elements/Message.mdx
+++ b/packages/palette-docs/content/docs/elements/Message.mdx
@@ -1,0 +1,26 @@
+---
+name: Message
+source: elements/Message
+---
+
+### Example
+
+A multi-variant way to display a message to the user.
+
+<Playground>
+  <Message variant="default" title="With Title">
+    <Text color="black60">Default</Text>
+  </Message>
+</Playground>
+
+<Message variant="info" my={1}>
+  Info
+</Message>
+
+<Message variant="warning" my={1}>
+  Warning
+</Message>
+
+<Message variant="error" my={1}>
+  Error
+</Message>


### PR DESCRIPTION
Noticed that `Message` was missing from our docs. 

<img width="715" alt="Screen Shot 2022-05-04 at 5 21 29 PM" src="https://user-images.githubusercontent.com/236943/166847384-21a4ebd3-62a7-4740-abbf-e0cf16e0126a.png">

cc @artsy/grow-devs 