### PR TITLE
fix(autocompleteinput): adjusts height when filtering results

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -175,3 +175,75 @@ export const Demo = () => {
     />
   )
 }
+
+const CITIES = [
+  { text: "New York", value: "new-york" },
+  { text: "Los Angeles", value: "los-angeles" },
+  { text: "London", value: "london" },
+  { text: "Berlin", value: "berlin" },
+  { text: "Paris", value: "paris" },
+  { text: "Rome", value: "rome" },
+  { text: "Madrid", value: "madrid" },
+  { text: "Barcelona", value: "barcelona" },
+  { text: "Amsterdam", value: "amsterdam" },
+  { text: "Brussels", value: "brussels" },
+  { text: "Copenhagen", value: "copenhagen" },
+  { text: "Dublin", value: "dublin" },
+  { text: "Florence", value: "florence" },
+  { text: "Geneva", value: "geneva" },
+  { text: "Helsinki", value: "helsinki" },
+  { text: "Hong Kong", value: "hong-kong" },
+  { text: "Lisbon", value: "lisbon" },
+  { text: "Milan", value: "milan" },
+  { text: "Monaco", value: "monaco" },
+  { text: "Moscow", value: "moscow" },
+  { text: "Munich", value: "munich" },
+  { text: "New Delhi", value: "new-delhi" },
+  { text: "Oslo", value: "oslo" },
+  { text: "Prague", value: "prague" },
+  { text: "Rio de Janeiro", value: "rio-de-janeiro" },
+  { text: "San Francisco", value: "san-francisco" },
+  { text: "São Paulo", value: "sao-paulo" },
+  { text: "Seoul", value: "seoul" },
+  { text: "Shanghai", value: "shanghai" },
+  { text: "Singapore", value: "singapore" },
+  { text: "Stockholm", value: "stockholm" },
+  { text: "Sydney", value: "sydney" },
+  { text: "Taipei", value: "taipei" },
+  { text: "Tokyo", value: "tokyo" },
+  { text: "Toronto", value: "toronto" },
+  { text: "Venice", value: "venice" },
+  { text: "Vienna", value: "vienna" },
+  { text: "Warsaw", value: "warsaw" },
+  { text: "Zurich", value: "zurich" },
+]
+
+export const FilterDemo = () => {
+  const [query, setQuery] = useState("")
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value)
+  }
+
+  return (
+    <Box
+      display="flex"
+      height="150vh"
+      width="100%"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <AutocompleteInput
+        width={["75%", "50%"]}
+        placeholder="Begin typing..."
+        options={CITIES.filter((option) => {
+          return option.text.toLowerCase().includes(query.toLowerCase())
+        })}
+        onChange={handleChange}
+        onSelect={action("onSelect")}
+        onSubmit={action("onSubmit")}
+        onClose={action("onClose")}
+      />
+    </Box>
+  )
+}

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -22,6 +22,7 @@ import { LabeledInput } from "../LabeledInput"
 import { VisuallyHidden } from "../VisuallyHidden"
 import { AutocompleteInputOption } from "./AutocompleteInputOption"
 import { AutocompleteInputOptionLabel } from "./AutocompleteInputOptionLabel"
+import { ResponsiveValue } from "styled-system"
 
 export interface AutocompleteFooterActions {
   /** Call to close dropdown */
@@ -82,7 +83,7 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
     i: number
   ): React.ReactElement<any, string | React.JSXElementConstructor<any>>
   options: T[]
-  dropdownMaxHeight?: string | number
+  dropdownMaxHeight?: ResponsiveValue<string | number>
 }
 
 /** AutocompleteInput */
@@ -101,7 +102,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   height,
   renderOption = (option) => <AutocompleteInputOptionLabel {...option} />,
   options,
-  dropdownMaxHeight,
+  dropdownMaxHeight = 308, // 308 = roughly 5.5 options
   ...rest
 }: AutocompleteInputProps<T>) => {
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -161,9 +162,11 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   }, [reset, state.query])
 
   const { anchorRef, tooltipRef } = usePosition({
+    key: options.length,
     position: "bottom",
     offset: 10,
     active: isDropdownVisible,
+    clamp: false,
   })
 
   const { width } = useWidthOf({ ref: anchorRef })
@@ -291,24 +294,6 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   // Option that is being hovered or keyed into
   const staged = options[index]
 
-  const getMaxHeight = () => {
-    /* 308 = Roughly, 5.5 default sized options  */
-    if (!dropdownMaxHeight) return "308px"
-
-    const value =
-      typeof dropdownMaxHeight === "number"
-        ? `${dropdownMaxHeight}px`
-        : dropdownMaxHeight
-
-    const headerAndFooterHeight =
-      (headerRef?.current?.clientHeight ?? 0) +
-      (footerRef?.current?.clientHeight ?? 0)
-
-    return `calc(${value} - ${headerAndFooterHeight}px)`
-  }
-
-  const inputOptionsMaxHeight = getMaxHeight()
-
   return (
     <Box
       ref={composeRefs(containerRef, containsFocusRef) as any}
@@ -356,7 +341,8 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
           width={width}
         >
           <div ref={headerRef}>{header}</div>
-          <AutocompleteInputOptions maxHeight={inputOptionsMaxHeight}>
+
+          <AutocompleteInputOptions maxHeight={dropdownMaxHeight}>
             {optionsWithRefs.map(({ option, ref }, i) => {
               return (
                 <AutocompleteInputOption

--- a/packages/palette/src/utils/__tests__/usePosition.test.ts
+++ b/packages/palette/src/utils/__tests__/usePosition.test.ts
@@ -41,7 +41,13 @@ describe("placeTooltip", () => {
       left: 0,
     } as DOMRect
 
-    placeTooltip(anchor, tooltip, "top", 0, boundaryRect)
+    placeTooltip({
+      anchor,
+      tooltip,
+      position: "top",
+      offset: 0,
+      boundaryRect,
+    })
 
     expect(tooltip.style.display).toEqual("block")
     expect(tooltip.style.transform).toEqual("translate(150px, 0px)")
@@ -112,12 +118,12 @@ describe("shouldFlip", () => {
   it("returns false when safe", () => {
     expect(
       positions.map((position) =>
-        shouldFlip(
-          { x: 0, y: 0 },
+        shouldFlip({
+          targetPosition: { x: 0, y: 0 },
           position,
-          { top: 0, right: 500, bottom: 600, left: 0 },
-          { width: 100, height: 100 }
-        )
+          boundaryRect: { top: 0, right: 500, bottom: 600, left: 0 },
+          tooltipRect: { width: 100, height: 100 },
+        })
       )
     ).toEqual([
       false,
@@ -138,12 +144,12 @@ describe("shouldFlip", () => {
   it("returns true when at page boundaries", () => {
     expect(
       positions.map((position) =>
-        shouldFlip(
-          { x: 401, y: 501 },
+        shouldFlip({
+          targetPosition: { x: 401, y: 501 },
           position,
-          { top: 0, right: 500, bottom: 600, left: 0 },
-          { width: 100, height: 100 }
-        )
+          boundaryRect: { top: 0, right: 500, bottom: 600, left: 0 },
+          tooltipRect: { width: 100, height: 100 },
+        })
       )
     ).toEqual([
       false,


### PR DESCRIPTION
This addresses an issue that @MrSltun brought up wherein the new phone number input wherein filtering results wouldn't change the dropdown anchor point; so if the dropdown was flipped so that results were above it, filtering them would leave the dropdown anchored to the top.

Edit: I went with a simpler solution for heights: it appears that generally for the combobox pattern, adjusting the drawer size isn't necessarily desirable. Instead I've added support for responsive props and simplified the code somewhat.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@32.1.1-canary.1298.27720.0
  npm install @artsy/palette@33.1.1-canary.1298.27720.0
  # or 
  yarn add @artsy/palette-charts@32.1.1-canary.1298.27720.0
  yarn add @artsy/palette@33.1.1-canary.1298.27720.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
