### PR TITLE
fix(TX-609): radio button alignment 

### DIFF
--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import styled, { css } from "styled-components"
+import { Spacer } from "../.."
 import { Flex, FlexProps } from "../../elements/Flex"
 import { isText } from "../../helpers/isText"
 import { Text } from "../Text"
@@ -73,17 +74,17 @@ export const Radio: React.FC<RadioProps> = ({
       error={error}
       {...rest}
     >
-      <RadioDot
-        disabled={disabled}
-        hover={hover}
-        focus={focus}
-        selected={selected}
-        error={error}
-        mr={1}
-      />
-
       <Flex flexDirection="column" flex={1}>
         <Flex alignItems="center" flex={1}>
+          <RadioDot
+            disabled={disabled}
+            hover={hover}
+            focus={focus}
+            selected={selected}
+            error={error}
+            mr={1}
+          />
+
           {isText(title) ? (
             <Text variant="sm-display" lineHeight={description ? undefined : 1}>
               {title}
@@ -94,9 +95,12 @@ export const Radio: React.FC<RadioProps> = ({
         </Flex>
 
         {isText(description) ? (
-          <Text variant="xs" color="black60">
-            {description}
-          </Text>
+          <Flex>
+            <Spacer ml="30px" />
+            <Text variant="xs" color="black60">
+              {description}
+            </Text>
+          </Flex>
         ) : (
           description
         )}
@@ -127,7 +131,7 @@ const Container = styled(Flex)<{
           ${RADIO_STATES.hover}
 
           // Radio
-          > div:first-of-type {
+          > div:nth-of-type(2) {
             ${props.selected
               ? RADIO_DOT_STATES.hover.selected
               : RADIO_DOT_STATES.hover.resting}
@@ -139,7 +143,7 @@ const Container = styled(Flex)<{
         ${RADIO_STATES.focus}
 
         // Radio
-        > div:first-of-type {
+        > div:nth-of-type(2) {
           ${props.selected
             ? RADIO_DOT_STATES.focus.selected
             : RADIO_DOT_STATES.focus.resting}


### PR DESCRIPTION
[TX-609](https://artsyproduct.atlassian.net/browse/TX-609)

This PR fixes the alignment of the radio button so that it is in line with the main label when there is a subtitle present. 

### After

<img width="595" alt="Screenshot 2022-08-25 at 11 31 29 AM" src="https://user-images.githubusercontent.com/50849237/186641386-90b6f39f-49f7-4c94-8f11-9a19f6fae8f3.png">

### Before
<img width="683" alt="Screenshot 2022-08-25 at 12 27 33 PM" src="https://user-images.githubusercontent.com/50849237/186641543-0ec81269-adf8-48e0-995c-750d08e84120.png">

