### PR TITLE
feat(box): supports gap

### DIFF
--- a/packages/palette/src/elements/Box/Box.story.tsx
+++ b/packages/palette/src/elements/Box/Box.story.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { States } from "storybook-states"
+import { Box, BoxProps } from "../Box"
+
+export default {
+  title: "Components/Box",
+}
+
+export const Stack = () => {
+  return (
+    <States<BoxProps> states={[{}, { gap: 1 }, { gap: 2 }, { gap: [2, 4] }]}>
+      <Box display="flex" flexDirection="column">
+        <Box bg="yellow100">1</Box>
+        <Box bg="yellow100">2</Box>
+        <Box bg="yellow100">3</Box>
+        <Box bg="yellow100">4</Box>
+        <Box bg="yellow100">5</Box>
+        <Box bg="yellow100">6</Box>
+      </Box>
+    </States>
+  )
+}

--- a/packages/palette/src/elements/Box/Box.tsx
+++ b/packages/palette/src/elements/Box/Box.tsx
@@ -15,12 +15,21 @@ import {
   LayoutProps,
   position,
   PositionProps,
+  ResponsiveValue,
   space,
   SpaceProps,
+  system,
   textAlign,
   TextAlignProps,
 } from "styled-system"
 import { splitProps } from "../../utils/splitProps"
+
+const gap = system({
+  gap: {
+    property: "gap",
+    scale: "space",
+  },
+})
 
 export interface BoxProps
   extends BackgroundProps,
@@ -31,7 +40,9 @@ export interface BoxProps
     LayoutProps,
     PositionProps,
     SpaceProps,
-    TextAlignProps {}
+    TextAlignProps {
+  gap?: ResponsiveValue<string | number>
+}
 
 /**
  * All the system functions for Box
@@ -45,7 +56,8 @@ export const boxMixin = compose(
   layout,
   position,
   space,
-  textAlign
+  textAlign,
+  gap
 )
 
 /**


### PR DESCRIPTION
Due to conditional rendering in the artwork sidebar, proper support for `gap` would go a long way. This lets us implement a `Stack` and avoid problems with conditional rendering on `<Join separator={<Spacer y={1} />}>`

![](https://static.damonzucconi.com/_capture/TA6qyjwf.png)