### PR TITLE
fix(button): offsets icon for padding balance

### DIFF
--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -99,11 +99,16 @@ export const Button: React.ForwardRefExoticComponent<
           width="100%"
         >
           {!success && Icon && (
-            <Icon fill="currentColor" mr={0.5} aria-hidden="true" />
+            <Icon fill="currentColor" mr={0.5} ml={-0.5} aria-hidden="true" />
           )}
 
           {success && (
-            <CheckmarkIcon fill="currentColor" mr={0.5} aria-hidden="true" />
+            <CheckmarkIcon
+              fill="currentColor"
+              mr={0.5}
+              ml={-0.5}
+              aria-hidden="true"
+            />
           )}
 
           {children}


### PR DESCRIPTION
Surprised this never came up. With the `Pill`s we offset the icons so that the padding doesn't look visually off balance. We should do the same on `Button`


| Before | After |
| --- | --- |
| <img src="https://static.damonzucconi.com/_capture/ruI341XBHGzV6XN8f9ZAyR0VZ5AKxxmF1Mvntzo0vlnYSWjPtlc4JDiPfQU6bDCS7jSPLM8RbXH9SfDWXX1LJQMtcL2ok62DwPTe.png"> | <img src="https://static.damonzucconi.com/_capture/jPTiYAWjCQo8l6ErLLRv4mBf8ukQ2uM8Nf6SVfCwJlSfJ90PnZtd5QKya9OZPCoZw7aFZkPy6XKBDlr5R1DeBORoapfKmy5aQ3eu.png"> |