### PR TITLE
fix(tooltip): correctly handles positioning edge case by skipping when inactive

### DIFF
--- a/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.story.tsx
@@ -11,6 +11,7 @@ import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 import { Tooltip, TooltipProps } from "./Tooltip"
 import { Stack } from "../Stack"
+import { Column, GridColumns } from "../GridColumns"
 
 const CONTENT = "Lorem ipsum dolor sit amet consectetur adipisicing elit?"
 
@@ -264,4 +265,19 @@ export const StressTest = () => {
 
 StressTest.story = {
   parameters: { chromatic: { disable: true } },
+}
+
+export const PositioningBug = () => {
+  return (
+    <GridColumns>
+      <Column span={9}>Example left-column content</Column>
+      <Column span={3} display="flex" flexDirection="column" gap={2}>
+        <Tooltip content="Example content">
+          <Button size="small">Example tooltip trigger</Button>
+        </Tooltip>
+
+        <Text variant="xs">There should not be a horizontal scrollbar</Text>
+      </Column>
+    </GridColumns>
+  )
 }

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -63,7 +63,7 @@ export const usePosition = ({
   const anchorRef = useRef<HTMLElement | null>(null)
 
   const update = () => {
-    if (!tooltipRef.current || !anchorRef.current) return
+    if (!active || !tooltipRef.current || !anchorRef.current) return
 
     const { current: tooltip } = tooltipRef
     const { current: anchor } = anchorRef


### PR DESCRIPTION
We noticed that on some pages with `Tooltip` components in right sidebars, we would see the tooltip dramatically positioned offscreen. @tam-kis noticed that by changing the immediate positioning context to relative we could contain it within the parent. I don't think this change has gone unnoticed for 3 months, so it's unclear what changed to trigger this bug. However we just need to skip positioning when the `Tooltip` is inactive, regardless.