### PR TITLE
fix(spinner): supports box props; respects theme

### DIFF
--- a/packages/palette/src/elements/Spinner/Spinner.story.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.story.tsx
@@ -1,9 +1,17 @@
 import React from "react"
-import { Spinner } from "./Spinner"
+import { States } from "storybook-states"
+import { Spinner, SpinnerProps } from "./Spinner"
 
 export default {
   title: "Components/Spinner",
+  parameters: { chromatic: { disable: true } },
 }
+
+export const Default = () => (
+  <States<SpinnerProps> states={[{}, { color: "brand", size: "small", m: 2 }]}>
+    <Spinner position="static" />
+  </States>
+)
 
 export const DefaultSpinner = () => {
   return <Spinner />
@@ -15,5 +23,4 @@ export const SpinnerWithDelayedShow = () => {
 
 SpinnerWithDelayedShow.story = {
   name: "Spinner with delayed show",
-  parameters: { chromatic: { disable: true } },
 }

--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -1,9 +1,11 @@
+import { themeGet } from "@styled-system/theme-get"
 import React, { useEffect, useState } from "react"
 import styled, { keyframes } from "styled-components"
-import { color } from "../../helpers"
+import { BoxProps } from "../../../dist"
 import { Color } from "../../Theme"
+import { Box } from "../Box"
 
-export interface SpinnerProps {
+export interface SpinnerProps extends Omit<BoxProps, "size"> {
   /** Delay before spinner appears */
   delay?: number
   /** Width of the spinner */
@@ -29,16 +31,19 @@ export const getSize = (props: SpinnerProps) => {
         width: base.width * 0.5,
         height: base.height * 0.5,
       }
+
     case "medium":
       return {
         width: base.width * 0.8,
         height: base.height * 0.8,
       }
+
     case "large":
       return {
         width: base.width,
         height: base.height,
       }
+
     default:
       return {
         width: props.width,
@@ -54,37 +59,39 @@ const spin = keyframes`
 `
 
 /** Generic Spinner component */
-export const Spinner: React.FC<SpinnerProps> = (props) => {
-  const [show, setShow] = useState(props.delay === 0)
+export const Spinner: React.FC<SpinnerProps> = ({ delay, ...rest }) => {
+  const [show, setShow] = useState(delay === 0)
 
   useEffect(() => {
     const timeout = setTimeout(() => {
       setShow(true)
-    }, props.delay)
+    }, delay)
 
     return () => {
       clearTimeout(timeout)
     }
-  }, [])
+  }, [delay])
 
   if (!show) {
     return null
   }
 
-  return <SpinnerBar {...props} />
+  return <SpinnerBar {...rest} />
 }
 
-const SpinnerBar = styled.div<SpinnerProps>`
+const SpinnerBar = styled(Box)<SpinnerProps>`
   animation: ${spin} 1s infinite linear;
-  position: absolute;
 
   ${(props) => {
     const { width, height } = getSize(props)
 
     return `
       background-color: ${
-        props.color === "currentColor" ? "currentColor" : color(props.color!)
+        props.color === "currentColor"
+          ? "currentColor"
+          : themeGet(`colors.${props.color}`)(props)
       };
+
       width: ${width}px;
       height: ${height}px;
       top: calc(50% - ${height}px / 2);
@@ -92,8 +99,9 @@ const SpinnerBar = styled.div<SpinnerProps>`
     `
   }};
 `
-
+// TODO: Remove default `position`, `top`, & `left` props
 Spinner.defaultProps = {
+  position: "absolute",
   delay: 0,
   width: 25,
   height: 6,


### PR DESCRIPTION
Fixes an annoyance with the `Spinner` component. Can now turn off the default assumption that it should be positioned absolutely. Would like to make that default sensible (static) but, for another day.