### PR TITLE
feat: add ability to pass `onClose` prop for `Popover` component

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions"
 import React from "react"
 import { States } from "storybook-states"
 import { Position, POSITION } from "../../utils"
@@ -16,7 +17,11 @@ export default {
 export const Default = () => {
   return (
     <States<Partial<PopoverProps>>
-      states={[{}, { title: "Example Title", visible: true }]}
+      states={[
+        {},
+        { title: "Example Title", visible: true },
+        { onClose: action("onClose") },
+      ]}
     >
       <Popover
         placement="bottom"

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -27,6 +27,7 @@ export interface PopoverProps extends BoxProps {
   visible?: boolean
   popover: React.ReactNode
   children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
+  onClose?: () => void
 }
 
 /**
@@ -39,6 +40,7 @@ export const Popover: React.FC<PopoverProps> = ({
   visible: _visible = false,
   children,
   popover,
+  onClose,
   ...rest
 }) => {
   const [visible, setVisible] = useState(false)
@@ -67,10 +69,15 @@ export const Popover: React.FC<PopoverProps> = ({
     setVisible(false)
   }, [])
 
+  const handleHide = useCallback(() => {
+    onHide()
+    onClose?.()
+  }, [onHide, onClose])
+
   useEffect(() => {
     const handleKeydown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        onHide()
+        handleHide()
       }
     }
 
@@ -79,7 +86,7 @@ export const Popover: React.FC<PopoverProps> = ({
     return () => {
       document.removeEventListener("keydown", handleKeydown)
     }
-  }, [onHide])
+  }, [handleHide])
 
   const { anchorRef, tooltipRef } = usePosition({
     position: placement,
@@ -89,7 +96,7 @@ export const Popover: React.FC<PopoverProps> = ({
 
   useClickOutside({
     ref: tooltipRef,
-    onClickOutside: onHide,
+    onClickOutside: handleHide,
     when: visible,
     type: "click",
   })
@@ -133,7 +140,7 @@ export const Popover: React.FC<PopoverProps> = ({
             pt={2}
             px={1}
             mx={0.5}
-            onClick={onHide}
+            onClick={handleHide}
             aria-label="Close"
           >
             <CloseIcon fill="black100" display="block" />


### PR DESCRIPTION
### Description
The `onClose` prop will be useful for those cases where the `Popover` is a controlled component and visibility is controlled via the `visible` prop

### Demo
https://user-images.githubusercontent.com/3513494/197190835-e73add19-ff5b-4098-a282-affaf3b65ad4.mp4

