### PR TITLE
fix(useportal): guards on removal

### DIFF
--- a/packages/palette/src/utils/usePortal.ts
+++ b/packages/palette/src/utils/usePortal.ts
@@ -11,7 +11,11 @@ export const usePortal = () => {
     document.body.appendChild(el)
 
     return () => {
-      document.body.removeChild(el)
+      try {
+        document.body.removeChild(el)
+      } catch (e) {
+        // Ignore
+      }
     }
   }, [])
 


### PR DESCRIPTION
Wraps the teardown here in a try/catch just in case something else has removed the node.