### PR TITLE
feat(pills): adds profile and gray variant; removes artist variant

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.story.tsx
+++ b/packages/palette/src/elements/Pill/Pill.story.tsx
@@ -64,10 +64,10 @@ export const Variants = () => {
 export const LinkExample = () => {
   return (
     <Pill
-      variant="artist"
+      variant="profile"
       as="a"
       // TODO: Need a decent way of typing the threaded polymorphic `as` prop
-      // @ts-expect-error  MIGRATE_STRICT_MODE
+      // @ts-expect-error MIGRATE_STRICT_MODE
       href="#example"
     >
       Artist Name
@@ -115,7 +115,7 @@ export const ArtistWithImage = () => {
       ]}
     >
       <Pill
-        variant="artist"
+        variant="profile"
         src={[
           "https://picsum.photos/seed/isa/30/30",
           "https://picsum.photos/seed/isa/60/60",

--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -14,7 +14,7 @@ export const PILL_VARIANT_NAMES = [
   "default",
   "search",
   "filter",
-  "artist",
+  "profile",
   "badge",
 ] as const
 
@@ -49,8 +49,8 @@ export type PillProps = ClickableProps & {
         >
       }
     | {
-        /** `"artist"` pills have an optional `src` */
-        variant?: Extract<PillVariant, "artist">
+        /** `"profile"` pills have an optional `src` */
+        variant?: Extract<PillVariant, "profile">
         /**
          * Optional avatar; 1x or [1x, 2x]
          * Should target 30x30 @1x, 60x60 @2x
@@ -68,12 +68,12 @@ export type PillProps = ClickableProps & {
 /**
  * A Pill is a non-CTA button.
  * It may be used for things like active filters, search states,
- * or to denote an artist entity (possibly in the context of a card).
+ * or to denote an profile entity (possibly in the context of a card).
  */
 export const Pill: React.FC<PillProps> = ({ children, Icon, ...rest }) => {
   return (
     <Container {...rest}>
-      {rest.variant === "artist" && (
+      {rest.variant === "profile" && (
         <Thumbnail
           {...(rest.src
             ? { src: typeof rest.src === "string" ? rest.src : rest.src[0] }
@@ -103,7 +103,7 @@ export const Pill: React.FC<PillProps> = ({ children, Icon, ...rest }) => {
       </Text>
 
       {((rest.variant === "filter" && !rest.disabled) ||
-        (rest.variant === "artist" && rest.selected)) && (
+        (rest.variant === "profile" && rest.selected)) && (
         <CloseIcon fill="currentColor" ml={0.5} width={15} height={15} />
       )}
     </Container>

--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -16,6 +16,7 @@ export const PILL_VARIANT_NAMES = [
   "filter",
   "profile",
   "badge",
+  "gray",
 ] as const
 
 export type PillVariant = typeof PILL_VARIANT_NAMES[number]
@@ -45,7 +46,7 @@ export type PillProps = ClickableProps & {
     | {
         variant?: Extract<
           PillVariant,
-          "default" | "search" | "badge" | "filter"
+          "default" | "search" | "badge" | "filter" | "gray"
         >
       }
     | {

--- a/packages/palette/src/elements/Pill/tokens.ts
+++ b/packages/palette/src/elements/Pill/tokens.ts
@@ -140,28 +140,31 @@ export const PILL_VARIANTS: Record<
     `,
   },
 
-  artist: {
+  profile: {
     ...DEFAULT_STATES,
     default: css`
       border-radius: 25px;
       height: 50px;
       padding: 0 ${themeGet("space.2")} 0 ${themeGet("space.1")};
+      background-color: ${themeGet("colors.black5")};
+      border-color: ${themeGet("colors.black5")};
     `,
     active: css`
-      background-color: ${themeGet("colors.black10")};
-      border-color: ${themeGet("colors.black10")};
+      background-color: ${themeGet("colors.black5")};
+      border-color: ${themeGet("colors.black5")};
       color: ${themeGet("colors.blue100")};
       text-decoration: underline;
     `,
     selected: css`
-      background-color: transparent;
       border-color: ${themeGet("colors.blue100")};
       color: ${themeGet("colors.black100")};
+      background-color: ${themeGet("colors.black5")};
+      border-color: ${themeGet("colors.black5")};
     `,
     disabled: css`
-      background-color: transparent;
-      border-color: ${themeGet("colors.black10")};
-      color: ${themeGet("colors.black60")};
+      background-color: ${themeGet("colors.black5")};
+      border-color: ${themeGet("colors.black5")};
+      color: ${themeGet("colors.black30")};
     `,
   },
 

--- a/packages/palette/src/elements/Pill/tokens.ts
+++ b/packages/palette/src/elements/Pill/tokens.ts
@@ -152,7 +152,7 @@ export const PILL_VARIANTS: Record<
     active: css`
       background-color: ${themeGet("colors.black5")};
       border-color: ${themeGet("colors.black5")};
-      color: ${themeGet("colors.blue100")};
+      color: ${themeGet("colors.black100")};
       text-decoration: underline;
     `,
     selected: css`
@@ -206,5 +206,36 @@ export const PILL_VARIANTS: Record<
       border-color: ${themeGet("colors.blue10")};
       color: ${themeGet("colors.blue100")};
     `,
+  },
+
+  gray: {
+    default: css`
+      border-radius: 15px;
+      height: 30px;
+      padding: 0 15px;
+      background-color: ${themeGet("colors.black10")};
+      border-color: ${themeGet("colors.black10")};
+      color: ${themeGet("colors.black100")};
+    `,
+    hover: css`
+      background-color: ${themeGet("colors.black10")};
+      border-color: ${themeGet("colors.black10")};
+      color: ${themeGet("colors.blue100")};
+      text-decoration: underline;
+    `,
+    focus: css`
+      background-color: ${themeGet("colors.black10")};
+      border-color: ${themeGet("colors.black10")};
+      color: ${themeGet("colors.blue100")};
+      text-decoration: underline;
+    `,
+    active: css`
+      background-color: ${themeGet("colors.black10")};
+      border-color: ${themeGet("colors.black10")};
+      color: ${themeGet("colors.black100")};
+      text-decoration: underline;
+    `,
+    selected: DEFAULT_STATES.selected,
+    disabled: DEFAULT_STATES.disabled,
   },
 }

--- a/packages/palette/src/themes/Themes.story.tsx
+++ b/packages/palette/src/themes/Themes.story.tsx
@@ -472,7 +472,7 @@ export const Components = () => {
                 </Pill>
               </Column>
 
-              {variant !== "artist" && (
+              {variant !== "profile" && (
                 <Column span={3}>
                   <Pill variant={variant} active>
                     Active


### PR DESCRIPTION
![](https://static.damonzucconi.com/_capture/6hmRcccYxUAVRvRe8qff4ZpKvXqOWgcA5iKoUwzc0wBXempLFjUmraszkeHcncv1FvZxt1aeFrh0IymD431kXTNFL12uMuJEjziF.png)

![](https://static.damonzucconi.com/_capture/7RCldht6IU73zibTuMOdYudD0eSlFPeNIS15aSV9ZZrJG5eRc6sLgnEwHxpJY445NEIcPwqJ7PhC6nW1P4SfAg6c1ws7Nq2RHWUc.png)

We can alter these actual styles later if there turns out to be a Figma spec. For now this is fine. Breaking change because we're dropping the `artist` variant.