### PR TITLE
fix: viewBox on icons

### DIFF
--- a/packages/palette/src/svgs/SecureLockIcon.tsx
+++ b/packages/palette/src/svgs/SecureLockIcon.tsx
@@ -8,7 +8,7 @@ export const SecureLockIcon: React.FC<IconProps> = ({
   ...props
 }) => {
   return (
-    <Icon viewBox="0 0 24 24" {...props}>
+    <Icon viewBox="0 0 18 18" {...props}>
       <Title>{title}</Title>
       <Path
         fill={color(props.fill!)}

--- a/packages/palette/src/svgs/VerifiedIcon.tsx
+++ b/packages/palette/src/svgs/VerifiedIcon.tsx
@@ -8,7 +8,7 @@ export const VerifiedIcon: React.FC<IconProps> = ({
   ...props
 }) => {
   return (
-    <Icon {...props} viewBox="0 0 24 24">
+    <Icon {...props} viewBox="0 0 18 18">
       <Title>{title}</Title>
       <Path
         className="verified-checkmark"


### PR DESCRIPTION
### Description

reverts viewBox to 18 from 24 on the icons added on #1207 

most of our icons have `viewBox="0 0 18 18"`