### PR TITLE
fix(checkbox): moves focus state onto focus-visible

### DIFF
--- a/packages/palette/src/elements/Checkbox/Checkbox.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.tsx
@@ -123,7 +123,7 @@ const Container = styled(Box)<{
         `}
       }
 
-      &:focus {
+      &:focus-visible {
         ${CHECKBOX_STATES.focus}
 
         // Check


### PR DESCRIPTION
We were seeing some slightly confusing UX when checkboxes were the first element in dropdowns, as when focus moves to the dropdown, the first checkbox gets focused. This actually does feel much better to use with a pointer device now as the checkbox won't visibly retain focus.