### PR TITLE
fix(select): corrects types

### DIFF
--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -60,6 +60,7 @@ export const Example = () => {
       title="Sort:"
       options={OPTIONS}
       selected="-year"
+      autoComplete="year"
     />
   )
 }

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -14,7 +14,7 @@ export interface Option {
 
 export interface SelectProps
   extends BoxProps,
-    Omit<React.HTMLAttributes<HTMLSelectElement>, "onSelect"> {
+    Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "onSelect" | "size"> {
   description?: string
   disabled?: boolean
   error?: string | boolean


### PR DESCRIPTION
Fixes types so we can support the autocomplete attribute.