### PR TITLE
Fixes Types of property 'maxHeight' are incompatible for AutocompleteInput

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -109,7 +109,7 @@ export const Default = () => {
               <Text variant="xs">Footer</Text>
             </Box>
           ),
-          maxHeight: "700px",
+          dropdownMaxHeight: "700px",
         },
       ]}
     >

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -75,7 +75,7 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
     i: number
   ): React.ReactElement<any, string | React.JSXElementConstructor<any>>
   options: T[]
-  maxHeight?: string | number
+  dropdownMaxHeight?: string | number
 }
 
 /** AutocompleteInput */
@@ -94,7 +94,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   height,
   renderOption = (option) => <AutocompleteInputOptionLabel {...option} />,
   options,
-  maxHeight,
+  dropdownMaxHeight,
   ...rest
 }: AutocompleteInputProps<T>) => {
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -282,9 +282,12 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
 
   const getMaxHeight = () => {
     /* 308 = Roughly, 5.5 default sized options  */
-    if (!maxHeight) return "308px"
+    if (!dropdownMaxHeight) return "308px"
 
-    const value = typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight
+    const value =
+      typeof dropdownMaxHeight === "number"
+        ? `${dropdownMaxHeight}px`
+        : dropdownMaxHeight
 
     const headerAndFooterHeight =
       (headerRef?.current?.clientHeight ?? 0) +


### PR DESCRIPTION
Follow-up for: https://github.com/artsy/palette/pull/1287

Previous PR caused an issue:

![Screenshot 2023-05-04 at 15 56 15](https://user-images.githubusercontent.com/3934579/236230700-b1d4bb03-58b0-4ae1-ace4-df6f04fbc54c.png)
