### PR TITLE
fix(responsivebox): utilize native aspect-ratio property in place of padding-bottom hack

### DIFF
--- a/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.story.tsx
+++ b/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.story.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from "react"
+import styled from "styled-components"
 import { Box } from "../Box"
 import { Text } from "../Text"
+import { Image } from "../Image"
 import {
   ResponsiveBox,
   ResponsiveBoxAspectDimensions,
@@ -105,4 +107,47 @@ export const MaxWidth100 = () => {
 
 MaxWidth100.story = {
   name: "maxWidth: 100%",
+}
+
+const Masonry = styled(Box)`
+  column-count: 3;
+
+  * {
+    break-inside: avoid;
+  }
+`
+
+export const ColumnsWithResponsiveImages = () => {
+  return (
+    <Masonry>
+      {new Array(12).fill(0).map((_, i) => {
+        const orientation = i % 3 === 0 ? "portrait" : "landscape"
+        const width = orientation === "portrait" ? 200 : 300
+        const height = orientation === "portrait" ? 300 : 200
+
+        return (
+          // Simply being wrapped in an extra `Box` causes a image loading bug in Chrome
+          <Box key={i}>
+            <ResponsiveBox
+              aspectWidth={width}
+              aspectHeight={height}
+              maxWidth="100%"
+              bg="black10"
+              mb={2}
+            >
+              <Image
+                lazyLoad
+                width="100%"
+                height="100%"
+                src={`https://picsum.photos/seed/${i}/${width}/${height}`}
+                srcSet={`https://picsum.photos/seed/${i}/${width}/${height} 1x, https://picsum.photos/seed/${i}/${
+                  width * 2
+                }/${height * 2} 2x`}
+              />
+            </ResponsiveBox>
+          </Box>
+        )
+      })}
+    </Masonry>
+  )
 }

--- a/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.tsx
+++ b/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.tsx
@@ -57,20 +57,14 @@ export const ResponsiveBox: React.FC<ResponsiveBoxProps> = ({
     <Box
       position="relative"
       width="100%"
-      style={{ maxWidth: scaled.maxWidth }}
+      overflow="hidden"
+      style={{
+        aspectRatio: `${aspectWidth} / ${aspectHeight}`,
+        maxWidth: scaled.maxWidth,
+      }}
       {...rest}
     >
-      <Box
-        position="relative"
-        width="100%"
-        height={0}
-        overflow="hidden"
-        style={{ paddingBottom: scaled.paddingBottom }}
-      />
-
-      <Box position="absolute" top={0} left={0} width="100%" height="100%">
-        {children}
-      </Box>
+      {children}
     </Box>
   )
 }


### PR DESCRIPTION
We're seeing an issue where: when `ResponsiveBox` components are used, within a single wrapper, within the context of a CSS column, images don't load. This appears to be a Chrome specific bug which has been introduced recently. My theory is that it has to do with the `height: 0`. Either way; it's not a bad reason to use this as a motivator to upgrade to just using native `aspect-ratio`, [which is well supported](https://caniuse.com/mdn-css_properties_aspect-ratio) in all the browsers we're concerned with. A nice benefit here is that we can drop 2 extra DOM nodes per instance.