### PR TITLE
fix(tooltip): spreads rest props

### DIFF
--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -32,6 +32,10 @@ export const Default = () => {
           visible: false,
           children: <>This text has a tooltip that never displays</>,
         },
+        {
+          visible: true,
+          textAlign: "center",
+        },
       ]}
     >
       {({ children, ...rest }) => (

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -42,6 +42,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   pointer = false,
   variant = "defaultLight",
   visible,
+  ...rest
 }) => {
   const [active, setActive] = useState(false)
 
@@ -102,7 +103,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
           />
         )}
 
-        <Panel variant={variant} p={1}>
+        <Panel variant={variant} p={1} {...rest}>
           {isText(content) ? <Text variant="xs">{content}</Text> : content}
         </Panel>
       </Tip>


### PR DESCRIPTION
This component accepts `BoxProps` but we weren't doing anything with them.