### PR TITLE
feat(popover/tooltip): variants and pointers

### DIFF
--- a/packages/palette/src/elements/Pointer/Pointer.tsx
+++ b/packages/palette/src/elements/Pointer/Pointer.tsx
@@ -1,0 +1,130 @@
+import React, { FC, useMemo } from "react"
+import styled from "styled-components"
+import { variant } from "styled-system"
+import { DROP_SHADOW } from "../../helpers"
+import { Position } from "../../utils"
+import { Box } from "../Box"
+
+const POINTER_VARIANTS = {
+  defaultLight: {
+    backgroundColor: "white100",
+  },
+  defaultDark: {
+    backgroundColor: "black100",
+  },
+}
+
+type PointerVariant = keyof typeof POINTER_VARIANTS
+
+export interface PointerProps {
+  isFlipped: boolean
+  placement: Position
+  variant?: PointerVariant
+}
+
+/**
+ * Internal-use component for displaying a triangular pointer to an anchor node
+ */
+export const Pointer: FC<PointerProps> = ({
+  isFlipped,
+  placement,
+  variant = "defaultLight",
+}) => {
+  const position = useMemo(() => {
+    switch (placement) {
+      case "top-start":
+        return {
+          bottom: isFlipped ? "100%" : 0,
+          left: `${POINTER_WIDTH}px`,
+        }
+      case "top":
+        return {
+          bottom: isFlipped ? "100%" : 0,
+          left: `calc(50% - ${POINTER_WIDTH / 2}px)`,
+        }
+      case "top-end":
+        return {
+          bottom: isFlipped ? "100%" : 0,
+          right: `${POINTER_WIDTH * 2}px`,
+        }
+      case "bottom-start":
+        return {
+          top: isFlipped ? "100%" : 0,
+          left: `${POINTER_WIDTH}px`,
+        }
+      case "bottom":
+        return {
+          top: isFlipped ? "100%" : 0,
+          left: `calc(50% - ${POINTER_WIDTH / 2}px)`,
+        }
+      case "bottom-end":
+        return {
+          top: isFlipped ? "100%" : 0,
+          right: `${POINTER_WIDTH * 2}px`,
+        }
+      case "left-start":
+        return {
+          top: `${POINTER_WIDTH}px`,
+          ...(isFlipped
+            ? { left: `-${POINTER_WIDTH / 2}px` }
+            : { right: `${POINTER_WIDTH / 2}px` }),
+        }
+      case "left":
+        return {
+          top: "50%",
+          ...(isFlipped
+            ? { left: `-${POINTER_WIDTH / 2}px` }
+            : { right: `${POINTER_WIDTH / 2}px` }),
+        }
+      case "left-end":
+        return {
+          bottom: `${POINTER_WIDTH}px`,
+          ...(isFlipped
+            ? { left: `-${POINTER_WIDTH / 2}px` }
+            : { right: `${POINTER_WIDTH / 2}px` }),
+        }
+      case "right-start":
+        return {
+          top: `${POINTER_WIDTH}px`,
+          ...(isFlipped
+            ? { right: `${POINTER_WIDTH / 2}px` }
+            : { left: `-${POINTER_WIDTH / 2}px` }),
+        }
+      case "right":
+        return {
+          top: "50%",
+          ...(isFlipped
+            ? { right: `${POINTER_WIDTH / 2}px` }
+            : { left: `-${POINTER_WIDTH / 2}px` }),
+        }
+      case "right-end":
+        return {
+          bottom: `${POINTER_WIDTH}px`,
+          ...(isFlipped
+            ? { right: `${POINTER_WIDTH / 2}px` }
+            : { left: `-${POINTER_WIDTH / 2}px` }),
+        }
+    }
+  }, [isFlipped, placement])
+
+  return <Container variant={variant} {...position} />
+}
+
+const POINTER_SIZE = 10 // px
+const POINTER_WIDTH = Math.sqrt(2 * Math.pow(10, 2)) // px
+
+const Container = styled(Box)<{ variant: PointerVariant }>`
+  z-index: -1;
+  position: absolute;
+
+  &::after {
+    content: "";
+    position: absolute;
+    width: ${POINTER_SIZE}px;
+    height: ${POINTER_SIZE}px;
+    transform-origin: 0 0;
+    transform: rotate(-45deg);
+    box-shadow: ${DROP_SHADOW};
+    ${variant({ variants: POINTER_VARIANTS })}
+  }
+`

--- a/packages/palette/src/elements/Pointer/index.ts
+++ b/packages/palette/src/elements/Pointer/index.ts
@@ -1,0 +1,1 @@
+export * from "./Pointer"

--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -19,8 +19,42 @@ export const Default = () => {
     <States<Partial<PopoverProps>>
       states={[
         {},
-        { title: "Example Title", visible: true },
+        { visible: true },
         { onClose: action("onClose") },
+        {
+          visible: true,
+          popover: (
+            <Text variant="xs" width={300}>
+              | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+              | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+              | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+              | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+              | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+              | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
+              | | | — (Content interaction with close button.)
+            </Text>
+          ),
+        },
+        {
+          visible: true,
+          p: 0,
+          popover: (
+            <>
+              {new Array(4).fill(0).map((_, i) => (
+                <Text
+                  key={i}
+                  variant="sm-display"
+                  overflowEllipsis
+                  bg="red10"
+                  px={1}
+                  py={0.5}
+                >
+                  Example Item
+                </Text>
+              ))}
+            </>
+          ),
+        },
       ]}
     >
       <Popover

--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -36,6 +36,7 @@ export const Default = () => {
           ),
         },
         {
+          pointer: true,
           visible: true,
           p: 0,
           popover: (
@@ -55,7 +56,12 @@ export const Default = () => {
             </>
           ),
         },
-        { variant: "defaultDark", placement: "bottom", visible: true },
+        {
+          variant: "defaultDark",
+          placement: "bottom",
+          visible: true,
+          pointer: true,
+        },
       ]}
     >
       <Popover
@@ -101,6 +107,8 @@ export const Placement = () => {
           <Popover
             popover={<Text variant="xs">{JSON.stringify(props)}</Text>}
             visible
+            variant="defaultDark"
+            pointer
             {...props}
           >
             {({ anchorRef }) => {
@@ -112,8 +120,7 @@ export const Placement = () => {
                   p={1}
                   maxWidth="50%"
                   mx="auto"
-                  bg="black100"
-                  color="white100"
+                  bg="black10"
                 >
                   {JSON.stringify(props)}
                 </Text>

--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -55,6 +55,7 @@ export const Default = () => {
             </>
           ),
         },
+        { variant: "defaultDark", placement: "bottom", visible: true },
       ]}
     >
       <Popover

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -7,6 +7,7 @@ import { Position, useClickOutside, usePosition } from "../../utils"
 import { useUpdateEffect } from "../../utils/useUpdateEffect"
 import { Box, BoxProps } from "../Box"
 import { Clickable } from "../Clickable"
+import { Pointer } from "../Pointer"
 
 export const POPOVER_VARIANTS = {
   defaultLight: {
@@ -34,6 +35,8 @@ export interface PopoverProps extends BoxProps {
   children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
   onClose?: () => void
   placement?: Position
+  /** Display triangular pointer back to anchor node */
+  pointer?: boolean
   popover: React.ReactNode
   variant?: PopoverVariant
   /** Initial default visibility */
@@ -45,12 +48,13 @@ export interface PopoverProps extends BoxProps {
  * positioned relative to, another element.
  */
 export const Popover: React.FC<PopoverProps> = ({
-  placement = "top",
-  visible: _visible = false,
   children,
-  popover,
   onClose,
+  placement = "top",
+  pointer = false,
+  popover,
   variant = "defaultLight",
+  visible: _visible = false,
   ...rest
 }) => {
   const [visible, setVisible] = useState(false)
@@ -98,7 +102,11 @@ export const Popover: React.FC<PopoverProps> = ({
     }
   }, [handleHide])
 
-  const { anchorRef, tooltipRef } = usePosition({
+  const {
+    anchorRef,
+    tooltipRef,
+    state: { isFlipped },
+  } = usePosition({
     position: placement,
     offset: 10,
     active: visible,
@@ -121,15 +129,37 @@ export const Popover: React.FC<PopoverProps> = ({
           ref={tooltipRef as any}
           zIndex={1}
           display="inline-block"
+          position="relative"
           variant={variant}
         >
-          <Close p={1} onClick={handleHide} aria-label="Close">
+          {pointer && (
+            <Pointer
+              variant={variant}
+              placement={placement}
+              isFlipped={isFlipped}
+            />
+          )}
+
+          <Close
+            position="relative"
+            zIndex={2}
+            p={1}
+            onClick={handleHide}
+            aria-label="Close"
+          >
             <CloseIcon fill="currentColor" display="block" />
           </Close>
 
-          <Box py={2} px={1} {...rest}>
+          <Panel
+            variant={variant}
+            position="relative"
+            py={2}
+            px={1}
+            zIndex={1}
+            {...rest}
+          >
             {popover}
-          </Box>
+          </Panel>
         </Tip>
       )}
     </>
@@ -142,6 +172,10 @@ const Tip = styled(Box)<{ variant?: PopoverVariant }>`
   text-align: left;
   transition: opacity 250ms ease-out;
   box-shadow: ${DROP_SHADOW};
+  ${variant({ variants: POPOVER_VARIANTS })}
+`
+
+const Panel = styled(Box)<{ variant?: PopoverVariant }>`
   ${variant({ variants: POPOVER_VARIANTS })}
 `
 

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -1,15 +1,11 @@
 import React, { useCallback, useEffect, useState } from "react"
 import styled from "styled-components"
 import { DROP_SHADOW } from "../../helpers"
-import { isText } from "../../helpers/isText"
 import { CloseIcon } from "../../svgs"
 import { Position, useClickOutside, usePosition } from "../../utils"
 import { useUpdateEffect } from "../../utils/useUpdateEffect"
 import { Box, BoxProps } from "../Box"
 import { Clickable } from "../Clickable"
-import { Flex } from "../Flex"
-import { Spacer } from "../Spacer"
-import { Text } from "../Text"
 
 export interface PopoverActions {
   /** Call to show popover */
@@ -21,7 +17,6 @@ export interface PopoverActions {
 }
 
 export interface PopoverProps extends BoxProps {
-  title?: React.ReactNode
   placement?: Position
   /** Intially visible by default? */
   visible?: boolean
@@ -35,7 +30,6 @@ export interface PopoverProps extends BoxProps {
  * positioned relative to, another element.
  */
 export const Popover: React.FC<PopoverProps> = ({
-  title,
   placement = "top",
   visible: _visible = false,
   children,
@@ -112,43 +106,19 @@ export const Popover: React.FC<PopoverProps> = ({
           zIndex={1}
           display="inline-block"
           bg="white100"
-          p={2}
-          {...rest}
         >
-          {title && (
-            <>
-              <Flex alignItems="center" flex={1} justifyContent="space-between">
-                {isText(title) ? (
-                  <Text variant="lg-display" lineHeight={1}>
-                    {title}
-                  </Text>
-                ) : (
-                  title
-                )}
-
-                <Spacer x={4} />
-              </Flex>
-
-              <Spacer y={0.5} />
-            </>
-          )}
-
           <Clickable
-            position="absolute"
-            right={0}
-            top={0}
-            pt={2}
-            px={1}
-            mx={0.5}
+            p={1}
             onClick={handleHide}
             aria-label="Close"
+            style={{ float: "right" }}
           >
             <CloseIcon fill="black100" display="block" />
           </Clickable>
 
-          {!title && <Spacer y={2} />}
-
-          {popover}
+          <Box py={2} px={1} {...rest}>
+            {popover}
+          </Box>
         </Tip>
       )}
     </>

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -1,11 +1,25 @@
 import React, { useCallback, useEffect, useState } from "react"
 import styled from "styled-components"
+import { variant } from "styled-system"
 import { DROP_SHADOW } from "../../helpers"
 import { CloseIcon } from "../../svgs"
 import { Position, useClickOutside, usePosition } from "../../utils"
 import { useUpdateEffect } from "../../utils/useUpdateEffect"
 import { Box, BoxProps } from "../Box"
 import { Clickable } from "../Clickable"
+
+export const POPOVER_VARIANTS = {
+  defaultLight: {
+    backgroundColor: "white100",
+    color: "black100",
+  },
+  defaultDark: {
+    backgroundColor: "black100",
+    color: "white100",
+  },
+}
+
+export type PopoverVariant = keyof typeof POPOVER_VARIANTS
 
 export interface PopoverActions {
   /** Call to show popover */
@@ -17,12 +31,13 @@ export interface PopoverActions {
 }
 
 export interface PopoverProps extends BoxProps {
-  placement?: Position
-  /** Intially visible by default? */
-  visible?: boolean
-  popover: React.ReactNode
   children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
   onClose?: () => void
+  placement?: Position
+  popover: React.ReactNode
+  variant?: PopoverVariant
+  /** Initial default visibility */
+  visible?: boolean
 }
 
 /**
@@ -35,6 +50,7 @@ export const Popover: React.FC<PopoverProps> = ({
   children,
   popover,
   onClose,
+  variant = "defaultLight",
   ...rest
 }) => {
   const [visible, setVisible] = useState(false)
@@ -105,16 +121,11 @@ export const Popover: React.FC<PopoverProps> = ({
           ref={tooltipRef as any}
           zIndex={1}
           display="inline-block"
-          bg="white100"
+          variant={variant}
         >
-          <Clickable
-            p={1}
-            onClick={handleHide}
-            aria-label="Close"
-            style={{ float: "right" }}
-          >
-            <CloseIcon fill="black100" display="block" />
-          </Clickable>
+          <Close p={1} onClick={handleHide} aria-label="Close">
+            <CloseIcon fill="currentColor" display="block" />
+          </Close>
 
           <Box py={2} px={1} {...rest}>
             {popover}
@@ -125,10 +136,15 @@ export const Popover: React.FC<PopoverProps> = ({
   )
 }
 
-const Tip = styled(Box)`
+const Tip = styled(Box)<{ variant?: PopoverVariant }>`
   position: fixed;
   z-index: 1;
   text-align: left;
   transition: opacity 250ms ease-out;
   box-shadow: ${DROP_SHADOW};
+  ${variant({ variants: POPOVER_VARIANTS })}
+`
+
+const Close = styled(Clickable)`
+  float: right;
 `

--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -8,8 +8,7 @@ import { Clickable } from "../Clickable"
 import { Text } from "../Text"
 import { Tooltip, TooltipProps } from "./Tooltip"
 
-const CONTENT =
-  "Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis odio laudantium sint possimus debitis commodi iusto odit, sunt facilis consequuntur, hic rem doloremque illum provident temporibus atque. Ducimus, commodi necessitatibus?"
+const CONTENT = "Lorem ipsum dolor sit amet consectetur adipisicing elit?"
 
 export default {
   title: "Components/Tooltip",
@@ -22,6 +21,7 @@ export const Default = () => {
         { placement: "top-start" },
         { placement: "bottom", width: 600 },
         { placement: "bottom", visible: true },
+        { variant: "defaultDark", placement: "bottom", visible: true },
       ]}
     >
       <Tooltip content={CONTENT}>

--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -72,15 +72,20 @@ export const Placement = () => {
     >
       {(props) => {
         return (
-          <Tooltip content={JSON.stringify(props)} visible {...props}>
+          <Tooltip
+            content={JSON.stringify(props)}
+            variant="defaultDark"
+            pointer
+            visible
+            {...props}
+          >
             <Text
               variant="xs"
               textAlign="center"
               p={1}
               maxWidth="50%"
               mx="auto"
-              bg="black100"
-              color="white100"
+              bg="black10"
             >
               {JSON.stringify(props)}
             </Text>

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -1,9 +1,23 @@
 import React, { useState } from "react"
 import styled from "styled-components"
+import { variant } from "styled-system"
 import { DROP_SHADOW, isText } from "../../helpers"
 import { Position, usePosition } from "../../utils/usePosition"
 import { Box, BoxProps } from "../Box"
 import { Text } from "../Text"
+
+export const TOOLTIP_VARIANTS = {
+  defaultLight: {
+    backgroundColor: "white100",
+    color: "black100",
+  },
+  defaultDark: {
+    backgroundColor: "black100",
+    color: "white100",
+  },
+}
+
+export type TooltipVariant = keyof typeof TOOLTIP_VARIANTS
 
 export interface TooltipProps extends BoxProps {
   /** Anchor element to attach to tooltip */
@@ -11,6 +25,7 @@ export interface TooltipProps extends BoxProps {
   /** Content of tooltip */
   content: React.ReactNode
   placement?: Position
+  variant?: TooltipVariant
   visible?: boolean
 }
 
@@ -22,6 +37,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   content,
   width = 230,
   placement = "top",
+  variant = "defaultLight",
   visible,
 }) => {
   const [active, setActive] = useState(false)
@@ -58,9 +74,9 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
       <Tip
         ref={tooltipRef as any}
+        variant={variant}
         p={1}
         width={width}
-        bg="white100"
         zIndex={1}
         {...(visible
           ? // If there's a visible prop being passed; use that
@@ -74,7 +90,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   )
 }
 
-const Tip = styled(Box)`
+const Tip = styled(Box)<{ variant?: TooltipVariant }>`
   position: absolute;
   z-index: 1;
   transition: opacity 250ms ease-out;
@@ -82,6 +98,7 @@ const Tip = styled(Box)`
   box-shadow: ${DROP_SHADOW};
   cursor: default;
   pointer-events: none;
+  ${variant({ variants: TOOLTIP_VARIANTS })}
 `
 
 const compose = (a?: (...args: any) => any, b?: (...args: any) => any) => {

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from "react"
 import styled from "styled-components"
-import { DROP_SHADOW } from "../../helpers"
+import { DROP_SHADOW, isText } from "../../helpers"
 import { Position, usePosition } from "../../utils/usePosition"
-import { Box } from "../Box"
+import { Box, BoxProps } from "../Box"
 import { Text } from "../Text"
 
-export interface TooltipProps {
+export interface TooltipProps extends BoxProps {
+  /** Anchor element to attach to tooltip */
+  children: React.ReactElement<any, string | React.JSXElementConstructor<any>>
+  /** Content of tooltip */
   content: React.ReactNode
   placement?: Position
-  size?: "sm" | "lg"
-  width?: number | null
   visible?: boolean
-  children: React.ReactElement<any, string | React.JSXElementConstructor<any>>
 }
 
 /**
@@ -19,8 +19,7 @@ export interface TooltipProps {
  */
 export const Tooltip: React.FC<TooltipProps> = ({
   children,
-  content: _content,
-  size = "lg",
+  content,
   width = 230,
   placement = "top",
   visible,
@@ -38,8 +37,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const deactivate = () => {
     setActive(false)
   }
-
-  const content = typeof _content === "string" ? truncate(_content) : _content
 
   const { anchorRef, tooltipRef } = usePosition({
     position: placement,
@@ -60,10 +57,10 @@ export const Tooltip: React.FC<TooltipProps> = ({
       })}
 
       <Tip
-        p={size === "sm" ? 0.5 : 2}
+        ref={tooltipRef as any}
+        p={1}
         width={width}
         bg="white100"
-        ref={tooltipRef as any}
         zIndex={1}
         {...(visible
           ? // If there's a visible prop being passed; use that
@@ -71,7 +68,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
           : // Otherwise use the active state
             { opacity: active ? 1 : 0 })}
       >
-        <Text variant="xs">{content}</Text>
+        {isText(content) ? <Text variant="xs">{content}</Text> : content}
       </Tip>
     </>
   )
@@ -86,16 +83,6 @@ const Tip = styled(Box)`
   cursor: default;
   pointer-events: none;
 `
-
-const truncate = (tip: string): string => {
-  let substring = tip.substring(0, 300)
-
-  if (substring !== tip) {
-    substring += "…"
-  }
-
-  return substring
-}
 
 const compose = (a?: (...args: any) => any, b?: (...args: any) => any) => {
   return (...args) => {

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import { variant } from "styled-system"
 import { DROP_SHADOW, isText } from "../../helpers"
 import { Position, usePosition } from "../../utils/usePosition"
 import { Box, BoxProps } from "../Box"
+import { Pointer } from "../Pointer"
 import { Text } from "../Text"
 
 export const TOOLTIP_VARIANTS = {
@@ -25,6 +26,7 @@ export interface TooltipProps extends BoxProps {
   /** Content of tooltip */
   content: React.ReactNode
   placement?: Position
+  pointer?: boolean
   variant?: TooltipVariant
   visible?: boolean
 }
@@ -37,6 +39,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   content,
   width = 230,
   placement = "top",
+  pointer = false,
   variant = "defaultLight",
   visible,
 }) => {
@@ -54,7 +57,11 @@ export const Tooltip: React.FC<TooltipProps> = ({
     setActive(false)
   }
 
-  const { anchorRef, tooltipRef } = usePosition({
+  const {
+    anchorRef,
+    tooltipRef,
+    state: { isFlipped },
+  } = usePosition({
     position: placement,
     offset: 10,
     active: visible ?? active,
@@ -75,7 +82,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
       <Tip
         ref={tooltipRef as any}
         variant={variant}
-        p={1}
         width={width}
         zIndex={1}
         {...(visible
@@ -84,7 +90,17 @@ export const Tooltip: React.FC<TooltipProps> = ({
           : // Otherwise use the active state
             { opacity: active ? 1 : 0 })}
       >
-        {isText(content) ? <Text variant="xs">{content}</Text> : content}
+        {pointer && (
+          <Pointer
+            variant={variant}
+            placement={placement}
+            isFlipped={isFlipped}
+          />
+        )}
+
+        <Panel variant={variant} p={1}>
+          {isText(content) ? <Text variant="xs">{content}</Text> : content}
+        </Panel>
       </Tip>
     </>
   )
@@ -98,6 +114,10 @@ const Tip = styled(Box)<{ variant?: TooltipVariant }>`
   box-shadow: ${DROP_SHADOW};
   cursor: default;
   pointer-events: none;
+  ${variant({ variants: TOOLTIP_VARIANTS })}
+`
+
+const Panel = styled(Box)<{ variant?: TooltipVariant }>`
   ${variant({ variants: TOOLTIP_VARIANTS })}
 `
 

--- a/packages/palette/src/helpers/index.ts
+++ b/packages/palette/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from "./isText"
 export * from "./color"
 export * from "./injectGlobalStyles"
 export * from "./media"


### PR DESCRIPTION
### BREAKING CHANGES

* Removes `size` prop from `Tooltip`
* Removes `title` prop from `Popover`
* Adjusts padding in `Popover`

![](https://static.damonzucconi.com/_capture/3XMxyOFu.png)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@27.0.0-canary.1242.25654.0
  npm install @artsy/palette@28.0.0-canary.1242.25654.0
  # or 
  yarn add @artsy/palette-charts@27.0.0-canary.1242.25654.0
  yarn add @artsy/palette@28.0.0-canary.1242.25654.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
