### PR TITLE
add new banner background colour and text alignment

### DIFF
--- a/packages/palette/src/elements/Banner/Banner.story.tsx
+++ b/packages/palette/src/elements/Banner/Banner.story.tsx
@@ -16,6 +16,7 @@ export const Default = () => {
         { variant: "success" },
         { variant: "error" },
         { variant: "brand" },
+        { variant: "brandLight" },
       ]}
     >
       <Banner dismissable>

--- a/packages/palette/src/elements/Banner/Banner.story.tsx
+++ b/packages/palette/src/elements/Banner/Banner.story.tsx
@@ -11,6 +11,7 @@ export const Default = () => {
     <States<BannerProps>
       states={[
         { dismissable: false },
+        { justifyContentStart: true },
         { variant: "defaultLight" },
         { variant: "defaultDark" },
         { variant: "success" },

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -11,11 +11,13 @@ export type BannerVariant = keyof typeof BANNER_VARIANTS
 export interface BannerProps extends FlexProps {
   variant?: BannerVariant
   dismissable?: boolean
+  justifyContentStart?: boolean
 }
 
 /** A banner */
 export const Banner: React.FC<BannerProps> = ({
   dismissable = false,
+  justifyContentStart = false,
   children,
   ...rest
 }) => {
@@ -33,7 +35,7 @@ export const Banner: React.FC<BannerProps> = ({
         variant="xs"
         display="flex"
         alignItems="center"
-        justifyContent="center"
+        justifyContent={justifyContentStart ? "start" : "center"}
         textAlign="center"
         flex={1}
       >

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -84,6 +84,10 @@ export const BANNER_VARIANTS = {
     backgroundColor: "brand",
     color: "white100",
   },
+  brandLight: {
+    backgroundColor: "blue10",
+    color: "black100",
+  },
 }
 
 const Container = styled(Flex)`


### PR DESCRIPTION
In this PR, I add a `blue10` banner variant and  `justifyContent` property settings
Reason: we keep having [the blue10 banner with left text alignments in figma](https://www.figma.com/file/MbVDbVu5eF6PUCzjCENx4g/My-Collection-Landing-Page?node-id=723%3A32490&t=xt7xtwlElstNgzI9-0). Why not adding it to palette 

On the screenshot, the second banner shows test alignment settings and the last one - new colour

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/36167539/204836826-0dc58596-f20e-43b2-af5d-75d51fd436cb.png">
