### PR TITLE
fix(range): correctly sets width when within drawer

### DIFF
--- a/packages/palette/src/elements/Range/Range.story.tsx
+++ b/packages/palette/src/elements/Range/Range.story.tsx
@@ -8,6 +8,8 @@ import { LabeledInput } from "../LabeledInput"
 import { Flex } from "../Flex"
 import { Spacer } from "../Spacer"
 import { Text } from "../Text"
+import { Drawer } from "../Drawer"
+import { Button } from "../Button"
 
 export default {
   title: "Components/Range",
@@ -41,6 +43,36 @@ export const WithinModal = () => {
       </Box>
     </ModalBase>
   )
+}
+
+export const WithinDrawer = () => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <Button
+        onClick={() => {
+          setOpen(true)
+        }}
+      >
+        Open
+      </Button>
+
+      <Drawer
+        open={open}
+        onClose={() => {
+          setOpen(false)
+        }}
+      >
+        <Box width={400} p={2}>
+          <Range min={0} max={5000} step={10} onChange={action("onChange")} />
+        </Box>
+      </Drawer>
+    </>
+  )
+}
+
+WithinDrawer.story = {
+  parameters: { chromatic: { disable: true } },
 }
 
 export const InContext = () => {

--- a/packages/palette/src/elements/Range/Range.tsx
+++ b/packages/palette/src/elements/Range/Range.tsx
@@ -52,15 +52,12 @@ export const Range: React.FC<RangeProps> = ({
   }
 
   useEffect(() => {
-    if (!maxRef.current) return
-    setMaxWidth(maxRef.current.offsetWidth)
-  }, [])
-
-  useEffect(() => {
     const handleResize = () => {
       if (!maxRef.current) return
       setMaxWidth(maxRef.current.offsetWidth)
     }
+
+    requestAnimationFrame(handleResize)
 
     window.addEventListener("resize", handleResize, { passive: true })
 


### PR DESCRIPTION
It's actually unclear to me how this differed from the ModalDialog which also uses a portal but: when we switched the `Drawer` to use a portal, the range was no longer initializing it's width correctly.