### PR TITLE
feat: close dropdown only when link is clicked

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -144,8 +144,18 @@ export const Dropdown: React.FC<DropdownProps> = ({
 
     const handleClick = (event: MouseEvent) => {
       if (!panelRef.current || !openDropdownByClick) return
+      const target = event.target as Element
+      const tagName = target.tagName.toLowerCase()
+      let isClosableElement = tagName === "a"
+      let element: Element | null = target
 
-      if (panelRef.current.contains(event.target as Element)) {
+      // Find parent link element
+      if (!isClosableElement) {
+        element = target.closest("a")
+        isClosableElement = !!element
+      }
+
+      if (isClosableElement && element && panelRef.current.contains(element)) {
         onHide()
       }
     }


### PR DESCRIPTION
### Description
Previously, clicking on any element caused the dropdown menu to close. Now the menu will close only if the link was clicked

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/187439332-94aec74d-2dd7-4fd0-86f7-be8552988195.mp4

#### After
https://user-images.githubusercontent.com/3513494/187439838-cd280bf8-25f9-4d1f-862b-329192cb3ba8.mp4
