### PR TITLE
fix(dia-240): optimize tooltip when inactive

### DIFF
--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -10,6 +10,7 @@ import { Input } from "../Input"
 import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 import { Tooltip, TooltipProps } from "./Tooltip"
+import { Stack } from "../Stack"
 
 const CONTENT = "Lorem ipsum dolor sit amet consectetur adipisicing elit?"
 
@@ -227,4 +228,40 @@ export const PointerCentering = () => {
       </Tooltip>
     </>
   )
+}
+
+export const StressTest = () => {
+  return (
+    <Stack gap={1}>
+      {Array.from({ length: 3000 }).map((_, i) => {
+        return (
+          <Tooltip
+            key={i}
+            content={CONTENT}
+            pointer
+            variant="defaultDark"
+            placement="right"
+          >
+            <Text
+              variant="xs"
+              textAlign="center"
+              width={40}
+              height={40}
+              mx="auto"
+              bg="black10"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+            >
+              {i}
+            </Text>
+          </Tooltip>
+        )
+      })}
+    </Stack>
+  )
+}
+
+StressTest.story = {
+  parameters: { chromatic: { disable: true } },
 }

--- a/packages/palette/src/utils/useMutationObserver.ts
+++ b/packages/palette/src/utils/useMutationObserver.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from "react"
 import { useEffect } from "react"
 
 type UseMutationObserver = {
+  active?: boolean
   onMutate: MutationCallback
   options?: MutationObserverInit
 } & (
@@ -13,6 +14,7 @@ type UseMutationObserver = {
  * Accepts a ref and calls the `onMutate` callback when mutations are observed.
  */
 export const useMutationObserver = ({
+  active = true,
   onMutate,
   options = {
     attributes: true,
@@ -23,7 +25,7 @@ export const useMutationObserver = ({
   ...rest
 }: UseMutationObserver) => {
   useEffect(() => {
-    if (typeof MutationObserver === "undefined") {
+    if (!active || typeof MutationObserver === "undefined") {
       return
     }
 
@@ -40,5 +42,5 @@ export const useMutationObserver = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onMutate, options])
+  }, [onMutate, options, active])
 }

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -72,16 +72,16 @@ export const usePosition = ({
   }
 
   // Re-position when there's any change to the tooltip
-  useMutationObserver({ ref: tooltipRef, onMutate: update })
+  useMutationObserver({ ref: tooltipRef, onMutate: update, active })
 
   // Re-position when there's any change to the anchor's size
-  useResizeObserver({ target: anchorRef, onResize: update })
+  useResizeObserver({ target: anchorRef, onResize: update, active })
 
   // Listen to changes on key
   useIsomorphicLayoutEffect(update, [key])
 
   useIsomorphicLayoutEffect(() => {
-    if (!tooltipRef.current || !anchorRef.current) return
+    if (!active || !tooltipRef.current || !anchorRef.current) return
 
     const { current: tooltip } = tooltipRef
     const { current: anchor } = anchorRef
@@ -91,15 +91,12 @@ export const usePosition = ({
     tooltip.style.left = "0"
 
     const handleScroll = () => {
-      if (!active) return
       setState(placeTooltip({ anchor, tooltip, position, offset, flip, clamp }))
     }
 
-    if (active) {
-      document.addEventListener("scroll", handleScroll, {
-        passive: true,
-      })
-    }
+    document.addEventListener("scroll", handleScroll, {
+      passive: true,
+    })
 
     const handleResize = () => {
       setState(placeTooltip({ anchor, tooltip, position, offset, flip, clamp }))

--- a/packages/palette/src/utils/useResizeObserver.ts
+++ b/packages/palette/src/utils/useResizeObserver.ts
@@ -5,11 +5,13 @@ import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect"
 import { useLatest } from "./useLatest"
 
 type UseResizeObserver<T extends HTMLElement> = {
+  active?: boolean
   target: React.RefObject<T> | T | null
   onResize: UseResizeObserverCallback
 }
 
 export const useResizeObserver = <T extends HTMLElement>({
+  active = true,
   target,
   onResize,
 }: UseResizeObserver<T>) => {
@@ -17,7 +19,7 @@ export const useResizeObserver = <T extends HTMLElement>({
   const storedCallback = useLatest(onResize)
 
   useIsomorphicLayoutEffect(() => {
-    if (!resizeObserver) return
+    if (!active || !resizeObserver) return
 
     let didUnsubscribe = false
 


### PR DESCRIPTION
Closes [DIA-240](https://artsyproduct.atlassian.net/browse/DIA-240)

While although I cannot replicate a crash, no matter how many objects appear on page. I was seeing significant frame drops when resizing the window prior to this change, starting at around 3000 instances.

That said: obviously hundreds or thousands of components should never be in the DOM period and we should virtualize that list anyway. But, this should help.

[DIA-240]: https://artsyproduct.atlassian.net/browse/DIA-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ