### PR TITLE
fix(autocomplete): improves focus management for pointer devices

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -3,7 +3,11 @@ import React, { useState } from "react"
 import { States } from "storybook-states"
 import { Box } from "../Box"
 import { Text } from "../Text"
-import { AutocompleteInput, AutocompleteInputProps } from "./AutocompleteInput"
+import {
+  AutocompleteInput,
+  AutocompleteInputOptionType,
+  AutocompleteInputProps,
+} from "./AutocompleteInput"
 import { Clickable } from "../Clickable"
 
 export default {
@@ -220,9 +224,18 @@ const CITIES = [
 
 export const FilterDemo = () => {
   const [query, setQuery] = useState("")
+  const [selection, setSelection] = useState("")
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(event.target.value)
+  }
+
+  const handleSelect = (option: AutocompleteInputOptionType) => {
+    setSelection(JSON.stringify(option))
+  }
+
+  const handleClear = () => {
+    setQuery("")
   }
 
   return (
@@ -232,6 +245,8 @@ export const FilterDemo = () => {
       width="100%"
       alignItems="center"
       justifyContent="center"
+      flexDirection="column"
+      gap={2}
     >
       <AutocompleteInput
         width={["75%", "50%"]}
@@ -240,10 +255,15 @@ export const FilterDemo = () => {
           return option.text.toLowerCase().includes(query.toLowerCase())
         })}
         onChange={handleChange}
-        onSelect={action("onSelect")}
+        onSelect={handleSelect}
+        onClear={handleClear}
         onSubmit={action("onSubmit")}
         onClose={action("onClose")}
       />
+
+      <Text variant="xs">
+        Selected: {selection ? selection : "Nothing Yet"}
+      </Text>
     </Box>
   )
 }


### PR DESCRIPTION
Closes [GRO-1720](https://artsyproduct.atlassian.net/browse/GRO-1720)

A bit unintuitive but, to summarize:

When we click something in the header that isn't a button or link, the click will propagate down to the body and so focus leaves this element. Previously we were using that as an indication that the drawer should be closed. So what we do now to work around this is that on mouse down: flip a flag, and mouse up: reset it. This prevents the element from closing but we _still_ want to close it on actual clicks outside, so we use `useClickOutside` to handle those. Otherwise if you move focus out of the element by tabbing, we still close.

[GRO-1720]: https://artsyproduct.atlassian.net/browse/GRO-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ