### PR TITLE
fix(shelf): adds label to scrollbar thumb

### DIFF
--- a/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
+++ b/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
@@ -124,7 +124,7 @@ export const ShelfScrollBar: React.FC<ShelfScrollBarProps> = React.memo(
               backfaceVisibility: "hidden",
             }}
           >
-            <HitArea ref={thumbRef as any} tabIndex={-1} />
+            <HitArea ref={thumbRef as any} tabIndex={-1} aria-label="Thumb" />
           </Thumb>
         )}
       </Track>


### PR DESCRIPTION
A minor fix to address a kind of odd Lighthouse callout. We skip over this button with the tab index so the only time this gets announced is if you use a pointer device to access it.