### PR TITLE
feat(popover): optionally passes actions to popover

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -4,6 +4,8 @@ import { States } from "storybook-states"
 import { Position, POSITION } from "../../utils"
 import { Box } from "../Box"
 import { Button } from "../Button"
+import { Flex } from "../Flex"
+import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 import { Popover, PopoverProps } from "./Popover"
 
@@ -156,6 +158,64 @@ export const ManageFocus = () => {
             {CONTENT}
           </Text>
         }
+      >
+        {({ onVisible, anchorRef }) => {
+          return (
+            <Box textAlign="center">
+              <Button
+                ref={anchorRef}
+                variant="secondaryBlack"
+                size="small"
+                onClick={onVisible}
+              >
+                Click to display popover
+              </Button>
+            </Box>
+          )
+        }}
+      </Popover>
+    </States>
+  )
+}
+
+export const PopoverActions = () => {
+  return (
+    <States<Partial<PopoverProps>> states={[{ visible: true }]}>
+      <Popover
+        placement="bottom"
+        popover={({ onHide, onDismiss }) => {
+          return (
+            <>
+              <Text variant="xs" width={300}>
+                {CONTENT}
+              </Text>
+
+              <Spacer y={2} />
+
+              <Flex>
+                <Button
+                  flex={1}
+                  size="small"
+                  variant="secondaryBlack"
+                  onClick={onHide}
+                >
+                  Hide
+                </Button>
+
+                <Spacer x={1} />
+
+                <Button
+                  flex={1}
+                  size="small"
+                  variant="secondaryBlack"
+                  onClick={onDismiss}
+                >
+                  Dismiss
+                </Button>
+              </Flex>
+            </>
+          )
+        }}
       >
         {({ onVisible, anchorRef }) => {
           return (

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -27,12 +27,14 @@ export interface PopoverActions {
   onVisible(): void
   /** Call to hide popover */
   onHide(): void
+  /** Call to dismiss popover */
+  onDismiss(): void
   /** Pass ref to element you want the popover to be anchored to */
   anchorRef: React.MutableRefObject<HTMLElement>
 }
 
 export interface PopoverProps extends BoxProps {
-  children: ({ anchorRef, onVisible, onHide }: PopoverActions) => JSX.Element
+  children: (actions: PopoverActions) => JSX.Element
   ignoreClickOutside?: boolean
   manageFocus?: boolean
   offset?: number
@@ -43,7 +45,9 @@ export interface PopoverProps extends BoxProps {
   placement?: Position
   /** Display triangular pointer back to anchor node */
   pointer?: boolean
-  popover: React.ReactNode
+  popover:
+    | ((actions: Omit<PopoverActions, "anchorRef">) => JSX.Element)
+    | React.ReactNode
   variant?: PopoverVariant
   /** Initial default visibility */
   visible?: boolean
@@ -141,7 +145,12 @@ export const Popover: React.FC<PopoverProps> = ({
 
   return (
     <>
-      {children({ anchorRef: anchorRef as any, onVisible, onHide })}
+      {children({
+        anchorRef: anchorRef as any,
+        onVisible,
+        onHide: handleHide,
+        onDismiss: handleDismiss,
+      })}
 
       {visible &&
         createPortal(
@@ -180,7 +189,13 @@ export const Popover: React.FC<PopoverProps> = ({
               zIndex={1}
               {...rest}
             >
-              {popover}
+              {typeof popover === "function"
+                ? popover({
+                    onVisible,
+                    onHide: handleHide,
+                    onDismiss: handleDismiss,
+                  })
+                : popover}
             </Panel>
           </Tip>
         )}


### PR DESCRIPTION
Supports adding buttons to dismiss popovers from inside themselves. As needed for progressive onboarding.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@29.1.0-canary.1272.26566.0
  npm install @artsy/palette@30.1.0-canary.1272.26566.0
  # or 
  yarn add @artsy/palette-charts@29.1.0-canary.1272.26566.0
  yarn add @artsy/palette@30.1.0-canary.1272.26566.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
