### PR TITLE
fix(BorderedRadio): remove label hover and select underline 

### DIFF
--- a/packages/palette/src/elements/BorderedRadio/BorderedRadio.tsx
+++ b/packages/palette/src/elements/BorderedRadio/BorderedRadio.tsx
@@ -25,4 +25,8 @@ export const BorderedRadio = styled(Radio)<BorderedRadioProps>`
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
+
+  div {
+    text-decoration: none !important;
+  }
 `


### PR DESCRIPTION
[TX-500](https://artsyproduct.atlassian.net/browse/TX-500)

This PR removes the hover and select underline from bordered radio labels to align with the [figma](https://www.figma.com/file/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System?node-id=6726%3A3446). 