### PR TITLE
fix(pill): corrects selected state

### DIFF
--- a/packages/palette/src/elements/Pill/tokens.ts
+++ b/packages/palette/src/elements/Pill/tokens.ts
@@ -199,7 +199,7 @@ export const PILL_VARIANTS: Record<
       border-color: ${themeGet("colors.blue100")};
       color: ${themeGet("colors.black100")};
       background-color: ${themeGet("colors.black5")};
-      border-color: ${themeGet("colors.blue100")};
+      border-color: ${themeGet("colors.black5")};
     `,
     disabled: css`
       background-color: ${themeGet("colors.black5")};
@@ -239,7 +239,7 @@ export const PILL_VARIANTS: Record<
       border-color: ${themeGet("colors.blue100")};
       color: ${themeGet("colors.black100")};
       background-color: ${themeGet("colors.black5")};
-      border-color: ${themeGet("colors.blue100")};
+      border-color: ${themeGet("colors.black5")};
     `,
     disabled: css`
       background-color: ${themeGet("colors.black5")};


### PR DESCRIPTION
Selected state should not have a blue outline.