### PR TITLE
fix(drawer): renders using portal

### DIFF
--- a/packages/palette/src/elements/Drawer/Drawer.tsx
+++ b/packages/palette/src/elements/Drawer/Drawer.tsx
@@ -4,6 +4,7 @@ import { Flex } from "../Flex"
 import styled, { css } from "styled-components"
 import { zIndex } from "styled-system"
 import { FocusOn } from "react-focus-on"
+import { usePortal } from "../../utils/usePortal"
 
 export interface DrawerProps {
   open: boolean
@@ -19,7 +20,9 @@ export const Drawer: FC<DrawerProps> = ({
   open,
   onClose,
 }) => {
-  return (
+  const { createPortal } = usePortal()
+
+  return createPortal(
     <Container
       zIndex={zIndex}
       anchor={anchor}


### PR DESCRIPTION
I was expecting this to be more complicated but there's not much to this. I still think we could remove/append the whole thing from the DOM instead of it lying dormant but this _should_ work for our purposes. Will check it out with a canary.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@36.0.1-canary.1335.29422.0
  npm install @artsy/palette@37.0.1-canary.1335.29422.0
  # or 
  yarn add @artsy/palette-charts@36.0.1-canary.1335.29422.0
  yarn add @artsy/palette@37.0.1-canary.1335.29422.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
