### PR TITLE
fix(select): supresses top margin when inline

### DIFF
--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -95,7 +95,7 @@ export const Select: React.FC<SelectProps> = ({
           hover={!!hover}
           error={error!}
           focus={!!focus}
-          mt={title || description ? 0.5 : 0}
+          mt={variant !== "inline" && (title || description) ? 0.5 : 0}
         >
           <select
             id={id}


### PR DESCRIPTION
Minor thing noticed when removing some Grid components.