### PR TITLE
feat: add ability to open Dropdown by click

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -189,3 +189,39 @@ export const FocusOrder = () => {
     </Flex>
   )
 }
+
+export const OpenDropdownByClick = () => {
+  const dropdown = (
+    <Text variant="sm-display">
+      <Clickable display="block" width="100%" py={1} px={2}>
+        First
+      </Clickable>
+      <Clickable display="block" width="100%" py={1} px={2}>
+        Second
+      </Clickable>
+      <Clickable display="block" width="100%" py={1} px={2}>
+        Third
+      </Clickable>
+    </Text>
+  )
+
+  return (
+    <Flex>
+      <Dropdown dropdown={dropdown} openDropdownByClick>
+        {({ anchorRef, anchorProps }) => {
+          return (
+            <Button
+              ref={anchorRef}
+              variant="secondaryOutline"
+              size="small"
+              mr={1}
+              {...anchorProps}
+            >
+              Click to display dropdown
+            </Button>
+          )
+        }}
+      </Dropdown>
+    </Flex>
+  )
+}

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -159,8 +159,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       document.removeEventListener("keyup", handleKeyUp)
       document.removeEventListener("click", handleClick)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [panelRef])
+  }, [panelRef, openDropdownByClick])
 
   const activeRef = useRef(false)
 

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -42,12 +42,13 @@ export interface DropdownProps extends BoxProps {
   offset?: number
   /** Should the dropdown panel always be present in the DOM (vs removed when invisible) */
   keepInDOM?: boolean
+  openDropdownByClick?: boolean
   children: (dropdownActions: DropdownActions) => JSX.Element
 }
 
 /**
  * A `Dropdown` is a small modal-type element which is anchored, and can be
- * positioned relative to, another element and designed to be transitioned in on hover.
+ * positioned relative to, another element and designed to be transitioned in on hover or on click.
  */
 export const Dropdown: React.FC<DropdownProps> = ({
   placement = "top",
@@ -56,6 +57,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   children,
   offset = 10,
   dropdown,
+  openDropdownByClick,
   ...rest
 }) => {
   const [visible, setVisible] = useState(false)
@@ -91,6 +93,14 @@ export const Dropdown: React.FC<DropdownProps> = ({
       if (activeRef.current) return
       setVisible(false)
     }, 150)
+  }
+
+  const onToggleVisibility = () => {
+    if (visible) {
+      return onHide()
+    }
+
+    onVisible()
   }
 
   const {
@@ -132,13 +142,24 @@ export const Dropdown: React.FC<DropdownProps> = ({
       }
     }
 
+    const handleClick = (event: MouseEvent) => {
+      if (!panelRef.current || !openDropdownByClick) return
+
+      if (panelRef.current.contains(event.target as Element)) {
+        onHide()
+      }
+    }
+
     document.addEventListener("keydown", handleKeyDown)
     document.addEventListener("keyup", handleKeyUp)
+    document.addEventListener("click", handleClick)
 
     return () => {
       document.removeEventListener("keydown", handleKeyDown)
       document.removeEventListener("keyup", handleKeyUp)
+      document.removeEventListener("click", handleClick)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelRef])
 
   const activeRef = useRef(false)
@@ -207,9 +228,15 @@ export const Dropdown: React.FC<DropdownProps> = ({
   const anchorProps: React.HTMLAttributes<HTMLElement> = {
     "aria-expanded": visible,
     "aria-haspopup": true,
-    onMouseEnter: onVisible,
-    onMouseLeave: onHide,
-    onClick: onVisible,
+    ...(openDropdownByClick
+      ? {
+          onClick: onToggleVisibility,
+        }
+      : {
+          onMouseEnter: onVisible,
+          onMouseLeave: onHide,
+          onClick: onVisible,
+        }),
   }
 
   const { createPortal } = usePortal()
@@ -235,14 +262,18 @@ export const Dropdown: React.FC<DropdownProps> = ({
             ref={panelRef as any}
             zIndex={1}
             display="inline-block"
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
             placement={placement}
             style={{
               ...(keepInDOM
                 ? { visibility: visible ? "visible" : "hidden" }
                 : {}),
             }}
+            {...(openDropdownByClick
+              ? {}
+              : {
+                  onMouseEnter: handleMouseEnter,
+                  onMouseLeave: handleMouseLeave,
+                })}
             {...padding}
             {...rest}
           >


### PR DESCRIPTION
### Description
For the [FX-4007 task](https://artsyproduct.atlassian.net/browse/FX-4007), it is necessary to add the ability to open the menu by click (not hover effect). This PR adds such an opportunity for `Dropdown` component

### Demo
https://user-images.githubusercontent.com/3513494/172599110-c740a0f0-21c0-4695-9983-faf39d524f61.mp4

