### PR TITLE
fix(modaldialog): corrects padding with header

### DIFF
--- a/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
@@ -80,7 +80,11 @@ export const ModalDialogContent: React.FC<ModalDialogContentProps> = ({
             </Close>
           </Flex>
 
-          {header && <Box p={2}>{header}</Box>}
+          {header && (
+            <Box px={2} pb={2}>
+              {header}
+            </Box>
+          )}
         </Flex>
 
         <Box


### PR DESCRIPTION
BREAKING CHANGE: Removes top padding. Some workarounds apparently existed in the wild which will have to be removed.

This removes the top padding. I think this prop is a bit misguided to begin with and should probably be completely removed. I'm uncertain what the need for it was. I'm going publish a canary, see if I can remove it completely, otherwise remove the hacks and release as a breaking change.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@33.0.0-canary.1302.28027.0
  npm install @artsy/palette@34.0.0-canary.1302.28027.0
  # or 
  yarn add @artsy/palette-charts@33.0.0-canary.1302.28027.0
  yarn add @artsy/palette@34.0.0-canary.1302.28027.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
