### PR TITLE
feat(text): adds xxs tokens

### DIFF
--- a/packages/palette-tokens/src/typography/v3.ts
+++ b/packages/palette-tokens/src/typography/v3.ts
@@ -21,6 +21,7 @@ export const TEXT_VARIANT_NAMES = [
   "sm",
   "sm-display",
   "xs",
+  "xxs",
   "bq",
 ] as const;
 
@@ -69,6 +70,10 @@ export const TEXT_VARIANTS: Record<
   xs: {
     fontSize: "13px",
     lineHeight: "20px",
+  },
+  xxs: {
+    fontSize: "11px",
+    lineHeight: "14px",
   },
   bq: {
     fontSize: "50px",


### PR DESCRIPTION
Adds the `xxs` variant to `Text`

![](https://static.damonzucconi.com/_capture/WIqlgR1QpkS1egkA4mkQ58aCtlC0uqALunwVeFjbss6YzHGJUSSKlraB0sDZeYHwpa75oTpYvUQ0QYwq9GWTpRg9m9nDTItmtvye.png)