### PR TITLE
fix(TX-1071): pass the collapsed state into children

### DIFF
--- a/packages/palette/src/elements/Collapse/Collapse.story.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.story.tsx
@@ -10,21 +10,19 @@ export default {
 }
 
 export const Default = () => {
-  const [open, setOpen] = useState(false)
+  const [openCollapse, setOpenCollapse] = useState(false)
 
   return (
-    <>
-      <States<CollapseProps> states={[{ open: false }]}>
-        <>
-          <Button onClick={() => setOpen(!open)}>
-            {open ? "Close" : "Open"}
-          </Button>
-          <Spacer y={1} />
-          <Collapse open={open}>
-            <Text>This collapse is open.</Text>
-          </Collapse>
-        </>
-      </States>
-    </>
+    <States<Partial<CollapseProps>> states={[{ open: false }]}>
+      <>
+        <Button onClick={() => setOpenCollapse(!openCollapse)}>
+          {openCollapse ? "Close" : "Open"}
+        </Button>
+        <Spacer y={1} />
+        <Collapse open={openCollapse}>
+          <Text>This collapse is open.</Text>
+        </Collapse>
+      </>
+    </States>
   )
 }

--- a/packages/palette/src/elements/Collapse/Collapse.story.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.story.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react"
+import { States } from "storybook-states"
+import { Button } from "../Button"
+import { Spacer } from "../Spacer"
+import { Text } from "../Text"
+import { Collapse, CollapseProps } from "./Collapse"
+
+export default {
+  title: "Components/Collapse",
+}
+
+export const Default = () => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <States<CollapseProps> states={[{ open: false }]}>
+        <>
+          <Button onClick={() => setOpen(!open)}>
+            {open ? "Close" : "Open"}
+          </Button>
+          <Spacer y={1} />
+          <Collapse open={open}>
+            <Text>This collapse is open.</Text>
+          </Collapse>
+        </>
+      </States>
+    </>
+  )
+}

--- a/packages/palette/src/elements/Collapse/Collapse.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.tsx
@@ -93,11 +93,10 @@ export class Collapse extends React.Component<CollapseProps> {
         style={{
           transition: "height 0.3s ease",
           overflow: "hidden",
-          display: open ? "inline" : "none",
           ...heightProps,
         }}
       >
-        {children}
+        {typeof children === "function" ? children({ open }) : children}
       </div>
     )
   }

--- a/packages/palette/src/elements/Collapse/Collapse.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.tsx
@@ -93,6 +93,7 @@ export class Collapse extends React.Component<CollapseProps> {
         style={{
           transition: "height 0.3s ease",
           overflow: "hidden",
+          display: open ? "inline" : "none",
           ...heightProps,
         }}
       >


### PR DESCRIPTION
[TX-1071](https://artsyproduct.atlassian.net/browse/TX-1071)

This PR does not fix the above issue, however, it will allow us to more easily set the `tabIndex` for hidden child elements. 

I've also created a story as a noticed there wasn't one. 

[TX-1071]: https://artsyproduct.atlassian.net/browse/TX-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ