### PR TITLE
feat: make ShowMore more flexible

### DIFF
--- a/packages/palette/src/elements/Clickable/Clickable.tsx
+++ b/packages/palette/src/elements/Clickable/Clickable.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import { compose, ResponsiveValue, system } from "styled-system"
+import { splitProps } from "../../utils/splitProps"
 import { boxMixin, BoxProps } from "../Box"
 
 const cursor = system({ cursor: true })
@@ -12,6 +13,8 @@ export type ClickableProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
     cursor?: ResponsiveValue<string>
     textDecoration?: ResponsiveValue<string>
   }
+
+const clickableMixin = compose(boxMixin, cursor, textDecoration)
 
 /**
  * Clickable is a utility component useful for wrapping things like <div>s
@@ -27,7 +30,7 @@ export const Clickable = styled.button<ClickableProps>`
   font: inherit;
   text-align: inherit;
 
-  ${compose(boxMixin, cursor, textDecoration)}
+  ${clickableMixin}
 
   &:disabled {
     cursor: default;
@@ -38,3 +41,5 @@ Clickable.defaultProps = {
   cursor: "pointer",
   type: "button",
 }
+
+export const splitClickableProps = splitProps<ClickableProps>(clickableMixin)

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -83,7 +83,14 @@ const _FilterSelect: React.FC = () => {
           <FilterSelectResultItem key={item.value} {...item} />
         ))
       ) : (
-        <ShowMore expanded={expanded} initial={initialItemsToShow}>
+        <ShowMore
+          expanded={expanded}
+          initial={initialItemsToShow}
+          variant={"xs"}
+          textDecoration={"underline"}
+          mt={1}
+          textAlign="left"
+        >
           {itemsSorted.map((item) => {
             return <FilterSelectResultItem key={item.value} {...item} />
           })}

--- a/packages/palette/src/elements/ShowMore/ShowMore.story.tsx
+++ b/packages/palette/src/elements/ShowMore/ShowMore.story.tsx
@@ -21,3 +21,31 @@ export const Default = () => {
     </States>
   )
 }
+
+export const CommaSeparatedList = () => {
+  const artists = ["Monica Kim Garza", "John Houck", "Zemba Luzamba"]
+
+  return (
+    <States<Partial<ShowMoreProps>> states={[{}, { expanded: true }]}>
+      <ShowMore initial={1} variant="lg" textDecoration="underline" mt={1}>
+        {artists.map((artist, index) => {
+          let separator = ", "
+          if (index === artists.length - 1) {
+            separator = ". "
+          }
+
+          return (
+            <Text variant="lg" as="span" key={index}>
+              {artist}
+              {separator}
+            </Text>
+          )
+        })}
+      </ShowMore>
+    </States>
+  )
+}
+
+CommaSeparatedList.story = {
+  name: "Works with comma-separated list",
+}

--- a/packages/palette/src/elements/ShowMore/ShowMore.tsx
+++ b/packages/palette/src/elements/ShowMore/ShowMore.tsx
@@ -1,11 +1,15 @@
 import React, { Children, isValidElement, useState } from "react"
-import { Clickable } from "../Clickable"
-import { Text } from "../Text"
+import { Clickable, ClickableProps, splitClickableProps } from "../Clickable"
+import { Text, TextProps } from "../Text"
 
-export interface ShowMoreProps {
+export interface ShowMoreProps
+  extends ClickableProps,
+    Pick<TextProps, "variant"> {
   children: React.ReactNode
   initial?: number
   expanded?: boolean
+  hideText?: string
+  showMoreText?: string
 }
 
 export const INITIAL_ITEMS_TO_SHOW = 6
@@ -14,10 +18,15 @@ export const ShowMore: React.FC<ShowMoreProps> = ({
   initial = INITIAL_ITEMS_TO_SHOW,
   children,
   expanded = false,
+  hideText = "Hide",
+  showMoreText = "Show more",
+  ...rest
 }) => {
   const [isExpanded, setExpanded] = useState(expanded)
   const nodes = Children.toArray(children).filter(isValidElement)
   const hasMore = nodes.length > initial
+
+  const [clickableProps, { variant }] = splitClickableProps(rest)
 
   return (
     <>
@@ -25,12 +34,10 @@ export const ShowMore: React.FC<ShowMoreProps> = ({
 
       {hasMore && (
         <Clickable
-          mt={1}
-          textDecoration="underline"
-          textAlign="left"
           onClick={() => setExpanded((visibility) => !visibility)}
+          {...clickableProps}
         >
-          <Text variant="xs">{isExpanded ? "Hide" : "Show more"}</Text>
+          <Text variant={variant}>{isExpanded ? hideText : showMoreText}</Text>
         </Clickable>
       )}
     </>


### PR DESCRIPTION
Allowing clients to update the styles on the Clickable wrapper and Text component means we can use this component in cases like https://www.figma.com/file/9DMfKOi5RuuBD2f49eB9nV/Artwork-page?node-id=1825%3A96724