### PR TITLE
<back>: example input mask

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -119,6 +119,9 @@
   "dependencies": {
     "@artsy/icons": "^3.2.2",
     "@artsy/palette-tokens": "^5.0.0",
+    "@maskito/core": "^1.9.0",
+    "@maskito/kit": "^1.9.0",
+    "@maskito/react": "^1.9.0",
     "@seznam/compose-react-refs": "^1.0.6",
     "@styled-system/theme-get": "^5.1.2",
     "lodash": "^4.17.21",

--- a/packages/palette/src/elements/Input/Input.story.tsx
+++ b/packages/palette/src/elements/Input/Input.story.tsx
@@ -3,6 +3,8 @@ import { States } from "storybook-states"
 import styled from "styled-components"
 import { Button } from "../Button"
 import { Input, InputProps } from "./Input"
+import { useMaskito } from "@maskito/react"
+import { maskitoNumberOptionsGenerator } from "@maskito/kit"
 
 export default {
   title: "Components/Input",
@@ -78,4 +80,17 @@ export const Required = () => {
 
 export const CustomHeight = () => {
   return <Input height={40} placeholder="Input is 40px in height" />
+}
+
+export const MaskedInput = () => {
+  const inputRef = useMaskito({
+    options: maskitoNumberOptionsGenerator({
+      decimalSeparator: ".",
+      thousandSeparator: ",",
+      precision: 2,
+      prefix: "$",
+    }),
+  })
+
+  return <Input ref={inputRef} placeholder="$USD" />
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,6 +2469,21 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
+"@maskito/core@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@maskito/core/-/core-1.9.0.tgz#f1cfbef976015990be90837ad4efa134c162c0dd"
+  integrity sha512-WQIUrwkdIUg6PzAb4Apa0RjTPHB0EqZLc9/7kWCKVIixhkITRFXFg2BhiDVSRv0mIKVlAEJcOvvjHK5T3UaIig==
+
+"@maskito/kit@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@maskito/kit/-/kit-1.9.0.tgz#703e48abe8967e738844f7e96e7f2991d63af450"
+  integrity sha512-LNNgOJ0tAfrPoPehvoP+ZyYF9giOYL02sOMKyDC3IcqDNA8BAU0PARmS7TNsVEBpvSuJhU6xVt40nxJaONgUdw==
+
+"@maskito/react@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@maskito/react/-/react-1.9.0.tgz#6748e016eab62d3f3974ee3bfcdf47a00fde3019"
+  integrity sha512-6mjdXyaJDcZH1VnIYiR0kTA//F0q2djs0fKxfMfqEhEzyRR/HXL0VvsPRayk3HHy7wEtwR7bKgTNBwlwFdTj0g==
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"


### PR DESCRIPTION
Bit of a journey on this one. And, ultimately, wondering what next steps should be.

Initially I thought this would be easy to implement, but as you get into the problem, doing it correctly is very difficult.

Looking for a library, I was dismayed at how incomplete some solutions were, then, when finding a library that seemed to work they tend to be bloated, buggy, and unmaintained. Eventually came across this library, Maskito, which ticks all the boxes.

The authors did a nice blog post explaining some of the issues and their motivation, which is worth the read: https://medium.com/its-tinkoff/maskito-is-a-new-collection-of-libraries-for-text-field-masking-f64ec71951df

Before moving forward with anything we need to take stock and see where we could use masking and what masked inputs are actually required. I don't think it makes a ton of sense to just include this lib and wrap its props. I think it's also perfectly acceptable to not include this in Palette at all and instead to simply use it, as you can see it's pretty straightforward.

Depending on our needs https://github.com/nosir/cleave-zen could solve the simpler cases while being a bit lighter.