### PR TITLE
feat(types): Constrain spacing unit types

### DIFF
--- a/packages/palette/src/elements/Box/Box.tsx
+++ b/packages/palette/src/elements/Box/Box.tsx
@@ -20,6 +20,7 @@ import {
   textAlign,
   TextAlignProps,
 } from "styled-system"
+import { BaseSpaceProps } from "../../themes/types"
 import { splitProps } from "../../utils/splitProps"
 
 export interface BoxProps
@@ -30,7 +31,7 @@ export interface BoxProps
     GridAreaProps,
     LayoutProps,
     PositionProps,
-    SpaceProps,
+    SpaceProps<BaseSpaceProps>,
     TextAlignProps {}
 
 /**

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -13,12 +13,13 @@ import {
   width,
   WidthProps,
 } from "styled-system"
+import { BaseSpaceProps } from "../../themes/types"
 import { CleanTag } from "../CleanTag"
 import { LazyImage } from "./LazyImage"
 
 export interface ImageProps
   extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "width" | "height">,
-    SpaceProps,
+    SpaceProps<BaseSpaceProps>,
     WidthProps,
     HeightProps,
     MaxHeightProps,

--- a/packages/palette/src/elements/Separator/Separator.tsx
+++ b/packages/palette/src/elements/Separator/Separator.tsx
@@ -10,9 +10,10 @@ import {
   width,
   WidthProps,
 } from "styled-system"
+import { BaseSpaceProps } from "../../themes/types"
 
 export interface SeparatorProps
-  extends SpaceProps,
+  extends SpaceProps<BaseSpaceProps>,
     WidthProps,
     BorderProps,
     ColorProps {}

--- a/packages/palette/src/svgs/Icon.tsx
+++ b/packages/palette/src/svgs/Icon.tsx
@@ -8,10 +8,11 @@ import {
   SpaceProps,
 } from "styled-system"
 import { Color } from "../Theme"
+import { BaseSpaceProps } from "../themes/types"
 
 export interface IconProps
   extends React.SVGProps<any>,
-    SpaceProps,
+    SpaceProps<BaseSpaceProps>,
     PositionProps {
   fill?: Color | "currentColor"
   title?: string

--- a/packages/palette/src/themes/types.ts
+++ b/packages/palette/src/themes/types.ts
@@ -10,5 +10,8 @@ import {
 } from "@artsy/palette-tokens/dist/themes/v3"
 
 export type Color = ColorV2 | ColorV3
-export type SpacingUnit = SpacingUnitV2 | SpacingUnitV3
+export type SpacingUnit = SpacingUnitV2 | SpacingUnitV3 | `${number}px`
 export type Breakpoint = BreakpointV2 | BreakpointV3
+
+// Constrains styled-system's spacing unit to those defined by us
+export type BaseSpaceProps = { space: Record<SpacingUnit, any> }


### PR DESCRIPTION
Per convo with @pvinis and mobile plat, this constrains our spacing scale numeric values to only those within the design system, and if we need to step out of it we can use "3px" style values:

```tsx
<Box m={2} /> // good 
<Box m={3} /> // type-error
<Box m="3px" /> // good  
```

Opening a canary to see how it goes. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@28.3.0-canary.1254.25961.0
  npm install @artsy/palette@29.3.0-canary.1254.25961.0
  # or 
  yarn add @artsy/palette-charts@28.3.0-canary.1254.25961.0
  yarn add @artsy/palette@29.3.0-canary.1254.25961.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
