### PR TITLE
fix(EMI-1372): Fix Autofill background issue in the new inputs

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -93,6 +93,7 @@ export const Input: React.ForwardRefExoticComponent<
           {!!title && (
             <StyledLabel prefixOffset={prefixOffset} htmlFor={inputName}>
               {title}
+              <span />
             </StyledLabel>
           )}
 
@@ -213,12 +214,23 @@ const StyledLabel = styled.label<StyledInputProps>`
   top: 50%;
   left: 5px;
   padding: 0 5px;
-  background-color: ${themeGet("colors.white100")};
+  background-color: transparent;
   transform: translateY(-50%);
   transition: 0.25s cubic-bezier(0.64, 0.05, 0.36, 1);
   transition-property: color, transform, padding, font-size;
   font-family: ${themeGet("fonts.sans")};
   pointer-events: none;
+
+  & > span {
+    background-color: ${themeGet("colors.white100")};
+    height: 2px;
+    width: 100%;
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    z-index: -1;
+  }
 
   ${({ prefixOffset }) =>
     !!prefixOffset &&

--- a/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
@@ -257,7 +257,10 @@ export const PhoneInput: React.ForwardRefExoticComponent<
             {...inputProps}
           />
 
-          <StyledLabel htmlFor={inputName}>Phone Number</StyledLabel>
+          <StyledLabel htmlFor={inputName}>
+            Phone Number
+            <span />
+          </StyledLabel>
         </ContainerBox>
 
         {isDropdownVisible && (
@@ -473,11 +476,22 @@ const StyledLabel = styled.label`
   top: 0;
   left: 5px;
   padding: 0 5px;
-  background-color: ${themeGet("colors.white100")};
+  background-color: transparent;
   transform: translateY(-50%);
   transition: color 0.25s;
   font-family: ${themeGet("fonts.sans")};
   pointer-events: none;
   font-size: ${themeGet("textVariants.xs.fontSize")};
   color: ${themeGet("colors.black60")};
+
+  & > span {
+    background-color: ${themeGet("colors.white100")};
+    height: 2px;
+    width: 100%;
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    z-index: -1;
+  }
 `

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -89,7 +89,12 @@ export const Select: ForwardRefExoticComponent<
             })}
           </select>
 
-          {!!title && <StyledLabel htmlFor={id}>{title}</StyledLabel>}
+          {!!title && (
+            <StyledLabel htmlFor={id}>
+              {title}
+              <span />
+            </StyledLabel>
+          )}
         </Container>
 
         {required && !(error && typeof error === "string") && (
@@ -220,6 +225,17 @@ const StyledLabel = styled.label`
   transform: translateY(-50%);
   transition: 0.25s cubic-bezier(0.64, 0.05, 0.36, 1);
   transision-property: color, font-size, transform;
-  background-color: ${themeGet("colors.white100")};
+  background-color: transparent;
   font-family: ${themeGet("fonts.sans")};
+
+  & > span {
+    background-color: ${themeGet("colors.white100")};
+    height: 2px;
+    width: 100%;
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    z-index: -1;
+  }
 `

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -105,7 +105,10 @@ export const TextArea: React.ForwardRefExoticComponent<
           />
 
           {!!title && (
-            <StyledLabel htmlFor={inputProps.name}>{title}</StyledLabel>
+            <StyledLabel htmlFor={inputProps.name}>
+              {title}
+              <span />
+            </StyledLabel>
           )}
         </Box>
 
@@ -210,13 +213,24 @@ const StyledTextArea = styled.textarea<StyledTextAreaProps>`
 `
 const StyledLabel = styled.label`
   position: absolute;
-  top: 24px;
+  top: 25px;
   left: 6px;
   padding: 0 5px;
-  background-color: ${themeGet("colors.white100")};
+  background-color: transparent;
   transform: translateY(-50%);
   transition: 0.25s cubic-bezier(0.64, 0.05, 0.36, 1);
   transition-property: color, transform, padding, font-size;
   font-family: ${themeGet("fonts.sans")};
   pointer-events: none;
+
+  & > span {
+    background-color: ${themeGet("colors.white100")};
+    height: 2px;
+    width: 100%;
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    z-index: -1;
+  }
 `


### PR DESCRIPTION
This PR resolves [EMI-1372]

> [!IMPORTANT]
> This PR will be merged to #1250

## Description

This PR updates the background of the label to not interfere with the autofill feature

> [!NOTE]
> No structural changes were made, only visual ones

## Screenshots & Videos

### Autofill comparison

| Change | Screenshot |
|---|---|
| Before | <img width="705" alt="image" src="https://github.com/artsy/palette/assets/20655703/958989ed-80fd-491a-80f8-0e7418e2bae4"> |
| After |  <img width="705" alt="image" src="https://github.com/artsy/palette/assets/20655703/20da8f14-c00b-4f6f-b643-7d458858f2bd"> | 


### Animation changes
| Before | After |
|---|---|
| <video src="https://github.com/artsy/palette/assets/20655703/9a591f62-7074-43a1-a8d6-d291c7b4801a" /> | <video src="https://github.com/artsy/palette/assets/20655703/b399abc9-e097-4883-a988-748f8a8e0ce6" /> | 

### Changed inputs
| Element | Screenshot |
|---|---|
| Input | <img width="707" alt="image" src="https://github.com/artsy/palette/assets/20655703/3a98b3a4-19d2-4a8c-a4b9-1213502a96f4"> |
| Phone Input | <img width="705" alt="image" src="https://github.com/artsy/palette/assets/20655703/a2200da0-2e4d-4a03-b2fd-350a1b8edad4"> |
| Select | <img width="707" alt="image" src="https://github.com/artsy/palette/assets/20655703/0ffa2040-aa8f-4958-9e1f-fd19877e4652"> |
| TextArea | <img width="706" alt="image" src="https://github.com/artsy/palette/assets/20655703/9e7c7fc3-76ec-4e0c-b167-da60ce1cecd3"> |

