### PR TITLE
Revert "Revert "Revert "fix(usefocuslock): uses a more accurate method of determining focusable"""

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -122,7 +122,6 @@
     "react-lazy-load-image-component": "1.5.5",
     "react-remove-scroll": "2.5.5",
     "styled-system": "^5.1.5",
-    "tabbable": "^6.1.1",
     "trunc-html": "^1.1.2",
     "use-cursor": "^1.2.3",
     "use-keyboard-list-navigation": "2.4.2"

--- a/packages/palette/src/elements/Modal/__tests__/ModalBase.test.tsx
+++ b/packages/palette/src/elements/Modal/__tests__/ModalBase.test.tsx
@@ -3,29 +3,9 @@ import React, { useState } from "react"
 import { act } from "react-dom/test-utils"
 import { ModalBase } from "../ModalBase"
 
-jest.mock("tabbable", () => {
-  const tabbable = jest.requireActual("tabbable")
-
-  return {
-    ...tabbable,
-    tabbable: (node, options) =>
-      tabbable.tabbable(node, { ...options, displayCheck: "none" }),
-    focusable: (node, options) =>
-      tabbable.focusable(node, { ...options, displayCheck: "none" }),
-    isFocusable: (node, options) =>
-      tabbable.isFocusable(node, { ...options, displayCheck: "none" }),
-    isTabbable: (node, options) =>
-      tabbable.isTabbable(node, { ...options, displayCheck: "none" }),
-  }
-})
-
-const flushPromiseQueue = () => new Promise((resolve) => setTimeout(resolve, 0))
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 describe("ModalBase", () => {
-  beforeAll(() => {
-    jest.useFakeTimers()
-  })
-
   it("renders the children", () => {
     const wrapper = mount(<ModalBase onClose={jest.fn()}>content</ModalBase>)
     expect(wrapper.html()).toContain("content")
@@ -59,15 +39,11 @@ describe("ModalBase", () => {
           new KeyboardEvent("keydown", { key, shiftKey: shift })
         )
       })
-
-      await flushPromiseQueue()
+      await tick()
     }
 
     it("focuses the initial input", () => {
       const wrapper = mount(<Example />)
-
-      jest.runAllTimers()
-
       const input = wrapper.find("#foo")
       expect(input.getElement().props.id).toEqual("foo")
       expect(document.activeElement!.id).toEqual("foo")
@@ -76,34 +52,29 @@ describe("ModalBase", () => {
     it("manages the focus", async () => {
       mount(<Example />)
 
-      jest.runAllTimers()
-
       // Tabbing through
       expect(document.activeElement!.id).toEqual("foo")
-      keydown("Tab", false)
+      await keydown("Tab", false)
       expect(document.activeElement!.id).toEqual("bar")
-      keydown("Tab", false)
+      await keydown("Tab", false)
       expect(document.activeElement!.id).toEqual("baz")
       // Wraps around
-      keydown("Tab", false)
+      await keydown("Tab", false)
       expect(document.activeElement!.id).toEqual("foo")
       // Shift+tab backwards
-      keydown("Tab", true)
+      await keydown("Tab", true)
       expect(document.activeElement!.id).toEqual("baz")
-      keydown("Tab", true)
+      await keydown("Tab", true)
       expect(document.activeElement!.id).toEqual("bar")
-      keydown("Tab", true)
+      await keydown("Tab", true)
       expect(document.activeElement!.id).toEqual("foo")
-      keydown("Tab", true)
+      await keydown("Tab", true)
       // Wraps around
       expect(document.activeElement!.id).toEqual("baz")
     })
 
     it("returns focus to the previous element when closed", () => {
       const wrapper = mount(<Example />, { attachTo: document.body })
-
-      jest.runAllTimers()
-
       expect(document.activeElement!.id).toEqual("foo")
       wrapper.find("#open").simulate("click")
       expect(document.activeElement!.id).toEqual("qux")

--- a/packages/palette/src/utils/__tests__/useFocusLock.test.tsx
+++ b/packages/palette/src/utils/__tests__/useFocusLock.test.tsx
@@ -3,22 +3,6 @@ import React, { useRef } from "react"
 import { act } from "react-dom/test-utils"
 import { useFocusLock } from "../useFocusLock"
 
-jest.mock("tabbable", () => {
-  const tabbable = jest.requireActual("tabbable")
-
-  return {
-    ...tabbable,
-    tabbable: (node, options) =>
-      tabbable.tabbable(node, { ...options, displayCheck: "none" }),
-    focusable: (node, options) =>
-      tabbable.focusable(node, { ...options, displayCheck: "none" }),
-    isFocusable: (node, options) =>
-      tabbable.isFocusable(node, { ...options, displayCheck: "none" }),
-    isTabbable: (node, options) =>
-      tabbable.isTabbable(node, { ...options, displayCheck: "none" }),
-  }
-})
-
 const flushPromiseQueue = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 const keydown = async (key: string, shift?: boolean) => {
@@ -50,35 +34,27 @@ const Wrapper: React.FC = () => {
 }
 
 describe("useFocusLock", () => {
-  beforeAll(() => {
-    jest.useFakeTimers()
-  })
-
   it("cycles through the tabbable elements", async () => {
     mount(<Wrapper />, { attachTo: document.body })
 
-    jest.runAllTimers()
-
     expect(document.activeElement?.id).toEqual("1")
-    keydown("Tab")
+    await keydown("Tab")
     expect(document.activeElement?.id).toEqual("2")
-    keydown("Tab")
+    await keydown("Tab")
     expect(document.activeElement?.id).toEqual("3")
-    keydown("Tab")
+    await keydown("Tab")
     expect(document.activeElement?.id).toEqual("1")
   })
 
   it("can handle reverse with shift", async () => {
     mount(<Wrapper />, { attachTo: document.body })
 
-    jest.runAllTimers()
-
     expect(document.activeElement?.id).toEqual("1")
-    keydown("Tab", true)
+    await keydown("Tab", true)
     expect(document.activeElement?.id).toEqual("3")
-    keydown("Tab", true)
+    await keydown("Tab", true)
     expect(document.activeElement?.id).toEqual("2")
-    keydown("Tab", true)
+    await keydown("Tab", true)
     expect(document.activeElement?.id).toEqual("1")
   })
 })

--- a/packages/palette/src/utils/useFocusLock.story.tsx
+++ b/packages/palette/src/utils/useFocusLock.story.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react"
+import React, { useRef } from "react"
 import { useFocusLock } from "./useFocusLock"
 import { Input } from "../elements/Input"
 import { Button } from "../elements/Button"
@@ -26,9 +26,6 @@ export const Default = () => {
         <Button variant="primaryGray" tabIndex={-1}>
           Skipped
         </Button>
-        <Button variant="primaryGray" disabled>
-          Disabled
-        </Button>
         <Button variant="primaryGray">Focusable</Button>
       </div>
       <Input placeholder="Not focusable" />
@@ -53,25 +50,6 @@ export const WithAutocompleteInput = () => {
           { text: "Three", value: "three" },
         ]}
       />
-    </div>
-  )
-}
-
-export const DisableToEnable = () => {
-  const [value, setValue] = useState("")
-
-  const ref = useRef<HTMLDivElement | null>(null)
-
-  useFocusLock({ ref })
-
-  return (
-    <div ref={ref}>
-      <Input
-        placeholder="Value"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-      <Button disabled={!value}>Submit</Button>
     </div>
   )
 }

--- a/packages/palette/src/utils/useFocusLock.ts
+++ b/packages/palette/src/utils/useFocusLock.ts
@@ -1,31 +1,34 @@
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useCursor } from "use-cursor"
 import { useMutationObserver } from "./useMutationObserver"
-import { tabbable } from "tabbable"
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]:not([tabindex='-1'])",
+  "area[href]:not([tabindex='-1'])",
+  "input:not([disabled]):not([tabindex='-1'])",
+  "select:not([disabled]):not([tabindex='-1'])",
+  "textarea:not([disabled]):not([tabindex='-1'])",
+  "button:not([disabled]):not([tabindex='-1'])",
+  '[tabindex="0"]',
+].join(", ")
 
 interface UseFocusLock {
   ref: React.MutableRefObject<HTMLElement | null>
   active?: boolean
 }
 
-type FocusableElement = HTMLElement | SVGElement
-
-const MUTATION_OBSERVER_OPTIONS = {
-  attributes: true,
-  subtree: true,
-  attributeFilter: ["disabled"],
-}
-
 /**
  * Locks focus within the given element
  */
 export const useFocusLock = ({ ref, active = true }: UseFocusLock) => {
-  const [focusableEls, setFocusableEls] = useState<FocusableElement[]>([])
+  const [focusableEls, setFocusableEls] = useState<HTMLElement[]>([])
 
   const updateFocusableEls = useCallback(() => {
     if (ref.current === null) return
 
-    setFocusableEls(tabbable(ref.current))
+    setFocusableEls(
+      Array.from(ref.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    )
 
     // When `active` changes that typically means our target ref
     // is being inserted into the DOM, so we need to update the focusable elements.
@@ -33,27 +36,18 @@ export const useFocusLock = ({ ref, active = true }: UseFocusLock) => {
   }, [active])
 
   // Set initial focusable elements on mount
-  useEffect(() => {
-    // Wait for the next tick to ensure focusable elements are in the DOM
-    const timeout = setTimeout(() => {
-      updateFocusableEls()
-    }, 0)
-
-    return () => {
-      clearTimeout(timeout)
-    }
-  }, [updateFocusableEls])
+  useEffect(updateFocusableEls, [updateFocusableEls])
 
   const skipUpdateFocusRef = useRef(false)
 
-  const handleMutate = useCallback(
-    (mutations: MutationRecord[]) => {
+  // Detects when DOM changes and updates focusable elements
+  useMutationObserver({
+    ref,
+    onMutate: (mutations) => {
       // Check to see if any of the mutations has either added or removed nodes
       const hasMeaningfullyMutated = mutations.some((mutation) => {
         return (
-          mutation.addedNodes.length > 0 ||
-          mutation.removedNodes.length > 0 ||
-          mutation.attributeName === "disabled"
+          mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0
         )
       })
 
@@ -62,14 +56,6 @@ export const useFocusLock = ({ ref, active = true }: UseFocusLock) => {
         updateFocusableEls()
       }
     },
-    [updateFocusableEls]
-  )
-
-  // Detects when DOM changes and updates focusable elements
-  useMutationObserver({
-    ref,
-    onMutate: handleMutate,
-    options: MUTATION_OBSERVER_OPTIONS,
   })
 
   const {

--- a/packages/palette/src/utils/useMutationObserver.ts
+++ b/packages/palette/src/utils/useMutationObserver.ts
@@ -9,19 +9,17 @@ type UseMutationObserver = {
   | { element?: HTMLElement | null }
 )
 
-const DEFAULT_OPTIONS = {
-  attributes: true,
-  characterData: true,
-  childList: true,
-  subtree: true,
-}
-
 /**
  * Accepts a ref and calls the `onMutate` callback when mutations are observed.
  */
 export const useMutationObserver = ({
   onMutate,
-  options = DEFAULT_OPTIONS,
+  options = {
+    attributes: true,
+    characterData: true,
+    childList: true,
+    subtree: true,
+  },
   ...rest
 }: UseMutationObserver) => {
   useEffect(() => {
@@ -31,14 +29,15 @@ export const useMutationObserver = ({
 
     const el = "ref" in rest ? rest.ref.current : rest.element
 
-    if (!el) return
-    const observer = new MutationObserver(onMutate)
+    if (el) {
+      const observer = new MutationObserver(onMutate)
 
-    // Start observing the target node for configured mutations
-    observer.observe(el, options)
+      // Start observing the target node for configured mutations
+      observer.observe(el, options)
 
-    return () => {
-      observer.disconnect()
+      return () => {
+        observer.disconnect()
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onMutate, options])

--- a/yarn.lock
+++ b/yarn.lock
@@ -15404,11 +15404,6 @@ synchronous-promise@^2.0.15, synchronous-promise@^2.0.5:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
 
-tabbable@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.1.tgz#40cfead5ed11be49043f04436ef924c8890186a0"
-  integrity sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg==
-
 table@^6.0.9:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"


### PR DESCRIPTION
Reverts artsy/palette#1267

Sigh. It looks like this is manifesting some kind of issue where nothing is focusable. This is sporadic and only surfaced by Integrity. I think I'll just replace this with a library dedicated to focus locking instead of our own thing here.