### PR TITLE
fix(WP-52): search navigates to correct pathname on local

### DIFF
--- a/packages/palette-docs/src/components/Sidebar/SearchBox.tsx
+++ b/packages/palette-docs/src/components/Sidebar/SearchBox.tsx
@@ -1,4 +1,5 @@
 import { LabeledInput, MagnifyingGlassIcon } from "@artsy/palette"
+import { navigate } from "gatsby"
 import React, { useEffect } from "react"
 import "./algolia.css"
 
@@ -20,6 +21,10 @@ export function SearchBox() {
       indexName: window.docsearchSettings.indexName,
       inputSelector: "#search",
       debug: window.docsearchSettings.indexName,
+      handleSelected: (_input, _context, suggestion) => {
+        const { pathname, hash } = new URL(suggestion.url)
+        navigate(`${pathname}${hash}`)
+      },
     })
   }, [])
 


### PR DESCRIPTION
[WP-52](https://artsyproduct.atlassian.net/browse/WP-52)

I overrode the default DocSearch navigate behavior and replaced it with Gatsby navigate. This should make the search always navigate to the correct pathname, even when running locally. 
