### PR TITLE
feat(popover): supports optionally ignoring outside clicks

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -63,6 +63,9 @@ export const Default = () => {
           pointer: true,
           zIndex: 99,
         },
+        {
+          ignoreClickOutside: true,
+        },
       ]}
     >
       <Popover

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -35,6 +35,7 @@ export interface PopoverProps extends BoxProps {
   children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
   offset?: number
   onClose?: () => void
+  ignoreClickOutside?: boolean
   placement?: Position
   /** Display triangular pointer back to anchor node */
   pointer?: boolean
@@ -52,6 +53,7 @@ export const Popover: React.FC<PopoverProps> = ({
   children,
   onClose,
   offset = 10,
+  ignoreClickOutside = false,
   placement = "top",
   pointer = false,
   popover,
@@ -118,7 +120,7 @@ export const Popover: React.FC<PopoverProps> = ({
   useClickOutside({
     ref: tooltipRef,
     onClickOutside: handleHide,
-    when: visible,
+    when: visible && !ignoreClickOutside,
     type: "click",
   })
 


### PR DESCRIPTION
Needed to support progressive onboarding, wherein these must be manually dismissed, or dismissed by taking the appropriate action.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@28.5.0-canary.1259.26120.0
  npm install @artsy/palette@29.5.0-canary.1259.26120.0
  # or 
  yarn add @artsy/palette-charts@28.5.0-canary.1259.26120.0
  yarn add @artsy/palette@29.5.0-canary.1259.26120.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
