### PR TITLE
fix(pill): corrects x icon behavior

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -111,7 +111,8 @@ export const Pill = forwardRef<
         )}
       </Text>
 
-      {((rest.variant === "filter" && !rest.disabled) ||
+      {((rest.variant === "gray" && rest.selected) ||
+        (rest.variant === "filter" && rest.selected) ||
         (rest.variant === "profile" && rest.selected)) && (
         <CloseIcon fill="currentColor" ml={0.5} width={15} height={15} />
       )}


### PR DESCRIPTION
The `selected` state can be stacked with the other states. As such the `filter` variant of `Pill` had an idle and selected state which were identical. This corrects that. We also add the x icon to the `gray` variant so that it matches it's larger version.

![](https://static.damonzucconi.com/_capture/BticlpzpYEw1NrqPxOVVYH9sjN0N0nDy1CY9PSzVf0WYG2c7vRi5VSX8QcvidaoVJ32AExV4tWJO6Zuu7ifiG5FFiL3yQkQBYt9W.png)