### PR TITLE
fix(readmore): corrects clickable areas in expanded state

### DIFF
--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -72,7 +72,7 @@ export const CharacterCapWithHtml = () => {
         <hr />
         <p>
           <strong>Lorem ipsum dolor</strong> sit amet consectetur adipisicing
-          elit. Ducimus eligendi obcaecati voluptate{" "}
+          elit. Ducimus eligendi obcaecati voluptate
           <em>molestias vero nobis voluptatum</em>, tenetur dolorum assumenda.
         </p>
         <p>
@@ -107,7 +107,7 @@ export const WithCustomizableTypography = () => {
             <hr />
             <p>
               <strong>Lorem ipsum dolor</strong> sit amet consectetur
-              adipisicing elit. Ducimus eligendi obcaecati voluptate{" "}
+              adipisicing elit. Ducimus eligendi obcaecati voluptate
               <em>molestias vero nobis voluptatum</em>, tenetur dolorum
               assumenda.
             </p>
@@ -143,7 +143,7 @@ export const WithCustomizableTypography2 = () => {
             <hr />
             <p>
               <strong>Lorem ipsum dolor</strong> sit amet consectetur
-              adipisicing elit. Ducimus eligendi obcaecati voluptate{" "}
+              adipisicing elit. Ducimus eligendi obcaecati voluptate
               <em>molestias vero nobis voluptatum</em>, tenetur dolorum
               assumenda.
             </p>

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -1,47 +1,9 @@
 import React, { useState } from "react"
 import styled from "styled-components"
 import truncate from "trunc-html"
-import { Clickable, ClickableProps } from "../Clickable"
+import { Clickable } from "../Clickable"
 import { Text } from "../Text"
-
-const ReadMoreOrLessLink: React.FC<ClickableProps> = ({
-  children,
-  ...rest
-}) => {
-  return (
-    <>
-      {" "}
-      <Clickable
-        aria-expanded="false"
-        cursor="pointer"
-        textDecoration="underline"
-        {...rest}
-      >
-        <Text variant="xs" fontWeight="bold">
-          {children}
-        </Text>
-      </Clickable>
-    </>
-  )
-}
-
-ReadMoreOrLessLink.displayName = "ReadMoreOrLessLink"
-
-const Container = styled.div<{ isExpanded: boolean }>`
-  cursor: pointer;
-
-  > span {
-    display: ${({ isExpanded }) => (isExpanded ? "block" : "inline")};
-  }
-
-  > span > *:last-child {
-    display: inherit;
-  }
-`
-
-Container.displayName = "Container"
-
-const HTML_TAG_REGEX = /(<([^>]+)>)/gi
+import { Box } from "../Box"
 
 export interface ReadMoreProps {
   content: string
@@ -63,9 +25,8 @@ export const ReadMore: React.FC<ReadMoreProps> = ({
 }) => {
   const [expanded, setExpanded] = useState(!!isExpanded)
 
-  if (typeof expandedHTML !== "string") {
-    return null
-  }
+  if (typeof expandedHTML !== "string") return null
+
   const charCount = expandedHTML.replace(HTML_TAG_REGEX, "").length
 
   const truncatedHTML = truncate(expandedHTML, maxChars).html
@@ -92,16 +53,44 @@ export const ReadMore: React.FC<ReadMoreProps> = ({
   }
 
   return (
-    <Container onClick={handleClick} isExpanded={expanded}>
-      <span
-        dangerouslySetInnerHTML={{
-          __html: expanded ? expandedHTML : truncatedHTML,
-        }}
-      />
+    <Container aria-expanded={expanded}>
+      {expanded ? (
+        <>
+          <Box dangerouslySetInnerHTML={{ __html: expandedHTML }} />
 
-      <ReadMoreOrLessLink>
-        {expanded ? "Read less" : "Read more"}
-      </ReadMoreOrLessLink>
+          <Clickable
+            cursor="pointer"
+            textDecoration="underline"
+            onClick={handleClick}
+          >
+            <Text variant="xs" fontWeight="bold">
+              Read less
+            </Text>
+          </Clickable>
+        </>
+      ) : (
+        <Clickable onClick={handleClick}>
+          <span dangerouslySetInnerHTML={{ __html: truncatedHTML }} />{" "}
+          <Text
+            as="span"
+            variant="xs"
+            fontWeight="bold"
+            style={{ textDecoration: "underline" }}
+          >
+            Read more
+          </Text>
+        </Clickable>
+      )}
     </Container>
   )
 }
+
+const Container = styled.div`
+  > * > span > *:last-child {
+    display: inherit;
+  }
+`
+
+Container.displayName = "Container"
+
+const HTML_TAG_REGEX = /(<([^>]+)>)/gi

--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -33,23 +33,23 @@ describe("ReadMore", () => {
 
   it("Auto expands text that is less than max char count", () => {
     const wrapper = mount(<ReadMore maxChars={100} content={htmlCopy} />)
-    expect(wrapper.find("ReadMoreOrLessLink").length).toEqual(0)
+    expect(wrapper.find("button").length).toEqual(0)
   })
 
   it("changes the button text on click", () => {
     const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
-    expect(wrapper.find("button").text()).toEqual("Read more")
+    expect(wrapper.find("button").text()).toContain("Read more")
     wrapper.find("button").simulate("click")
     expect(wrapper.find("button").text()).toEqual("Read less")
     wrapper.find("button").simulate("click")
-    expect(wrapper.find("button").text()).toEqual("Read more")
+    expect(wrapper.find("button").text()).toContain("Read more")
   })
 
   it("does not expand if disabled", () => {
     const wrapper = mount(<ReadMore maxChars={20} content={copy} disabled />)
-    expect(wrapper.find("ReadMoreOrLessLink").length).toBe(1)
-    wrapper.simulate("click")
-    expect(wrapper.find("ReadMoreOrLessLink").length).toBe(1)
+    expect(wrapper.find("button").length).toBe(1)
+    wrapper.find("button").simulate("click")
+    expect(wrapper.find("button").length).toBe(1)
   })
 
   it("calls the click callback when clicked", () => {
@@ -58,7 +58,7 @@ describe("ReadMore", () => {
       <ReadMore maxChars={20} content={copy} onReadMoreClicked={callback} />
     )
     expect(callback).not.toBeCalled()
-    wrapper.simulate("click")
+    wrapper.find("button").simulate("click")
     expect(callback).toBeCalled()
   })
 })


### PR DESCRIPTION
Truncated content frequently features clickable links. The entire surface shouldn't be a button.