### PR TITLE
feat(NX-3251): add drawer element

### DIFF
--- a/packages/palette/src/elements/Drawer/Drawer.story.tsx
+++ b/packages/palette/src/elements/Drawer/Drawer.story.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import { Drawer } from "./Drawer"
+import { DrawerProvider } from "./DrawerProvider"
+import { useDrawer } from "./useDrawer"
+import { Flex } from "../Flex"
+import { Button } from "../Button"
+
+export default {
+  title: "Components/Drawer",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <DrawerProvider>
+        <Story />
+      </DrawerProvider>
+    ),
+  ],
+}
+
+const Layout: React.FC = ({ children }) => {
+  const { toggle } = useDrawer()
+
+  return (
+    <>
+      {children}
+
+      <Flex width="100%" height="100%" flexDirection={["column", "row"]}>
+        <Flex flex={1} />
+        <Flex flex={2} flexDirection="column">
+          <Button size="small" onClick={toggle}>
+            Open Drawer
+          </Button>
+        </Flex>
+        <Flex flex={1} />
+      </Flex>
+    </>
+  )
+}
+
+const Content = () => {
+  const { toggle } = useDrawer()
+
+  return (
+    <Flex justifyContent="center" py={2}>
+      <Button size="small" onClick={toggle}>
+        Close Drawer
+      </Button>
+    </Flex>
+  )
+}
+
+export const Default = () => {
+  return (
+    <Layout>
+      <Drawer>
+        <Content />
+      </Drawer>
+    </Layout>
+  )
+}
+
+export const Left = () => {
+  return (
+    <Layout>
+      <Drawer anchor="left">
+        <Content />
+      </Drawer>
+    </Layout>
+  )
+}

--- a/packages/palette/src/elements/Drawer/Drawer.tsx
+++ b/packages/palette/src/elements/Drawer/Drawer.tsx
@@ -1,0 +1,98 @@
+import React, { FC } from "react"
+import { Box, Flex, breakpoints } from "@artsy/palette"
+import styled, { css } from "styled-components"
+import { zIndex } from "styled-system"
+import { useDrawer } from "./useDrawer"
+
+export interface DrawerProps {
+  anchor?: "left" | "right"
+  flexContent?: number
+  flexOverlay?: number
+}
+
+export const Drawer: FC<DrawerProps> = ({
+  children,
+  anchor = "right",
+  flexContent = 1,
+  flexOverlay = 3,
+}) => {
+  const { isOpen, toggle } = useDrawer()
+  const activeClass = isOpen ? "active" : ""
+
+  return (
+    <Container
+      position="fixed"
+      zIndex={9999}
+      className={activeClass}
+      anchor={anchor}
+      isOpen={isOpen}
+    >
+      <Box
+        flex={[1, flexContent]}
+        height="100%"
+        backgroundColor="white100"
+        overflowY="scroll"
+        className={activeClass}
+      >
+        {children}
+      </Box>
+
+      <Overlay
+        backgroundColor="black100"
+        height="100%"
+        display={["none", "flex"]}
+        flex={flexOverlay}
+        onClick={toggle}
+        className={activeClass}
+        data-testid="drawer-overlay"
+      />
+    </Container>
+  )
+}
+
+const Container = styled(Flex)<DrawerProps & { isOpen: boolean }>`
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(
+    0.075,
+    0.82,
+    0.165,
+    1
+  ); /* easeOutCirc */
+  align-items: center;
+  justify-content: center;
+  ${zIndex}
+
+  ${(props) => {
+    return css`
+      transform: translateX(${props.anchor === "left" ? -100 : 100}%);
+      flex-direction: ${props.anchor === "left" ? "row" : "row-reverse"};
+      transition-duration: ${props.isOpen ? "300ms" : "6000ms"};
+      transition-delay: ${props.isOpen ? 0 : 100}ms;
+
+      /* If the screen width is not too big a shorter delay is better */
+      @media (max-width: ${breakpoints.sm}) {
+        transition-duration: ${props.isOpen ? "300ms" : "600ms"};
+      }
+    `
+  }}
+
+  &.active {
+    transform: translateX(0);
+  }
+`
+
+const Overlay = styled(Box)`
+  opacity: 0;
+  transition: opacity 50ms ease;
+  pointer-events: none;
+
+  &.active {
+    opacity: 0.5;
+    pointer-events: auto;
+    transition: opacity 300ms ease 200ms;
+  }
+`

--- a/packages/palette/src/elements/Drawer/DrawerProvider.tsx
+++ b/packages/palette/src/elements/Drawer/DrawerProvider.tsx
@@ -1,0 +1,29 @@
+import React, { FC, useCallback, useState, createContext } from "react"
+
+export const DrawerContext = createContext<{
+  isOpen: boolean
+  toggle: () => void
+  close: () => void
+}>({
+  isOpen: false,
+  toggle: () => {
+    // NOOP
+  },
+  close: () => {
+    // NOOP
+  },
+})
+
+export const DrawerProvider: FC = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+
+  const close = useCallback(() => setIsOpen(false), [])
+
+  return (
+    <DrawerContext.Provider value={{ isOpen, toggle, close }}>
+      {children}
+    </DrawerContext.Provider>
+  )
+}

--- a/packages/palette/src/elements/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/palette/src/elements/Drawer/__tests__/Drawer.test.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { mount } from "enzyme"
+import { Drawer } from "../Drawer"
+import { DrawerProvider } from "../DrawerProvider"
+import { Button } from "../../Button"
+import { Text } from "../../Text"
+import { useDrawer } from "../useDrawer"
+
+const Provider = ({ children }) => {
+  return <DrawerProvider>{children}</DrawerProvider>
+}
+
+const DrawerContent: React.FC = () => {
+  const { toggle } = useDrawer()
+
+  return (
+    <>
+      <Button onClick={() => toggle()}>Open</Button>
+      <Drawer>
+        <Text>Drawer Content</Text>
+      </Drawer>
+    </>
+  )
+}
+
+describe("Drawer", () => {
+  it("renders the drawer content when the open button is clicked", () => {
+    const wrapper = mount(
+      <Provider>
+        <DrawerContent />
+      </Provider>
+    )
+
+    expect(wrapper.find(Drawer).childAt(0).prop("isOpen")).toBe(false)
+
+    wrapper.find(Button).simulate("click")
+
+    expect(wrapper.find(Drawer).childAt(0).prop("isOpen")).toBe(true)
+  })
+
+  it("hides the drawer when the overlay is clicked", () => {
+    const wrapper = mount(
+      <Provider>
+        <DrawerContent />
+      </Provider>
+    )
+
+    wrapper.find("Button").simulate("click")
+    expect(wrapper.find(Drawer).childAt(0).prop("isOpen")).toBe(true)
+
+    wrapper.find("[data-testid='drawer-overlay']").first().simulate("click")
+    expect(wrapper.find(Drawer).childAt(0).prop("isOpen")).toBe(false)
+  })
+})

--- a/packages/palette/src/elements/Drawer/index.tsx
+++ b/packages/palette/src/elements/Drawer/index.tsx
@@ -1,0 +1,3 @@
+export * from "./Drawer"
+export * from "./DrawerProvider"
+export * from "./useDrawer"

--- a/packages/palette/src/elements/Drawer/useDrawer.ts
+++ b/packages/palette/src/elements/Drawer/useDrawer.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react"
+import { DrawerContext } from "./DrawerProvider"
+
+export const useDrawer = () => {
+  const { isOpen, toggle } = useContext(DrawerContext)
+
+  return { isOpen, toggle }
+}


### PR DESCRIPTION
Related also to https://github.com/artsy/volt-v2/pull/424 and [NX-3251]

This PR creates a drawer element following some specs we used in upcoming features that the NX team is working on.

The idea here is based on the concept of having a provider with a hook linked to toggle the Drawer on/off. Since we don't have any specs somethings in this PR we can make them flexible once we have the official specs for the Drawer, like the flex of the Overlay and Drawer Content.

Desktop

https://github.com/artsy/palette/assets/15792853/d0e0cd80-f970-4c2d-8061-3d9fbc68964e

Mobile

https://github.com/artsy/palette/assets/15792853/8adb3f67-ca71-44f8-9414-73d2e1ae89d7

