### PR TITLE
fix(range): prevent min from exactly equaling max

### DIFF
--- a/packages/palette/src/elements/Range/Range.tsx
+++ b/packages/palette/src/elements/Range/Range.tsx
@@ -38,7 +38,7 @@ export const Range: React.FC<RangeProps> = ({
   const handleMinChange = ({
     target: { valueAsNumber: value },
   }: React.ChangeEvent<HTMLInputElement>) => {
-    if (value > values[1]) return
+    if (value > values[1] - step) return
     setValues([value, values[1]])
     onChange?.([value, values[1]])
   }
@@ -46,7 +46,7 @@ export const Range: React.FC<RangeProps> = ({
   const handleMaxChange = ({
     target: { valueAsNumber: value },
   }: React.ChangeEvent<HTMLInputElement>) => {
-    if (value < values[0]) return
+    if (value < values[0] + step) return
     setValues([values[0], value])
     onChange?.([values[0], value])
   }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-362

Addresses an issue where non-sensical artwork alerts are created, with a min value exactly equal to the max value. Apart from being nearly useless as alerts for collectors, this also confuses the data display for partners.

It seems to make sense to fix this at the library level since min=max is probably not terribly useful in any context?

**Bonus**: this brings the behavior in line with the corresponding component in Eigen.

## Before

`min` could exactly equal `max`.

![before-fix gif 5 128](https://github.com/artsy/palette/assets/140521/e2133c3f-1d82-4324-baf9-00ffee993000)

## After

`min` and  `max` are guaranteed to be separated by `step`

![after-fix gif 5 128](https://github.com/artsy/palette/assets/140521/054ad090-5f9c-4ae4-b7e9-083b82e56881)

