### PR TITLE
feat(button): implements responsive sizes

### DIFF
--- a/packages/palette/src/elements/Button/Button.story.tsx
+++ b/packages/palette/src/elements/Button/Button.story.tsx
@@ -204,3 +204,7 @@ export const WithIcon = () => {
     </States>
   )
 }
+
+export const ResponsiveSize = () => {
+  return <Button size={["small", "large"]}>Resize Viewport</Button>
+}

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -3,10 +3,11 @@ import React, { useEffect, useRef } from "react"
 import styled, { css } from "styled-components"
 import { ResponsiveValue, variant } from "styled-system"
 import { CheckIcon, IconProps } from "../../svgs"
+import { TextVariant } from "../../Theme"
 import { THEME_V3 } from "../../themes"
 import { boxMixin, BoxProps } from "../Box"
 import { Spinner } from "../Spinner"
-import { Text } from "../Text"
+import { Text, TextProps } from "../Text"
 import { BUTTON_SIZES, BUTTON_TEXT_SIZES, BUTTON_VARIANTS } from "./tokens"
 import { ButtonSize, ButtonVariant } from "./types"
 
@@ -25,7 +26,7 @@ export interface ButtonProps
    */
   variant?: ResponsiveValue<ButtonVariant>
   /** Size of the button */
-  size?: ButtonSize
+  size?: ResponsiveValue<ButtonSize>
   /** Displays a loader in the button */
   loading?: boolean
   /** Forces hover state */
@@ -90,7 +91,7 @@ export const Button: React.ForwardRefExoticComponent<
 
         <Text
           lineHeight={1}
-          variant={BUTTON_TEXT_SIZES[size]}
+          variant={getTextVariant(size)}
           opacity={loading ? 0 : 1}
           display="flex"
           alignItems={alignItems}
@@ -209,3 +210,17 @@ const Container = styled.button<ContainerProps & ButtonProps>`
 
   ${boxMixin};
 `
+
+const getTextVariant = (
+  size: ResponsiveValue<ButtonSize>
+): TextProps["variant"] => {
+  if (typeof size === "string") {
+    return BUTTON_TEXT_SIZES[size]
+  }
+
+  if (Array.isArray(size)) {
+    return size.map((s) => BUTTON_TEXT_SIZES[s!] as TextVariant)
+  }
+
+  return BUTTON_TEXT_SIZES.large
+}

--- a/packages/palette/src/elements/Spinner/Spinner.story.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.story.tsx
@@ -8,7 +8,13 @@ export default {
 }
 
 export const Default = () => (
-  <States<SpinnerProps> states={[{}, { color: "brand", size: "small", m: 2 }]}>
+  <States<SpinnerProps>
+    states={[
+      {},
+      { color: "brand", size: "small", m: 2 },
+      { size: ["small", "medium", "large"] },
+    ]}
+  >
     <Spinner position="static" />
   </States>
 )

--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -1,65 +1,48 @@
-import { themeGet } from "@styled-system/theme-get"
 import React, { useEffect, useState } from "react"
 import styled, { keyframes } from "styled-components"
-import { BoxProps } from "../../../dist"
-import { Color } from "../../Theme"
-import { Box } from "../Box"
+import { ResponsiveValue, variant } from "styled-system"
+import { Box, BoxProps } from "../Box"
 
-export interface SpinnerProps extends Omit<BoxProps, "size"> {
+const SPINNER_VARIANTS = {
+  small: {
+    width: 12.5,
+    height: 3,
+    // TODO: Remove `top` and `left`
+    top: "calc(50% - 1.5px)",
+    left: "calc(50% - 6.25px)",
+  },
+
+  medium: {
+    width: 20,
+    height: 4.8,
+    // TODO: Remove `top` and `left`
+    top: "calc(50% - 2.4px)",
+    left: "calc(50% - 10px)",
+  },
+
+  large: {
+    width: 25,
+    height: 6,
+    // TODO: Remove `top` and `left`
+    top: "calc(50% - 3px)",
+    left: "calc(50% - 12.5px)",
+  },
+} as const
+
+export type SpinnerSize = keyof typeof SPINNER_VARIANTS
+
+export interface SpinnerProps
+  extends Omit<BoxProps, "size" | "width" | "height"> {
   /** Delay before spinner appears */
   delay?: number
-  /** Width of the spinner */
-  width?: number
-  /** Height of the spinner */
-  height?: number
   /** Size of the spinner */
-  size?: "small" | "medium" | "large"
+  size?: ResponsiveValue<SpinnerSize>
   /** Color of the spinner */
-  color?: Color | "currentColor"
+  color?: ResponsiveValue<string>
 }
-
-/**
- * Returns width and height of spinner based on size
- * @param props
- */
-export const getSize = (props: SpinnerProps) => {
-  const base = { width: 25, height: 6 }
-
-  switch (props.size) {
-    case "small":
-      return {
-        width: base.width * 0.5,
-        height: base.height * 0.5,
-      }
-
-    case "medium":
-      return {
-        width: base.width * 0.8,
-        height: base.height * 0.8,
-      }
-
-    case "large":
-      return {
-        width: base.width,
-        height: base.height,
-      }
-
-    default:
-      return {
-        width: props.width,
-        height: props.height,
-      }
-  }
-}
-
-const spin = keyframes`
-  100% {
-    transform: rotate(360deg)
-  }
-`
 
 /** Generic Spinner component */
-export const Spinner: React.FC<SpinnerProps> = ({ delay, ...rest }) => {
+export const Spinner: React.FC<SpinnerProps> = ({ delay, color, ...rest }) => {
   const [show, setShow] = useState(delay === 0)
 
   useEffect(() => {
@@ -72,39 +55,27 @@ export const Spinner: React.FC<SpinnerProps> = ({ delay, ...rest }) => {
     }
   }, [delay])
 
-  if (!show) {
-    return null
-  }
+  if (!show) return null
 
-  return <SpinnerBar {...rest} />
+  return <Bar bg={color ?? "currentColor"} {...rest} />
 }
 
-const SpinnerBar = styled(Box)<SpinnerProps>`
-  animation: ${spin} 1s infinite linear;
-
-  ${(props) => {
-    const { width, height } = getSize(props)
-
-    return `
-      background-color: ${
-        props.color === "currentColor"
-          ? "currentColor"
-          : themeGet(`colors.${props.color}`)(props)
-      };
-
-      width: ${width}px;
-      height: ${height}px;
-      top: calc(50% - ${height}px / 2);
-      left: calc(50% - ${width}px / 2);
-    `
-  }};
+const spin = keyframes`
+  100% {
+    transform: rotate(360deg)
+  }
 `
-// TODO: Remove default `position`, `top`, & `left` props
+
+const Bar = styled(Box)`
+  animation: ${spin} 1s infinite linear;
+  ${variant({ variants: SPINNER_VARIANTS, prop: "size" })}
+`
+
 Spinner.defaultProps = {
+  // TODO: Remove `position`
   position: "absolute",
   delay: 0,
-  width: 25,
-  height: 6,
+  size: "large",
   color: "black100",
 }
 


### PR DESCRIPTION
This PR gives us a responsive `size` prop for the `Button` component (as well as `Spinner`).