### PR TITLE
fix(range): removes labelled tuple for time being

### DIFF
--- a/packages/palette/src/elements/Range/Range.tsx
+++ b/packages/palette/src/elements/Range/Range.tsx
@@ -16,7 +16,7 @@ export interface RangeProps extends BoxProps {
   max: number
   step: number
   value?: number[]
-  onChange?: (range: [min: number, max: number]) => void
+  onChange?: (range: [number, number]) => void
 }
 
 export const Range: React.FC<RangeProps> = ({


### PR DESCRIPTION
Not a super critical piece of typing, this is a TS 4.0 feature that Volt doesn't have yet and it's causing some issues with the upgrade.