### PR TITLE
fix(text): updates default variant to v3

### DIFF
--- a/packages/palette/src/elements/Text/Text.tsx
+++ b/packages/palette/src/elements/Text/Text.tsx
@@ -114,5 +114,5 @@ Text.displayName = "Text"
 
 Text.defaultProps = {
   fontFamily: "sans",
-  variant: "text",
+  variant: "sm",
 }


### PR DESCRIPTION
Should have done this a while ago. Updates the default variant from `text` to `sm`.