### PR TITLE
Be defensive when animating Collapse

### DIFF
--- a/packages/palette/src/elements/Collapse/Collapse.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.tsx
@@ -44,7 +44,9 @@ export class Collapse extends React.Component<CollapseProps> {
       this.wrapperRef.style.height = prevHeight
       // wait for a tick before setting goal height to allow transition
       this.wrapperModifyTimeout = setTimeout(() => {
-        this.wrapperRef!.style.height = goalheight + "px"
+        if (this.wrapperRef) {
+          this.wrapperRef.style.height = goalheight + "px"
+        }
       }, 10)
     } else if (!this.props.open && this.wrapperRef.style.height !== "0px") {
       // animate closing
@@ -53,7 +55,9 @@ export class Collapse extends React.Component<CollapseProps> {
       this.wrapperRef.style.height = currentHeight + "px"
       // wait for a tick before setting it to 0 to allow transition
       this.wrapperModifyTimeout = setTimeout(() => {
-        this.wrapperRef!.style.height = "0px"
+        if (this.wrapperRef) {
+          this.wrapperRef.style.height = "0px"
+        }
       }, 10)
     }
   }


### PR DESCRIPTION
I noticed a flaky error happens on Force CI ([example](https://app.circleci.com/pipelines/github/artsy/force/52795/workflows/8bb542a0-ed21-4864-bd46-053663728635/jobs/395284)) sometimes when running tests:

```
TypeError: Cannot read properties of null (reading 'style')

  at style (node_modules/@artsy/palette/src/elements/Collapse/Collapse.tsx:56:26)
```

When running tests individually, this error doesn't happen. My theory is that the callback in `setTimeout` is not finished in the same test and instead is leaked into the subsequent test and fails with the `null` error. Perhaps the element is already gone by then.

This PR makes the callback more defensive. Not really sure how to write a test for this. 😅 