### PR TITLE
fix: Hide placeholder text for select elements

### DIFF
--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -216,6 +216,14 @@ const Container = styled(Clickable)<ContainerProps>`
         cursor: default;
         ${MULTISELECT_STATES.disabled}
       }
+
+      // Hide text behind title when it's visible
+      ${props.title &&
+      !props.complete &&
+      !props.visible &&
+      css`
+        color: transparent !important;
+      `}
     `
   }}
 

--- a/packages/palette/src/elements/MultiSelect/tokens.ts
+++ b/packages/palette/src/elements/MultiSelect/tokens.ts
@@ -32,6 +32,12 @@ export const MULTISELECT_STATES: Record<State, any> = {
 
     & > label {
       color: ${themeGet("colors.blue100")};
+
+      ${({ complete }) =>
+        !complete &&
+        css`
+          text-decoration: underline;
+        `})}
     }
   `,
   completed: css`

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -241,7 +241,7 @@ const Container = styled(Box)<ContainerProps>`
         !props.optionSelected &&
         props.title &&
         css`
-          color: transparent;
+          color: transparent !important;
         `}
       `
     }};


### PR DESCRIPTION

> [!IMPORTANT]
> This PR will be merged to #1250 


### Description
This PR fixes a small issue with the text behind the label showing on hover for `Select` and the name in `MultiSelect`

### Screenshots

| | Before | After |
|---|---|---|
| Select | <img width="740" alt="image" src="https://github.com/artsy/palette/assets/20655703/a8ab90a8-2974-45c3-bc0d-92b64c769256"> | <img width="742" alt="image" src="https://github.com/artsy/palette/assets/20655703/e80d855c-ca24-4c08-8945-67c20a89128a"> |
| MultiSelect | <img width="740" alt="image" src="https://github.com/artsy/palette/assets/20655703/55939da3-1089-4126-8059-5a516fcf1358"> | <img width="741" alt="image" src="https://github.com/artsy/palette/assets/20655703/a36895fb-8d60-4784-a494-d3d5aa2f71a6"> |



