### PR TITLE
feat(popover): adds prop to disable focus management

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -140,3 +140,38 @@ export const Placement = () => {
 Placement.story = {
   parameters: { chromatic: { disable: true } },
 }
+
+export const ManageFocus = () => {
+  return (
+    <States<Partial<PopoverProps>>
+      states={[
+        { visible: true, manageFocus: false },
+        { visible: true, manageFocus: true },
+      ]}
+    >
+      <Popover
+        placement="bottom"
+        popover={
+          <Text variant="xs" width={300}>
+            {CONTENT}
+          </Text>
+        }
+      >
+        {({ onVisible, anchorRef }) => {
+          return (
+            <Box textAlign="center">
+              <Button
+                ref={anchorRef}
+                variant="secondaryBlack"
+                size="small"
+                onClick={onVisible}
+              >
+                Click to display popover
+              </Button>
+            </Box>
+          )
+        }}
+      </Popover>
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -33,9 +33,10 @@ export interface PopoverActions {
 
 export interface PopoverProps extends BoxProps {
   children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
+  ignoreClickOutside?: boolean
+  manageFocus?: boolean
   offset?: number
   onClose?: () => void
-  ignoreClickOutside?: boolean
   placement?: Position
   /** Display triangular pointer back to anchor node */
   pointer?: boolean
@@ -51,9 +52,10 @@ export interface PopoverProps extends BoxProps {
  */
 export const Popover: React.FC<PopoverProps> = ({
   children,
-  onClose,
-  offset = 10,
   ignoreClickOutside = false,
+  manageFocus = true,
+  offset = 10,
+  onClose,
   placement = "top",
   pointer = false,
   popover,
@@ -71,6 +73,8 @@ export const Popover: React.FC<PopoverProps> = ({
 
   // Yields focus back and forth between popover and anchor
   useUpdateEffect(() => {
+    if (!manageFocus) return
+
     if (visible && tooltipRef.current) {
       tooltipRef.current.focus()
       return


### PR DESCRIPTION
With the progressive onboarding we're kind of using these like tooltips with external triggers. This allows us to ignore the typical focus management the `Popover` does.