### PR TITLE
docs(storybook): add notice about our storybooks site

### DIFF
--- a/packages/palette-docs/content/docs/index.mdx
+++ b/packages/palette-docs/content/docs/index.mdx
@@ -15,6 +15,22 @@ used across all Artsy's product ecosystem.
 
 Have questions? Join us in #design-system on slack, we're always happy to help.
 
+<Message variant="info" title="Palette Storybook">
+  Note that we use React Storybooks for developing Palette components;{" "}
+  <a href="https://palette-storybook.artsy.net/" target="_blank">
+    check it out here.
+  </a>
+  <br /> <br />
+  While storybooks doesn't provide live code examples, it's often a more
+  complete representation what features are are available via props. <br />
+  <br /> For more info, see our <a
+    href="https://palette.artsy.net/guides/development"
+    target="_blank"
+  >
+    development guide
+  </a>.
+</Message>
+
 ### Getting Started
 
 To add Palette into your app, install it as a package:


### PR DESCRIPTION
Adds a notice to the palette homepage reminding the user about storybooks: 

<img width="1406" alt="Screen Shot 2022-05-23 at 12 29 55 PM" src="https://user-images.githubusercontent.com/236943/169892770-b6867907-55d5-4d76-ab94-18be94db89af.png">

