### PR TITLE
chore(docs): Fix broken links

### DIFF
--- a/packages/palette-docs/content/docs/atoms/Spacing.mdx
+++ b/packages/palette-docs/content/docs/atoms/Spacing.mdx
@@ -4,7 +4,7 @@ subNavOrder: 1
 ---
 
 When building layouts and components, palette hooks into a handful of
-[reusable base-10 spacing units](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx#L98-L112).
+[reusable base-10 spacing units](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx#L98-L112).
 With ten pixels as the base, `1` equals `10px`, `2` equals `20px`, `.5` equals
 `5px` (and so on). This allows us to constrain the possibilities available to a
 component to only what's defined in our spacing system and thus reduce drift.

--- a/packages/palette-docs/content/docs/guides/development.mdx
+++ b/packages/palette-docs/content/docs/guides/development.mdx
@@ -9,17 +9,17 @@ how it's done.
 ### Overview
 
 \- During development most of your time will be spent in
-[`packages/palette`](https://github.com/artsy/palette/tree/master/packages/palette),
+[`packages/palette`](https://github.com/artsy/palette/tree/main/packages/palette),
 the main Palette library. Here you'll write new components inside of the
 `elements` folder, add tests, and define
-[storybook stories](https://github.com/artsy/palette/blob/master/packages/palette/src/elements/Avatar/Avatar.story.tsx)
+[storybook stories](https://github.com/artsy/palette/blob/main/packages/palette/src/elements/Avatar/Avatar.story.tsx)
 for each.
 
 \- If adding or changing a component, make sure to update the docs in
-[`packages/palette-docs`](https://github.com/artsy/palette/tree/master/packages/palette-docs).
+[`packages/palette-docs`](https://github.com/artsy/palette/tree/main/packages/palette-docs).
 
 \- If needing to modify the theme, see
-[`packages/palette-tokens`](https://github.com/artsy/palette/tree/master/packages/palette-docs).
+[`packages/palette-tokens`](https://github.com/artsy/palette/tree/main/packages/palette-docs).
 
 \- New package versions are published by attaching appropriate semver github
 labels to PRs; by default, all PRs have `minor` automatically assigned. When a
@@ -81,7 +81,7 @@ sub-packages:
 ### palette-tokens
 
 Starting at `palette-tokens`, we can see the
-[theme](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx)
+[theme](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx)
 that powers all of Palette. This is a simple object with keys such as
 `breakpoints`, `space` and `color`, and is read in by the main `palette` lib as
 well as [Eigen](https://github.com/artsy/eigen), our React Native mobile app.
@@ -89,7 +89,7 @@ well as [Eigen](https://github.com/artsy/eigen), our React Native mobile app.
 ### palette
 
 The `palette` package is where all of our components are defined. See the
-[elements](https://github.com/artsy/palette/tree/master/packages/palette/src/elements)
+[elements](https://github.com/artsy/palette/tree/main/packages/palette/src/elements)
 folder for the complete list.
 
 ### palette-docs

--- a/packages/palette-docs/content/docs/guides/migration.mdx
+++ b/packages/palette-docs/content/docs/guides/migration.mdx
@@ -12,10 +12,10 @@ of.
 **For reference, check out the difference between our v2 and v3 themes below:**
 
 **v2**:
-[palette-tokens/v2](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v2.tsx)
+[palette-tokens/v2](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v2.tsx)
 
 **v3**:
-[palette-tokens/v3](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx)
+[palette-tokens/v3](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx)
 
 ### How to Migrate
 
@@ -54,11 +54,11 @@ const MyApp = () => {
 ```
 
 This is useful if you're programmatically setting things, as we do in Force
-[via our route config](https://github.com/artsy/force/blob/master/src/v2/Apps/Artwork/artworkRoutes.tsx#L14).
+[via our route config](https://github.com/artsy/force/blob/main/src/v2/Apps/Artwork/artworkRoutes.tsx#L14).
 
 Once the component tree is wrapped in the correct provider you should be able to
 access our
-[v3 theme](https://github.com/artsy/palette/blob/master/packages/palette-tokens/src/themes/v3.tsx).
+[v3 theme](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v3.tsx).
 
 ### Using the `useThemeConfig` hook
 
@@ -105,7 +105,7 @@ Will return dynamic values for `tokens.px` -- either `px={5}` if `v2`, or
 `px={2}` if `v3`.
 
 (See
-[here](https://github.com/artsy/force/blob/master/src/v2/Components/Footer/Footer.tsx#L219-L226)
+[here](https://github.com/artsy/force/blob/main/src/v2/Components/Footer/Footer.tsx#L219-L226)
 for a real-world example.)
 
 ### Typography

--- a/packages/palette-docs/content/docs/index.mdx
+++ b/packages/palette-docs/content/docs/index.mdx
@@ -21,8 +21,8 @@ Have questions? Join us in #design-system on slack, we're always happy to help.
     check it out here.
   </a>
   <br /> <br />
-  While storybooks doesn't provide live code examples, it's often a more
-  complete representation what features are are available via props. <br />
+  While Storybooks doesn't provide live code examples, it's often a more
+  complete representation what features are available via props. <br />
   <br /> For more info, see our <a
     href="https://palette.artsy.net/guides/development"
     target="_blank"
@@ -62,7 +62,7 @@ export const App = (props) => {
 ```
 
 From there you should be able to access the values from Palette's
-[Theme.tsx](https://github.com/artsy/palette/blob/master/packages/palette/src/Theme.tsx)
+[Theme.tsx](https://github.com/artsy/palette/blob/main/packages/palette/src/Theme.tsx)
 file:
 
 ```tsx

--- a/packages/palette-docs/src/layouts/MainLayout.tsx
+++ b/packages/palette-docs/src/layouts/MainLayout.tsx
@@ -184,7 +184,7 @@ const EditButton = ({ editUrl }) => {
 }
 
 const VIEW_SOURCE_BASE_URL =
-  "https://github.com/artsy/palette/tree/master/packages/palette/src"
+  "https://github.com/artsy/palette/tree/main/packages/palette/src"
 
 export const ViewSourceButton = ({ source }) => {
   return (

--- a/packages/palette-docs/src/utils/getEditUrl.ts
+++ b/packages/palette-docs/src/utils/getEditUrl.ts
@@ -1,7 +1,7 @@
 import { takeRight } from "lodash"
 
 const BASE_EDIT_URL =
-  "https://github.com/artsy/palette/edit/master/packages/palette-docs/content/"
+  "https://github.com/artsy/palette/edit/main/packages/palette-docs/content/"
 
 export function getEditUrl(fileAbsolutePath) {
   const pathParts = fileAbsolutePath.split("/")

--- a/packages/palette-tokens/README.md
+++ b/packages/palette-tokens/README.md
@@ -51,8 +51,8 @@ You can learn more about this work from [our blog][footer_blog] and by following
 our [job postings][footer_jobs]!
 
 [footer_website]: https://www.artsy.net/
-[footer_principles]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md
-[footer_open]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default
+[footer_principles]: https://github.com/artsy/README/blob/main/culture/engineering-principles.md
+[footer_open]: https://github.com/artsy/README/blob/main/culture/engineering-principles.md#open-source-by-default
 [footer_blog]: https://artsy.github.io/
 [footer_twitter]: https://twitter.com/ArtsyOpenSource
 [footer_api]: https://developers.artsy.net/


### PR DESCRIPTION
Landed in bizarro world on this one. I swear this was already done? 

In any case, fixes some `master` -> `main` docs links. 