### PR TITLE
fix(expandable): better supports multi-line expandable headings

### DIFF
--- a/packages/palette/src/elements/Expandable/Expandable.story.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.story.tsx
@@ -47,6 +47,7 @@ export const Default = () => {
             </div>
           ),
         },
+        { label: "Lorem ipsum dolor sit amet consectetur adipisicing elit." },
       ]}
     >
       <Expandable label="Example" maxWidth={350}>

--- a/packages/palette/src/elements/Expandable/Expandable.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.tsx
@@ -45,13 +45,14 @@ export const Expandable: React.FC<ExpandableProps> = ({
         justifyContent="space-between"
         borderTop="1px solid"
         borderColor={borderColor}
-        pt={1}
+        pt={2}
+        pb={1}
         disabled={disabled}
         aria-expanded={expanded}
         onClick={handleClick}
         {...clickableProps}
       >
-        <Flex flex={1} minHeight={40} display="flex" alignItems="center">
+        <Flex flex={1} display="flex" alignItems="center">
           {isText(label) ? <Text variant="sm-display">{label}</Text> : label}
         </Flex>
 


### PR DESCRIPTION
Discovered a replication of [the `Expandable` inside of Force](https://github.com/artsy/force/blob/df14d993fdc5859d9dcc6cde5a64c5c8152ca249/src/Components/Artwork/SidebarExpandable.tsx#L22). After chatting with @mdole it seems it was added because this implementation didn't anticipate multi-line labels. That's all — this PR changes from `minHeight` to using top/bottom padding values, which better expresses the intent behind the Figma mock ups.