### PR TITLE
fix(popover): threads through z-index to correct element

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -61,6 +61,7 @@ export const Default = () => {
           placement: "bottom",
           visible: true,
           pointer: true,
+          zIndex: 99,
         },
       ]}
     >

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -57,6 +57,7 @@ export const Popover: React.FC<PopoverProps> = ({
   popover,
   variant = "defaultLight",
   visible: _visible = false,
+  zIndex,
   ...rest
 }) => {
   const [visible, setVisible] = useState(false)
@@ -132,7 +133,7 @@ export const Popover: React.FC<PopoverProps> = ({
           <Tip
             tabIndex={0}
             ref={tooltipRef as any}
-            zIndex={1}
+            zIndex={zIndex ?? 1}
             display="inline-block"
             position="relative"
             variant={variant}


### PR DESCRIPTION
Threads through the `z-index` to the positioned element rather than the panel.