### PR TITLE
feat(pill): supports right side icon positioning

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.story.tsx
+++ b/packages/palette/src/elements/Pill/Pill.story.tsx
@@ -6,6 +6,7 @@ import { Pill, PillProps, PillVariant, PILL_VARIANT_NAMES } from "./Pill"
 import { Box } from "../Box"
 import { Join } from "../Join"
 import GraphIcon from "@artsy/icons/GraphIcon"
+import ChevronSmallDownIcon from "@artsy/icons/ChevronSmallDownIcon"
 import styled from "styled-components"
 import { Popover } from "../Popover"
 
@@ -132,6 +133,11 @@ export const PillWithIcon = () => {
   return (
     <States<PillProps>
       states={[
+        {
+          iconPosition: "right",
+          Icon: ChevronSmallDownIcon,
+          variant: "default",
+        },
         {},
         { focus: true },
         { hover: true },

--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -42,6 +42,8 @@ export type PillProps = ClickableProps & {
   selected?: boolean
   /** Optional icon slot */
   Icon?: React.FunctionComponent<BoxProps & { fill?: ResponsiveValue<string> }>
+  /** Optional: Icon positioning */
+  iconPosition?: "left" | "right"
 } & (
     | {
         variant?: Extract<
@@ -76,7 +78,7 @@ export type PillProps = ClickableProps & {
 export const Pill = forwardRef<
   HTMLAnchorElement & HTMLButtonElement,
   PillProps
->(({ children, Icon, ...rest }, forwardedRef) => {
+>(({ children, Icon, iconPosition = "left", ...rest }, forwardedRef) => {
   const variant =
     rest.variant === "profile" && rest.compact ? "gray" : rest.variant
 
@@ -95,7 +97,9 @@ export const Pill = forwardRef<
         />
       )}
 
-      {Icon && <Icon fill="currentColor" ml={-0.5} mr={0.5} />}
+      {Icon && iconPosition === "left" && (
+        <Icon fill="currentColor" ml={-0.5} mr={0.5} />
+      )}
 
       <Text
         variant={rest.variant === "search" ? ["xs", "sm-display"] : "xs"}
@@ -110,6 +114,10 @@ export const Pill = forwardRef<
           </>
         )}
       </Text>
+
+      {Icon && iconPosition === "right" && (
+        <Icon fill="currentColor" ml={0.5} mr={-0.5} />
+      )}
 
       {((rest.variant === "gray" && rest.selected) ||
         (rest.variant === "filter" && rest.selected) ||


### PR DESCRIPTION
Closes [DIA-215](https://artsyproduct.atlassian.net/browse/DIA-215)

To support quick filter anchors, we allow a right-side positioning of icons.

[DIA-215]: https://artsyproduct.atlassian.net/browse/DIA-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ