### PR TITLE
feat: adding header to AutoCompleteInput component

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -77,6 +77,19 @@ export const Default = () => {
             </Box>
           ),
         },
+        {
+          options: [OPTIONS[0], OPTIONS[1]],
+          header: (
+            <Box px={2} py={1} bg="black10">
+              <Text variant="xs">Header</Text>
+            </Box>
+          ),
+          footer: (
+            <Box px={2} py={1} bg="black10">
+              <Text variant="xs">Footer</Text>
+            </Box>
+          ),
+        },
       ]}
     >
       <AutocompleteInput

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -59,6 +59,7 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
   extends Omit<InputProps, "onSelect" | "onSubmit"> {
   defaultValue?: string
   loading?: boolean
+  header?: React.ReactNode
   footer?: React.ReactNode
   /** on <enter> when no option is selected */
   onSubmit?(query: string): void
@@ -80,6 +81,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   defaultValue = "",
   id,
   loading,
+  header,
   footer,
   onSubmit,
   onSelect,
@@ -319,6 +321,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
           role="listbox"
           width={width}
         >
+          {header}
           <AutocompleteInputOptions>
             {optionsWithRefs.map(({ option, ref }, i) => {
               return (


### PR DESCRIPTION
This PR adds `header` props to the `<AutoCompleteInput />` component. 