### PR TITLE
fix(button): avoids passing the loading prop to the underlying dom node

### DIFF
--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -79,7 +79,7 @@ export const Button: React.ForwardRefExoticComponent<
         ref={composeRefs(ref, forwardedRef) as any}
         onClick={handleClick}
         size={size}
-        loading={loading}
+        $loading={loading}
         success={success}
         tabIndex={loading ? -1 : 0}
         display="inline-flex"
@@ -127,8 +127,10 @@ Button.defaultProps = {
 
 type ContainerProps = Pick<
   ButtonProps,
-  "active" | "disabled" | "focus" | "hover" | "loading" | "size" | "success"
->
+  "active" | "disabled" | "focus" | "hover" | "size" | "success"
+> & {
+  $loading?: boolean
+}
 
 export const buttonMixin = css`
   cursor: pointer;
@@ -169,7 +171,7 @@ const Container = styled.button<ContainerProps & ButtonProps>`
       `
     }
 
-    if (props.loading) {
+    if (props.$loading) {
       return css`
         cursor: auto;
         transition: none;


### PR DESCRIPTION
Closes [DIA-387](https://artsyproduct.atlassian.net/browse/DIA-387)

This just renames the loading prop on the container to match the transient props API in SC5. It doesn't actually work as a transient prop in this case because we are on 4, but it suppresses the warning regardless because it's not passing anything to `loading`, which is a native attribute.

[DIA-387]: https://artsyproduct.atlassian.net/browse/DIA-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ