### PR TITLE
feat: Spacer uses `x`/`y` now

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ to peek at the proposal and provide feedback before moving forward.
 In the project root run the following:
 
 ```sh
+$ lerna bootstrap
 $ yarn storybook
 ```
 

--- a/packages/palette/src/elements/Button/Button.story.tsx
+++ b/packages/palette/src/elements/Button/Button.story.tsx
@@ -67,7 +67,7 @@ export const Variants = () => {
             : { bg: "white100", color: "black100" })}
         >
           <Flex>
-            <Join separator={<Spacer ml={2} />}>
+            <Join separator={<Spacer x={2} />}>
               <Button {...props}>Default</Button>
 
               <Button {...props} focus>

--- a/packages/palette/src/elements/Dialog/Dialog.tsx
+++ b/packages/palette/src/elements/Dialog/Dialog.tsx
@@ -62,7 +62,7 @@ export const Dialog: FC<DialogProps> = ({
                 {secondaryCta.text}
               </Button>
 
-              <Spacer ml={1} />
+              <Spacer x={1} />
             </>
           )}
 

--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.story.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.story.tsx
@@ -19,7 +19,7 @@ export const Default = () => {
       ]}
     >
       <HorizontalOverflow bg="black10" p={2}>
-        <Join separator={<Spacer mr={2} />}>
+        <Join separator={<Spacer x={2} />}>
           {Array.from(Array(50)).map((_, i) => (
             <Text key={i} variant="sm-display" color="black100" mr={2}>
               Example #{i}
@@ -35,7 +35,7 @@ export const FillHeightCenteredContent = () => {
   return (
     <Box height={100} bg="red10">
       <HorizontalOverflow border="1px solid" p={2} height="100%">
-        <Join separator={<Spacer mr={2} />}>
+        <Join separator={<Spacer x={2} />}>
           {Array.from(Array(50)).map((_, i) => (
             <Text
               key={i}

--- a/packages/palette/src/elements/Modal/Modal.tsx
+++ b/packages/palette/src/elements/Modal/Modal.tsx
@@ -124,10 +124,10 @@ export const Modal: FC<ModalProps> = ({
                 isScrolled={isScrolled}
                 px={2}
               >
-                <Spacer my={1} />
+                <Spacer y={2} />
                 <Flex>
                   <Box pr={6} flex={1}>
-                    <Join separator={<Spacer py={1} />}>
+                    <Join separator={<Spacer y={2} />}>
                       {hasLogo && <Logo my={1} />}
                       {title && (
                         <Text
@@ -147,7 +147,7 @@ export const Modal: FC<ModalProps> = ({
                     </CloseIconWrapper>
                   )}
                 </Flex>
-                <Spacer py={1} />
+                <Spacer y={2} />
               </ModalStickyHeader>
 
               <ModalScrollContent

--- a/packages/palette/src/elements/Modal/ModalBase.story.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.story.tsx
@@ -62,7 +62,7 @@ const Example: React.FC<
           >
             <Box textAlign="center">
               <Text variant="sm-display" color="white100">
-                <Join separator={<Spacer my={1} />}>
+                <Join separator={<Spacer y={2} />}>
                   <>Some example content. Click outside to close.</>
                   <Button variant="primaryWhite" onClick={handleClose}>
                     Or click here to close.

--- a/packages/palette/src/elements/ModalDialog/ModalDialogContent.story.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialogContent.story.tsx
@@ -69,7 +69,7 @@ export const Default = () => {
       ]}
     >
       <ModalDialogContent onClose={action("onClose")} maxHeight={400}>
-        <Join separator={<Spacer mt={1} />}>
+        <Join separator={<Spacer y={1} />}>
           <Text variant="sm">
             Lorem ipsum, dolor sit amet consectetur adipisicing elit. Eaque,
             neque voluptates! Sapiente, sint magnam. Assumenda, hic eius

--- a/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
@@ -64,7 +64,7 @@ export const ModalDialogContent: React.FC<ModalDialogContentProps> = ({
                 />
               )}
 
-              {hasLogo && title && <Spacer mt={2} />}
+              {hasLogo && title && <Spacer y={2} />}
 
               {title && <Text variant="lg-display">{title}</Text>}
             </Box>

--- a/packages/palette/src/elements/Pill/Pill.story.tsx
+++ b/packages/palette/src/elements/Pill/Pill.story.tsx
@@ -31,7 +31,7 @@ export const Variants = () => {
             : { bg: "white100", color: "black100" })}
         >
           <Flex>
-            <Join separator={<Spacer ml={2} />}>
+            <Join separator={<Spacer x={2} />}>
               <Pill {...props}>Default</Pill>
 
               <Pill {...props} focus>

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -126,10 +126,10 @@ export const Popover: React.FC<PopoverProps> = ({
                   title
                 )}
 
-                <Spacer ml={4} />
+                <Spacer x={4} />
               </Flex>
 
-              <Spacer mt={0.5} />
+              <Spacer y={0.5} />
             </>
           )}
 
@@ -146,7 +146,7 @@ export const Popover: React.FC<PopoverProps> = ({
             <CloseIcon fill="black100" display="block" />
           </Clickable>
 
-          {!title && <Spacer mt={2} />}
+          {!title && <Spacer y={2} />}
 
           {popover}
         </Tip>

--- a/packages/palette/src/elements/RadioGroup/RadioGroup.story.tsx
+++ b/packages/palette/src/elements/RadioGroup/RadioGroup.story.tsx
@@ -23,7 +23,7 @@ export const Default = () => {
       ]}
     >
       <RadioGroup onSelect={action("onSelect")}>
-        <Join separator={<Spacer mb={0.5} />}>
+        <Join separator={<Spacer y={0.5} />}>
           {["Visual", "Linguistic", "Spatial", "Aural", "Gestural"].map(
             (value) => {
               return <Radio key={value} value={value} label={value} />
@@ -51,7 +51,7 @@ export const WithDefaultValue = () => {
 
       <RadioGroup defaultValue={defaultValue} onSelect={action("onSelect")}>
         <Radio value="SHIP" label="Provide shipping address" />
-        <Spacer mb={0.5} />
+        <Spacer y={0.5} />
         <Radio value="PICKUP" label="Arrange for pickup" />
       </RadioGroup>
     </>

--- a/packages/palette/src/elements/Range/Range.story.tsx
+++ b/packages/palette/src/elements/Range/Range.story.tsx
@@ -51,12 +51,12 @@ export const InContext = () => {
       <Flex>
         <LabeledInput title="Min" label="$USD" flex={1} value={min} />
 
-        <Spacer ml={1} />
+        <Spacer x={1} />
 
         <LabeledInput title="Max" label="$USD" flex={1} value={max} />
       </Flex>
 
-      <Spacer mt={1} />
+      <Spacer y={1} />
 
       <Range
         min={0}
@@ -66,7 +66,7 @@ export const InContext = () => {
         onChange={setMinMax}
       />
 
-      <Spacer mt={0.5} />
+      <Spacer y={0.5} />
 
       <Flex justifyContent="space-between">
         <Text variant="xs">$0</Text>

--- a/packages/palette/src/elements/Skeleton/Skeleton.story.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.story.tsx
@@ -58,7 +58,7 @@ const ExampleArtworkSkeleton: React.FC<{ i: number }> = ({ i }) => {
   return (
     <>
       <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />
-      <Spacer mt={1} />
+      <Spacer y={1} />
       <SkeletonText variant="sm-display">Artist Name</SkeletonText>
       <SkeletonText variant="sm-display">Artwork Title</SkeletonText>
       <SkeletonText variant="xs">Partner</SkeletonText>
@@ -77,7 +77,7 @@ export const _ExampleArtworkSkeleton = () => {
 
 export const StressTest = () => {
   return (
-    <Join separator={<Spacer mt={6} />}>
+    <Join separator={<Spacer y={6} />}>
       {Array.from(Array(12)).map((_, i) => {
         return (
           <Skeleton key={`a-${i}`} overflow="hidden">

--- a/packages/palette/src/elements/Spacer/Spacer.story.tsx
+++ b/packages/palette/src/elements/Spacer/Spacer.story.tsx
@@ -1,0 +1,56 @@
+import { THEME } from "@artsy/palette-tokens/dist/themes/v3"
+import React from "react"
+import { States } from "storybook-states"
+import { Box } from "../Box"
+import { Spacer, SpacerProps } from "./Spacer"
+
+export default {
+  title: "Components/Spacer",
+  component: Spacer,
+}
+
+const VALUES = Object.keys(THEME.space)
+  .sort((a, b) => {
+    return Number(a) - Number(b)
+  })
+  .map((value) => Number(value))
+
+export const Default = () => {
+  return (
+    <States<SpacerProps>
+      states={[
+        ...VALUES.map((value) => ({ y: value })),
+        ...VALUES.map((value) => ({ x: value })),
+      ]}
+    >
+      {({ x, y }) => {
+        if (y) {
+          return (
+            <_Spacer>
+              <Box height={2} width={100} bg="black60" />
+
+              <Spacer y={y} />
+
+              <Box height={2} width={100} bg="black60" />
+            </_Spacer>
+          )
+        }
+
+        return (
+          <_Spacer>
+            <Box display="flex">
+              <Box height={100} width={2} bg="black60" />
+
+              <Spacer x={x} />
+
+              <Box height={100} width={2} bg="black60" />
+            </Box>
+          </_Spacer>
+        )
+      }}
+    </States>
+  )
+}
+
+const _Spacer = Box
+_Spacer.displayName = "Spacer"

--- a/packages/palette/src/elements/Spacer/Spacer.tsx
+++ b/packages/palette/src/elements/Spacer/Spacer.tsx
@@ -1,14 +1,16 @@
 import React from "react"
 import { Box, BoxProps } from "../../elements/Box"
 
-/** Spacer implements Box */
-export type SpacerProps = BoxProps & React.HTMLAttributes<HTMLDivElement>
+export type SpacerProps = {
+  x?: BoxProps["ml"]
+  y?: BoxProps["mt"]
+} & React.HTMLAttributes<HTMLDivElement>
 
 /**
- * A component used to inject space where it's needed
+ * Used to inject space where it's needed.
  */
-export const Spacer: React.FC<SpacerProps> = (props) => {
-  return <Box {...props} />
+export const Spacer = ({ x, y, ...restProps }: SpacerProps) => {
+  return <Box {...restProps} ml={x} mt={y} />
 }
 
 Spacer.displayName = "Spacer"

--- a/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
+++ b/packages/palette/src/elements/StaticCountdownTimer/StaticCountdownTimer.tsx
@@ -55,7 +55,7 @@ export const StaticCountdownTimer: React.FC<{
           fill={highlight}
           style={{ marginTop: "1.5px" }}
         />
-        <Spacer mr="7px" />
+        <Spacer x="7px" />
         <TimeRemaining
           countdownEnd={countdownEnd}
           highlight={highlight}

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -101,7 +101,7 @@ export const TextArea: React.ForwardRefExoticComponent<
               )}
             </div>
 
-            <Spacer m={0.5} />
+            <Spacer y={0.5} />
           </>
         )}
 

--- a/packages/palette/src/elements/Toasts/Toasts.tsx
+++ b/packages/palette/src/elements/Toasts/Toasts.tsx
@@ -16,7 +16,7 @@ export const Toasts: React.FC<ToastsProps> = ({ limit = 5, ...rest }) => {
   return (
     <>
       <Box {...rest}>
-        <Join separator={<Spacer mt={1} />}>
+        <Join separator={<Spacer y={1} />}>
           {takeRight(toasts, limit).map(({ id, ...rest }) => (
             <Toast key={id} id={id} {...rest} />
           ))}

--- a/packages/palette/src/themes/Themes.story.tsx
+++ b/packages/palette/src/themes/Themes.story.tsx
@@ -112,7 +112,7 @@ export const Spacing = () => {
 
       <Separator color="black30" my={12} />
 
-      <Join separator={<Spacer my={2} />}>
+      <Join separator={<Spacer y={2} />}>
         {spacing.map((key) => {
           const px = parseFloat(key) * 10
 


### PR DESCRIPTION
no more confusing `ml` and `mt` and `mx` and ..





<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@26.0.0-canary.1232.25371.0
  npm install @artsy/palette@27.0.0-canary.1232.25371.0
  # or 
  yarn add @artsy/palette-charts@26.0.0-canary.1232.25371.0
  yarn add @artsy/palette@27.0.0-canary.1232.25371.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

## Release Notes

To migrate to this version, replace the following props on`Spacer`:
- `mb`, `mt` with `y`.
- `ml`, `mr` with `x`.
- `my` with `y`. if in a flex context, double the value (`my={1}` becomes `y={2}`).
- `mx` with `x`. if in a flex context,double the value (`mx={1}` becomes `x={2}`).
- `m` with either `x` or `y`, figure out which one you need based on the case. if in a flex context, double the value as well.
- similarly for `p*`.
