### PR TITLE
fix: Avatar border issue on Safari

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -6,6 +6,12 @@ import { Flex, FlexProps } from "../Flex"
 import { Image, ImageProps } from "../Image"
 import { Text } from "../Text"
 
+/**
+ * On Safari, border-radius with overflow hidden on an image causes a rendering issue
+ * The image shows as a square at first, then the border-radius kicks in and it becomes a circle
+ * This is a css hack that solves the issue
+ * src: https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
+ */
 const Container = styled(Flex)`
   -webkit-mask-image: -webkit-radial-gradient(white, black);
 `

--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -1,9 +1,14 @@
 import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 import React from "react"
+import styled from "styled-components"
 import { splitBoxProps } from "../Box"
 import { Flex, FlexProps } from "../Flex"
 import { Image, ImageProps } from "../Image"
 import { Text } from "../Text"
+
+const Container = styled(Flex)`
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
+`
 
 export interface AvatarProps extends FlexProps, Partial<ImageProps> {
   /** If an image is missing, show initials instead */
@@ -54,7 +59,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   const { diameter, variant } = TOKENS[size] ?? TOKENS.sm
 
   return (
-    <Flex
+    <Container
       size={diameter}
       bg={TOKENS.bg}
       border={src ? "transparent" : "1px solid"}
@@ -89,6 +94,6 @@ export const Avatar: React.FC<AvatarProps> = ({
           />
         </Flex>
       )}
-    </Flex>
+    </Container>
   )
 }


### PR DESCRIPTION
This PR fixes the Avatar border-radius issue on Safari


https://user-images.githubusercontent.com/20655703/204067452-54351208-209f-49e9-b168-2ede45f0b2bb.mov


https://user-images.githubusercontent.com/20655703/204067454-1e45a2aa-7180-4c56-a5b9-dea70d0a3782.mov

