### PR TITLE
chore: support dotted pill

### DIFF
--- a/packages/palette/src/elements/Pill/Pill.story.tsx
+++ b/packages/palette/src/elements/Pill/Pill.story.tsx
@@ -156,6 +156,7 @@ export const PillWithIcon = () => {
         { variant: "filter", active: true },
         { variant: "filter", selected: true },
         { variant: "filter", disabled: true },
+        { variant: "dotted" },
       ]}
     >
       <Pill variant="badge" Icon={GraphIcon}>

--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -11,23 +11,24 @@ import { BoxProps } from "../Box"
 import { ResponsiveValue } from "styled-system"
 
 export const PILL_VARIANT_NAMES = [
-  "default",
-  "search",
-  "filter",
-  "profile",
   "badge",
+  "dotted",
+  "default",
+  "filter",
   "gray",
+  "profile",
+  "search",
 ] as const
 
 export type PillVariant = typeof PILL_VARIANT_NAMES[number]
 
 export type PillState =
-  | "default"
-  | "hover"
-  | "focus"
   | "active"
-  | "selected"
+  | "default"
   | "disabled"
+  | "focus"
+  | "hover"
+  | "selected"
 
 /** PillProps */
 export type PillProps = ClickableProps & {
@@ -48,7 +49,7 @@ export type PillProps = ClickableProps & {
     | {
         variant?: Extract<
           PillVariant,
-          "default" | "search" | "badge" | "filter" | "gray"
+          "badge" | "default" | "dotted" | "filter" | "gray" | "search"
         >
       }
     | {

--- a/packages/palette/src/elements/Pill/tokens.ts
+++ b/packages/palette/src/elements/Pill/tokens.ts
@@ -48,76 +48,7 @@ export const PILL_VARIANTS: Record<
     ...DEFAULT_STATES,
     default: css`
       ${DEFAULT_STATES.default}
-
       border-style: dashed;
-
-      ${Sup} {
-        color: ${themeGet("colors.blue100")};
-        transition: color 0.25s ease;
-        display: none;
-      }
-
-      @media (min-width: ${themeGet("breakpoints.0")}) {
-        height: 40px;
-        border-radius: 20px;
-        ${Sup} {
-          display: inline;
-        }
-      }
-    `,
-    focus: css`
-      ${DEFAULT_STATES.focus}
-      text-decoration: none;
-      border-style: dashed;
-      border-color: ${themeGet("colors.black10")};
-
-      span {
-        text-decoration: underline;
-      }
-    `,
-    hover: css`
-      ${DEFAULT_STATES.hover}
-      text-decoration: none;
-      border-style: dashed;
-      border-color: ${themeGet("colors.black10")};
-
-      span {
-        text-decoration: underline;
-      }
-
-      ${Sup} {
-        color: ${themeGet("colors.blue100")};
-      }
-    `,
-    active: css`
-      ${DEFAULT_STATES.active}
-      text-decoration: none;
-      border-style: dashed;
-      border-color: ${themeGet("colors.white100")};
-
-      span {
-        text-decoration: underline;
-      }
-
-      ${Sup} {
-        color: ${themeGet("colors.white100")};
-      }
-    `,
-    selected: css`
-      ${DEFAULT_STATES.selected}
-      border-style: dashed;
-      border-color: ${themeGet("colors.white100")};
-
-      ${Sup} {
-        color: ${themeGet("colors.white100")};
-      }
-    `,
-    disabled: css`
-      ${DEFAULT_STATES.disabled}
-
-      ${Sup} {
-        color: ${themeGet("colors.black60")};
-      }
     `,
   },
 

--- a/packages/palette/src/elements/Pill/tokens.ts
+++ b/packages/palette/src/elements/Pill/tokens.ts
@@ -44,6 +44,83 @@ export const PILL_VARIANTS: Record<
   PillVariant,
   Record<PillState, FlattenInterpolation<any>[]>
 > = {
+  dotted: {
+    ...DEFAULT_STATES,
+    default: css`
+      ${DEFAULT_STATES.default}
+
+      border-style: dashed;
+
+      ${Sup} {
+        color: ${themeGet("colors.blue100")};
+        transition: color 0.25s ease;
+        display: none;
+      }
+
+      @media (min-width: ${themeGet("breakpoints.0")}) {
+        height: 40px;
+        border-radius: 20px;
+        ${Sup} {
+          display: inline;
+        }
+      }
+    `,
+    focus: css`
+      ${DEFAULT_STATES.focus}
+      text-decoration: none;
+      border-style: dashed;
+      border-color: ${themeGet("colors.black10")};
+
+      span {
+        text-decoration: underline;
+      }
+    `,
+    hover: css`
+      ${DEFAULT_STATES.hover}
+      text-decoration: none;
+      border-style: dashed;
+      border-color: ${themeGet("colors.black10")};
+
+      span {
+        text-decoration: underline;
+      }
+
+      ${Sup} {
+        color: ${themeGet("colors.blue100")};
+      }
+    `,
+    active: css`
+      ${DEFAULT_STATES.active}
+      text-decoration: none;
+      border-style: dashed;
+      border-color: ${themeGet("colors.white100")};
+
+      span {
+        text-decoration: underline;
+      }
+
+      ${Sup} {
+        color: ${themeGet("colors.white100")};
+      }
+    `,
+    selected: css`
+      ${DEFAULT_STATES.selected}
+      border-style: dashed;
+      border-color: ${themeGet("colors.white100")};
+
+      ${Sup} {
+        color: ${themeGet("colors.white100")};
+      }
+    `,
+    disabled: css`
+      ${DEFAULT_STATES.disabled}
+
+      ${Sup} {
+        color: ${themeGet("colors.black60")};
+      }
+    `,
+  },
+
   default: DEFAULT_STATES,
 
   search: {


### PR DESCRIPTION
Conversation thread: https://artsy.slack.com/archives/C05EQL4R5N0/p1701182070690769?thread_ts=1700759129.374419&cid=C05EQL4R5N0

This PR adds the `dotted` version of the Pill component. This comes as a request from design. 
The component is used here https://www.figma.com/file/lVbIxbnH2IUk1K1FoxyFHV/Filters-and-Alerts-redesign?type=design&node-id=273-47116&mode=dev

**Palette Guidelines** 
![image](https://github.com/artsy/palette/assets/11945712/130955b2-a120-40f7-937c-1f4fa9f8f5cd)

**Demo**

https://github.com/artsy/palette/assets/11945712/8c0256cf-3ffe-4b96-a177-4724909c24b8





