### PR TITLE
fix(popover,tooltip): fixes default z-index handling

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -57,7 +57,7 @@ export const Popover: React.FC<PopoverProps> = ({
   popover,
   variant = "defaultLight",
   visible: _visible = false,
-  zIndex,
+  zIndex = 1,
   ...rest
 }) => {
   const [visible, setVisible] = useState(false)
@@ -133,7 +133,7 @@ export const Popover: React.FC<PopoverProps> = ({
           <Tip
             tabIndex={0}
             ref={tooltipRef as any}
-            zIndex={zIndex ?? 1}
+            zIndex={zIndex}
             display="inline-block"
             position="relative"
             variant={variant}
@@ -176,7 +176,6 @@ export const Popover: React.FC<PopoverProps> = ({
 
 const Tip = styled(Box)<{ variant?: PopoverVariant }>`
   position: fixed;
-  z-index: 1;
   text-align: left;
   transition: opacity 250ms ease-out;
   box-shadow: ${DROP_SHADOW};

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -44,6 +44,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   pointer = false,
   variant = "defaultLight",
   visible,
+  zIndex = 1,
   ...rest
 }) => {
   const [active, setActive] = useState(false)
@@ -86,7 +87,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
         ref={tooltipRef as any}
         variant={variant}
         width={width}
-        zIndex={1}
+        zIndex={zIndex}
         style={
           // If visible is explictly set to `false` then the tooltip should be hidden
           // Otherwise it should be visible or utilize the active state.
@@ -117,7 +118,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
 const Tip = styled(Box)<{ variant?: TooltipVariant }>`
   position: absolute;
-  z-index: 1;
   transition: opacity 250ms ease-out;
   text-align: left;
   box-shadow: ${DROP_SHADOW};


### PR DESCRIPTION
Minor fix: the `z-index` here was being duplicated in the `styled` declaration, which was taking precedence.