### PR TITLE
fix: Add `value` & `onChange` to Select

### DIFF
--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -52,13 +52,15 @@ export const Select: ForwardRefExoticComponent<
       selected,
       title,
       onSelect,
+      onChange,
+      value,
       ...rest
     },
     ref
   ) => {
     const [boxProps, selectProps] = splitBoxProps(rest)
     // due to :has not available in Firefox yet, we need to add the styles to the label using JS
-    const [selectedOption, setSelectedOption] = useState(selected)
+    const [selectedOption, setSelectedOption] = useState(selected || value)
     const [isFocused, setIsFocused] = useState(false)
     const [isHovered, setIsHovered] = useState(false)
 
@@ -92,6 +94,7 @@ export const Select: ForwardRefExoticComponent<
             value={selected}
             onChange={(event) => {
               onSelect && onSelect(event.target.value)
+              onChange && onChange(event)
               setSelectedOption(event.target.value)
             }}
             {...selectProps}


### PR DESCRIPTION

> [!IMPORTANT]
> This PR will be merged to #1250 


### Description
This PR adds a handler for `value` and `onChange` props to Select

> [!NOTE]
> Not having a handler for onChange overrides the one we have and blocks the `:has` polyfills for Firefox

