### PR TITLE
fix(EMI-1373): Fix Select issues with Firefox

### DIFF
--- a/packages/palette/src/elements/Select/Select.story.tsx
+++ b/packages/palette/src/elements/Select/Select.story.tsx
@@ -33,7 +33,7 @@ export const Default = () => {
         { title: "Sort", error: "Something went wrong." },
         { title: "Sort", disabled: true },
         { title: "Sort", required: true },
-        { selected: "lastValue" },
+        { selected: "year" },
         { title: "Pick something", required: true, id: "pick" },
         { title: "Pick something", description: "This matters a lot." },
       ]}

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -1,11 +1,17 @@
+import THEME from "@artsy/palette-tokens"
 import { themeGet } from "@styled-system/theme-get"
-import React, { forwardRef, ForwardRefExoticComponent, Ref } from "react"
+import React, {
+  forwardRef,
+  ForwardRefExoticComponent,
+  Ref,
+  useState,
+} from "react"
 import styled, { css } from "styled-components"
+import { RequiredField } from "../../shared/RequiredField"
 import { Box, BoxProps, splitBoxProps } from "../Box"
 import { Text } from "../Text"
-import { SELECT_STATES } from "./tokens"
 import { Tooltip } from "../Tooltip"
-import { RequiredField } from "../../shared/RequiredField"
+import { SELECT_STATES } from "./tokens"
 
 export interface Option {
   value: string
@@ -51,6 +57,50 @@ export const Select: ForwardRefExoticComponent<
     ref
   ) => {
     const [boxProps, selectProps] = splitBoxProps(rest)
+    // due to :has not available in Firefox yet, we need to add the styles to the label using JS
+    const [selectedOption, setSelectedOption] = useState(selected)
+    const [isFocused, setIsFocused] = useState(false)
+    const [isHovered, setIsHovered] = useState(false)
+
+    // if there is no selected option (or is it empty)
+    // and the select is not focused
+    // and the title prop is present
+    const selectStyle = !isFocused &&
+      !selectedOption &&
+      !!title && {
+        color: "transparent",
+      }
+
+    // if there is a selected option
+    // and the select is not focused
+    // and the title prop is present
+    const labelSpanStyle = !isFocused &&
+      !!selectedOption &&
+      !!title && {
+        height: 2,
+        top: "50%",
+      }
+
+    // if the selected option is not empty
+    const labelStyleSelected = selectedOption && {
+      transform: "translateY(-150%)",
+      fontSize: THEME.textVariants.xs.fontSize,
+    }
+
+    // if the select is focused and there is no selected option (or it is empty)
+    const labelStyleFocused = isFocused &&
+      !selectedOption && {
+        textDecoration: "underline",
+      }
+
+    // if the select is hovered and there is no selected option (or it is empty)
+    // and the select is not disabled
+    const labelStyleHovered = isHovered &&
+      !selectedOption &&
+      !disabled && {
+        textDecoration: "underline",
+        color: THEME.colors.blue100,
+      }
 
     return (
       <Box width="100%" {...boxProps}>
@@ -68,6 +118,10 @@ export const Select: ForwardRefExoticComponent<
           error={error!}
           focus={!!focus}
           title={title}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
         >
           <select
             ref={ref as any}
@@ -77,7 +131,9 @@ export const Select: ForwardRefExoticComponent<
             value={selected}
             onChange={(event) => {
               onSelect && onSelect(event.target.value)
+              setSelectedOption(event.target.value)
             }}
+            style={{ ...selectProps.style, ...selectStyle }}
             {...selectProps}
           >
             {options.map(({ value, text }) => {
@@ -90,9 +146,17 @@ export const Select: ForwardRefExoticComponent<
           </select>
 
           {!!title && (
-            <StyledLabel htmlFor={id}>
+            <StyledLabel
+              htmlFor={id}
+              style={{
+                ...labelStyleSelected,
+                ...labelStyleFocused,
+                ...labelStyleHovered,
+              }}
+            >
               {title}
-              <span />
+
+              <span style={{ ...labelSpanStyle }} />
             </StyledLabel>
           )}
         </Container>

--- a/packages/palette/src/elements/Select/tokens.ts
+++ b/packages/palette/src/elements/Select/tokens.ts
@@ -23,6 +23,21 @@ export const SELECT_STATES: Record<State, any> = {
         top: 50%;
       }
     }
+
+    // Firefox polyfill for :has
+    ${({ optionSelected }) =>
+      optionSelected &&
+      css`
+        + label {
+          transform: translateY(-150%);
+          font-size: ${themeGet("textVariants.xs.fontSize")};
+
+          & > span {
+            height: 2px;
+            top: 50%;
+          }
+        }
+      `}
   `,
   focus: css`
     color: ${themeGet("colors.black100")};
@@ -43,6 +58,15 @@ export const SELECT_STATES: Record<State, any> = {
     &:has(option[value=""]:checked) + label {
       text-decoration: underline;
     }
+
+    // Firefox polyfill for :has
+    ${({ optionSelected }) =>
+      !optionSelected &&
+      css`
+        + label {
+          text-decoration: underline;
+        }
+      `}
   `,
   hover: css`
     color: ${themeGet("colors.blue100")};
@@ -57,6 +81,17 @@ export const SELECT_STATES: Record<State, any> = {
       color: ${themeGet("colors.blue100")};
       text-decoration: underline;
     }
+
+    // Firefox polyfill for :has
+    ${({ optionSelected, disabled }) =>
+      !optionSelected &&
+      !disabled &&
+      css`
+        + label {
+          color: ${themeGet("colors.blue100")};
+          text-decoration: underline;
+        }
+      `}
   `,
   completed: css`
     border-color: ${themeGet("colors.black60")};
@@ -75,6 +110,20 @@ export const SELECT_STATES: Record<State, any> = {
         top: 50%;
       }
     }
+
+    // Firefox polyfill for :has
+    ${({ optionSelected }) =>
+      optionSelected &&
+      css`
+        + label {
+          transform: translateY(-150%);
+          font-size: ${themeGet("textVariants.xs.fontSize")};
+    
+          & > span {
+            height: 2px;
+            top: 50%;
+          }
+      `}
   `,
   disabled: css`
     color: ${themeGet("colors.black30")};
@@ -95,6 +144,20 @@ export const SELECT_STATES: Record<State, any> = {
         top: 50%;
       }
     }
+
+    // Firefox polyfill for :has
+    ${({ optionSelected }) =>
+      optionSelected &&
+      css`
+        + label {
+          transform: translateY(-150%);
+          font-size: ${themeGet("textVariants.xs.fontSize")};
+    
+          & > span {
+            height: 2px;
+            top: 50%;
+          }
+      `}
   `,
   error: css`
     color: ${themeGet("colors.black100")};


### PR DESCRIPTION
This PR resolves [EMI-1373]

> [!IMPORTANT]
> This PR will be merged to #1250 

### Description
This PR solves the issue with `:has` pseudo-class [not being supported by Firefox](https://caniuse.com/css-has) by applying the styles using JS instead of CSS selectors

### Videos
| Before | After |
|---|---|
| <video src="https://github.com/artsy/palette/assets/20655703/221a35af-56c4-4d3a-9974-c78d18e0ddc0" /> | <video src="https://github.com/artsy/palette/assets/20655703/5c8d3399-77fd-463c-9e9b-a2d938ebd66f" /> |




[EMI-1373]: https://artsyproduct.atlassian.net/browse/EMI-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ