### PR TITLE
style(range): fix spurious shadows in mobile Safari

### DIFF
--- a/packages/palette/src/elements/Range/Range.tsx
+++ b/packages/palette/src/elements/Range/Range.tsx
@@ -69,8 +69,8 @@ export const Range: React.FC<RangeProps> = ({
     }
   }, [])
 
-   // Sync local state with value prop
-   useUpdateEffect(() => {
+  // Sync local state with value prop
+  useUpdateEffect(() => {
     setValues(value)
   }, [...value])
 
@@ -114,15 +114,6 @@ export const Range: React.FC<RangeProps> = ({
         style={{ clip: maxRectangle }}
         aria-label={ariaLabels?.[1]}
       />
-
-      {/* Max slider is clipped so position a shadow independent of it */}
-      <Shadow
-        left={remapValue(
-          values[1],
-          { min, max },
-          { min: 0, max: maxWidth - RANGE_HANDLE_SIZE }
-        )}
-      />
     </Track>
   )
 }
@@ -143,18 +134,6 @@ const Track = styled(Flex)`
     margin-top: -1px;
     background-color: ${themeGet("colors.black30")};
   }
-`
-
-const Shadow = styled(Box)`
-  position: absolute;
-  width: ${RANGE_HANDLE_SIZE}px;
-  height: ${RANGE_HANDLE_SIZE}px;
-  top: 50%;
-  margin-top: -${RANGE_HANDLE_SIZE / 2}px;
-  background-color: transparent;
-  pointer-events: none;
-  border-radius: 50%;
-  box-shadow: ${FLAT_SHADOW};
 `
 
 const Selection = styled(Box)`
@@ -180,6 +159,7 @@ const handleStyles = css`
   background-color: ${themeGet("colors.white100")};
   border-radius: 50%;
   border: 1px solid ${themeGet("colors.black10")};
+  box-shadow: ${FLAT_SHADOW};
 `
 
 const Slider = styled.input`
@@ -218,16 +198,6 @@ const Slider = styled.input`
     &::-moz-range-thumb {
       box-shadow: none;
       background-color: ${themeGet("colors.black5")};
-    }
-  }
-
-  &:first-of-type {
-    &::-webkit-slider-thumb {
-      box-shadow: ${FLAT_SHADOW};
-    }
-
-    &::-moz-range-thumb {
-      box-shadow: ${FLAT_SHADOW};
     }
   }
 `


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-282

In a recent QA session for alerts functionality, Onyx noticed a visual glitch in the `Range` component that seems to affect only mobile Safari (😣)


## Before 

Web (left) is fine but mWeb (right) shows an extraneous shadow with a hard, clipped edge.

<img width="667" alt="before" src="https://github.com/artsy/palette/assets/140521/9e5467f9-8702-4b57-ba97-da15d8ac3eee">

## After 

Removing the `first-of-type` modifier and allowing both thumb sliders to get the `FLAT_SHADOW` style makes them consistent

<img width="667" alt="after" src="https://github.com/artsy/palette/assets/140521/a2ce36ca-d081-4276-b416-48fd2f9871f2">

---

After this change, I was concerned that the `Shadow` component placed to coincide with the max slider might need adjusting, but honestly we seem better off without it?

## With `Shadow`

Looks way too heavy, and there is still some clipping apparent.

<img width="763" alt="with Shadow" src="https://github.com/artsy/palette/assets/140521/f11aca4c-932f-4a56-9adf-a7f78ad07681">


## Without `Shadow`

There is _still_ some clipping happening, but it is essentially unnoticeable unless you are zoomed af. (I.e. try to spot it in the **After** screenshot above)

<img width="763" alt="without Shadow" src="https://github.com/artsy/palette/assets/140521/34eef3c1-fb5a-4b7a-a4f2-2e677f91a1d1">

