### PR TITLE
feat(autocompleteinput): exposes ref to the underlying input

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions"
-import React, { useState } from "react"
+import React, { useRef, useState } from "react"
 import { States } from "storybook-states"
 import { Box } from "../Box"
 import { Text } from "../Text"
@@ -9,6 +9,8 @@ import {
   AutocompleteInputProps,
 } from "./AutocompleteInput"
 import { Clickable } from "../Clickable"
+import { Flex } from "../Flex"
+import { Button } from "../Button"
 
 export default {
   title: "Components/AutocompleteInput",
@@ -265,5 +267,30 @@ export const FilterDemo = () => {
         Selected: {selection ? selection : "Nothing Yet"}
       </Text>
     </Box>
+  )
+}
+
+export const ProgrammaticFocus = () => {
+  const ref = useRef<HTMLInputElement | null>(null)
+
+  return (
+    <Flex flexDirection="column" gap={2}>
+      <AutocompleteInput
+        forwardRef={ref}
+        width={["75%", "50%"]}
+        placeholder="Begin typing..."
+        options={CITIES}
+      />
+
+      <Button
+        onClick={() => {
+          if (!ref.current) return
+          console.log({ ref })
+          ref.current.focus()
+        }}
+      >
+        Focus input
+      </Button>
+    </Flex>
   )
 }

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -75,6 +75,8 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
   footer?:
     | React.ReactNode
     | ((dropdownActions: AutocompleteFooterActions) => void)
+  /** Ref to the input; workaround generics */
+  forwardRef?: React.Ref<HTMLInputElement>
   /** on <enter> when no option is selected */
   onSubmit?(query: string): void
   /** on <click> or <enter> when an option is selected */
@@ -97,6 +99,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
   dropdownMaxHeight = 308, // 308 = roughly 5.5 options
   flip = true,
   footer,
+  forwardRef: forwardedRef,
   header,
   height,
   id,
@@ -325,7 +328,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
       {...boxProps}
     >
       <LabeledInput
-        ref={composeRefs(inputRef, anchorRef) as any}
+        ref={composeRefs(inputRef, anchorRef, forwardedRef) as any}
         role="combobox"
         aria-expanded={isDropdownVisible}
         aria-autocomplete="list"


### PR DESCRIPTION
Exposes a ref to the input so that we can programmatically focus it (`/` keypress for global search)