### PR TITLE
feat: disabling scrolling behavior for AutocompleteInput

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -90,6 +90,17 @@ export const Default = () => {
             </Box>
           ),
         },
+        {
+          options: [
+            ...OPTIONS,
+            ...OPTIONS.map((option) => ({
+              ...option,
+              text: `Another ${option.text}`,
+              value: `another-${option.value}`,
+            })),
+          ],
+          fullHeight: true,
+        },
       ]}
     >
       <AutocompleteInput

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -75,6 +75,8 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
     i: number
   ): React.ReactElement<any, string | React.JSXElementConstructor<any>>
   options: T[]
+  /** Pass "true" to avoid scrolling behavior */
+  fullHeight?: boolean
 }
 
 /** AutocompleteInput */
@@ -93,6 +95,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   height,
   renderOption = (option) => <AutocompleteInputOptionLabel {...option} />,
   options,
+  fullHeight,
   ...rest
 }: AutocompleteInputProps<T>) => {
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -323,7 +326,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
           width={width}
         >
           {header}
-          <AutocompleteInputOptions>
+          <AutocompleteInputOptions fullHeight={fullHeight}>
             {optionsWithRefs.map(({ option, ref }, i) => {
               return (
                 <AutocompleteInputOption
@@ -370,9 +373,13 @@ const AutocompleteInputDropdown = styled(Box)`
   z-index: 1;
 `
 
-const AutocompleteInputOptions = styled(Box)`
+interface AutocompleteInputOptionProps {
+  fullHeight?: boolean
+}
+
+const AutocompleteInputOptions = styled(Box)<AutocompleteInputOptionProps>`
   /* 308 = Roughly, 5.5 default sized options  */
-  max-height: 308px;
+  max-height: ${(props) => (props.fullHeight === true ? "none" : "308px")};
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 `


### PR DESCRIPTION
## Why we need it

We are building a new search dropdown based on `AutocompleteInput`. Currently all options do not fit into the options container, we want to change it.

![Screenshot 2023-04-28 at 15 58 01](https://user-images.githubusercontent.com/3934579/235168170-b08d014c-ab95-4730-a032-69a7e3e772ec.png)

## Demo

https://user-images.githubusercontent.com/3934579/235168192-4e968602-a029-4b9c-81b9-ffa9db446ba4.mp4
