### PR TITLE
fix(EMI-1561): Update "*required" color when the element is disabled

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -101,7 +101,7 @@ export const Input: React.ForwardRefExoticComponent<
         {(required || (inputProps?.maxLength && showCounter)) &&
           !(error && typeof error === "string") && (
             <Box display="flex" mt={0.5} mx={1}>
-              {required && <RequiredField flex={1} />}
+              {required && <RequiredField disabled={disabled} flex={1} />}
 
               {!!inputProps?.maxLength && showCounter && (
                 <Text flex={1} variant="xs" color="black60" textAlign="right">

--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -156,7 +156,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
       )}
 
       {required && !(error && typeof error === "string") && (
-        <RequiredField mt={0.5} ml={1} />
+        <RequiredField mt={0.5} ml={1} disabled={disabled} />
       )}
 
       {error && typeof error === "string" && (

--- a/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
@@ -300,7 +300,7 @@ export const PhoneInput: React.ForwardRefExoticComponent<
         )}
 
         {required && !(error && typeof error === "string") && (
-          <RequiredField mt={0.5} ml={1} />
+          <RequiredField mt={0.5} ml={1} disabled={disabled} />
         )}
 
         {error && typeof error === "string" && (

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -118,7 +118,7 @@ export const Select: ForwardRefExoticComponent<
         </Container>
 
         {required && !(error && typeof error === "string") && (
-          <RequiredField mt={0.5} ml={1} />
+          <RequiredField mt={0.5} ml={1} disabled={disabled} />
         )}
 
         {error && typeof error === "string" && (

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -115,7 +115,7 @@ export const TextArea: React.ForwardRefExoticComponent<
 
         {(required || characterLimit) && !(error && typeof error === "string") && (
           <Box display="flex" mt={0.5} mx={1}>
-            {required && <RequiredField flex={1} />}
+            {required && <RequiredField flex={1} disabled={disabled} />}
 
             {typeof characterLimit !== "undefined" && (
               <Text

--- a/packages/palette/src/shared/RequiredField.tsx
+++ b/packages/palette/src/shared/RequiredField.tsx
@@ -1,9 +1,16 @@
 import React from "react"
 import { Text, TextProps } from "../elements"
 
-export const RequiredField: React.FC<TextProps> = (props) => {
+export const RequiredField: React.FC<TextProps & { disabled?: boolean }> = (
+  props
+) => {
   return (
-    <Text variant="xs" color="black60" textAlign="left" {...props}>
+    <Text
+      variant="xs"
+      color={props.disabled ? "black30" : "black60"}
+      textAlign="left"
+      {...props}
+    >
       *Required
     </Text>
   )


### PR DESCRIPTION
This PR resolves [EMI-1561]

### Description
This PR updates the color of the "* Required" text under the input elements to be `black30` to match the disabled colors of the borders and the label

### Screenshots

| | Before | After |
|---|---|---|
| Input | <img width="712" alt="image" src="https://github.com/artsy/palette/assets/20655703/de7d0d7a-5f01-4609-8322-032a53928d5d"> | <img width="713" alt="image" src="https://github.com/artsy/palette/assets/20655703/020f40bf-56b6-429b-a1e1-4a0f635c3acc"> |
| Select | <img width="712" alt="image" src="https://github.com/artsy/palette/assets/20655703/49ba2a42-d8d1-4d9e-9116-eb714edf7b52"> | <img width="709" alt="image" src="https://github.com/artsy/palette/assets/20655703/38f540df-8ad2-4606-ab4c-58252d7e9dc4"> |
| Phone Input | <img width="710" alt="image" src="https://github.com/artsy/palette/assets/20655703/b13c25c3-32ba-43dc-bbec-d197fd290d37"> | <img width="710" alt="image" src="https://github.com/artsy/palette/assets/20655703/9d85095c-21e5-4858-8600-728b849a33ba"> |
| MultiSelect | <img width="713" alt="image" src="https://github.com/artsy/palette/assets/20655703/e5007394-da0a-4215-a9f9-563cf48b5db6"> | <img width="712" alt="image" src="https://github.com/artsy/palette/assets/20655703/f434c170-74a0-45b8-a30b-268f6ceaf1ff"> |
| TextArea | <img width="712" alt="image" src="https://github.com/artsy/palette/assets/20655703/8abe3e88-fca9-42e4-8e75-4dec586a48ce"> | <img width="713" alt="image" src="https://github.com/artsy/palette/assets/20655703/5042d4fd-c578-4ce6-98e3-84f204f80948"> |


[EMI-1561]: https://artsyproduct.atlassian.net/browse/EMI-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ