### PR TITLE
feat(TX-943): update link hover and visited colors

### DIFF
--- a/packages/palette/src/elements/Link/Link.tsx
+++ b/packages/palette/src/elements/Link/Link.tsx
@@ -1,3 +1,4 @@
+import { themeGet } from "@styled-system/theme-get"
 import styled from "styled-components"
 import { color } from "../../helpers"
 import { Color } from "../../Theme"
@@ -6,6 +7,7 @@ import { boxMixin, BoxProps } from "../Box"
 type UnderlineBehaviors = "default" | "hover" | "none"
 
 export interface LinkProps extends BoxProps {
+  visitedColor?: Color
   hoverColor?: Color
   noUnderline?: boolean
   underlineBehavior?: UnderlineBehaviors
@@ -29,17 +31,22 @@ const backwardsCompatCompute = (state: string, props: LinkProps) => {
 /**
  * Basic <a> tag styled with additional LinkProps
  *
- * @deprecated Do not use this component! 
- * Tip: If working on Force, please use RouterLink.  
+ * Tip: If working on Force, please use RouterLink.
  */
 export const Link = styled.a<LinkProps>`
-  color: ${color("black100")};
+  color: inherit;
   transition: color 0.25s;
   text-decoration: ${(props) => backwardsCompatCompute("normal", props)};
   &:hover {
     text-decoration: ${(props) => backwardsCompatCompute("hover", props)};
     color: ${(props) =>
-      props.hoverColor ? color(props.hoverColor) : color("black100")};
+      props.hoverColor ? color(props.hoverColor) : themeGet("colors.blue100")};
+  }
+  &:visited {
+    color: ${(props) =>
+      props.visitedColor
+        ? color(props.visitedColor)
+        : themeGet("colors.blue150")};
   }
   ${boxMixin};
 `


### PR DESCRIPTION
This PR updates the link styles to reflect the new design in [Figma](https://www.figma.com/file/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System?node-id=10105%3A18647&viewport=-2947%2C-4962%2C0.88&t=8CqNEOnea3jWNq5U-0). 

I went through Volt to see if there would be any issues with these changes. I’ve identified a couple of places where links will have a “visited color” when not desired and will update them. 

Once this is done, we can use as={Link} to components in force to get these new styles where needed. 