### PR TITLE
fix(EMI-1560): Add margin-top to elements when the title is present

### DIFF
--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -66,7 +66,7 @@ export const Input: React.ForwardRefExoticComponent<
           </Tooltip>
         )}
 
-        <Box position="relative">
+        <Box position="relative" mt={!!title && !description ? 1 : 0}>
           <StyledInput
             ref={ref as any}
             disabled={disabled}

--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -113,6 +113,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
       )}
 
       <Container
+        mt={!!title && !description ? 1 : 0}
         ref={anchorRef as any}
         onClick={onVisible}
         complete={complete || selection.length > 0}

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -75,6 +75,7 @@ export const Select: ForwardRefExoticComponent<
         )}
 
         <Container
+          mt={!!title && !description ? 1 : 0}
           disabled={!!disabled}
           hover={!!hover || isHovered}
           error={error!}

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -90,7 +90,7 @@ export const TextArea: React.ForwardRefExoticComponent<
           </Tooltip>
         )}
 
-        <Box position="relative">
+        <Box position="relative" mt={!!title && !description ? 1 : 0}>
           <StyledTextArea
             ref={ref as any}
             disabled={disabled}


### PR DESCRIPTION
This PR resolves [EMI-1560]

### Description
This PR adds a margin-top to the input elements when the `title` is present to prevent the title from overlapping on other elements

### Demo & Screenshots
| | Before | After |
|---|---|---|
| Input | <video src="https://github.com/artsy/palette/assets/20655703/4232fcf4-b6e6-4682-91fc-2ad601657e3b" /> | <video src="https://github.com/artsy/palette/assets/20655703/50168f9e-6932-46f5-b866-5df04a47138f" /> |
| TextArea | <img width="721" alt="image" src="https://github.com/artsy/palette/assets/20655703/cebe8eaa-0b0b-4e5c-bed1-910112880d12"> | <img width="719" alt="image" src="https://github.com/artsy/palette/assets/20655703/3b87351a-c88a-4c3c-8467-bdbda3e8d379"> |
| Select | <img width="726" alt="image" src="https://github.com/artsy/palette/assets/20655703/0e669393-7673-4c65-bf6a-6d71f8759dad"> | <img width="725" alt="image" src="https://github.com/artsy/palette/assets/20655703/f7d525f7-5803-4a2d-b6fd-81512990028a"> |	
| MultiSelect | <img width="718" alt="image" src="https://github.com/artsy/palette/assets/20655703/98f6de66-04ee-42ec-b75e-1eeea90db2ff"> | <img width="719" alt="image" src="https://github.com/artsy/palette/assets/20655703/ee0b65de-d5c7-41c1-8394-b9bf62cb0724"> |




	






[EMI-1560]: https://artsyproduct.atlassian.net/browse/EMI-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ