### PR TITLE
chore: add NODE_OPTIONS env var to storybook start script

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -24,7 +24,7 @@
     "type-check": "tsc --noEmit --pretty",
     "type-declarations": "tsc --emitDeclarationOnly",
     "watch": "concurrently --raw --kill-others 'yarn compile -w' 'yarn type-declarations -w'",
-    "storybook": "start-storybook -p 6006 --quiet",
+    "storybook": "export NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006 --quiet",
     "build-storybook": "build-storybook",
     "visual-test": "chromatic test --exit-zero-on-changes --project-token n02zjqmdqq"
   },


### PR DESCRIPTION
The goal of this PR is to make sure that Storybook runs without issues in our dev environments. I added a `NODE_OPTIONS` environment variable set to `--openssl-legacy-provider` in the Storybook start script to make Storybook compatible with Node version 16, addressing a known issue discussed internally. 

Related slack discussion [here](https://artsy.slack.com/archives/CP9P4KR35/p1696351565117019)