### PR TITLE
fix(pill): forwards ref to pill

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.story.tsx
+++ b/packages/palette/src/elements/Pill/Pill.story.tsx
@@ -7,6 +7,7 @@ import { Box } from "../Box"
 import { Join } from "../Join"
 import GraphIcon from "@artsy/icons/GraphIcon"
 import styled from "styled-components"
+import { Popover } from "../Popover"
 
 export default {
   title: "Components/Pill",
@@ -181,5 +182,19 @@ export const ProfileVariant = () => {
     >
       <Pill src="https://picsum.photos/seed/isa/60/60">Isa Genzken</Pill>
     </States>
+  )
+}
+
+export const PillWithPopover = () => {
+  return (
+    <>
+      <Popover placement="bottom" popover={<>Content</>}>
+        {({ anchorRef, onVisible }) => (
+          <Pill ref={anchorRef as any} onClick={() => onVisible()}>
+            Example
+          </Pill>
+        )}
+      </Popover>
+    </>
   )
 }

--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -1,5 +1,5 @@
 import { themeGet } from "@styled-system/theme-get"
-import React from "react"
+import React, { forwardRef } from "react"
 import styled from "styled-components"
 import { css } from "styled-components"
 import CloseIcon from "@artsy/icons/CloseIcon"
@@ -73,12 +73,15 @@ export type PillProps = ClickableProps & {
  * It may be used for things like active filters, search states,
  * or to denote an profile entity (possibly in the context of a card).
  */
-export const Pill: React.FC<PillProps> = ({ children, Icon, ...rest }) => {
+export const Pill = forwardRef<
+  HTMLAnchorElement & HTMLButtonElement,
+  PillProps
+>(({ children, Icon, ...rest }, forwardedRef) => {
   const variant =
     rest.variant === "profile" && rest.compact ? "gray" : rest.variant
 
   return (
-    <Container {...rest} variant={variant}>
+    <Container ref={forwardedRef as any} {...rest} variant={variant}>
       {rest.variant === "profile" && rest.src && !rest.compact && (
         <Thumbnail
           {...(rest.src
@@ -114,7 +117,9 @@ export const Pill: React.FC<PillProps> = ({ children, Icon, ...rest }) => {
       )}
     </Container>
   )
-}
+})
+
+Pill.displayName = "Pill"
 
 Pill.defaultProps = {
   variant: "default",


### PR DESCRIPTION
This passes along the `ref` to `Pill` components so that they may be used with `Popover`.