### PR TITLE
feat(H13):Add BlurHash to Image

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -41,7 +41,8 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "styled-components": "^4"
+    "styled-components": "^4",
+    "blurhash": "^2.0.5"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",
@@ -121,8 +122,10 @@
     "@artsy/palette-tokens": "^5.1.0",
     "@seznam/compose-react-refs": "^1.0.6",
     "@styled-system/theme-get": "^5.1.2",
+    "blurhash": "^2.0.5",
     "lodash": "^4.17.21",
     "proportional-scale": "^4.0.0",
+    "react-blurhash": "^0.3.0",
     "react-focus-on": "^3.7.0",
     "react-lazy-load-image-component": "1.5.5",
     "styled-system": "^5.1.5",

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -77,6 +77,22 @@ ImageLazyLoadSrcSet.story = {
   name: "Image + lazyLoad + srcSet",
 }
 
+export const ImageSrcSetBlurHash = () => {
+  return (
+    <Image
+      width="300px"
+      height="200px"
+      blurhash="LWF$66t6IUV@?wR*NFoKb_oJaeW;"
+      src="https://picsum.photos/seed/example/300/200"
+      srcSet="https://picsum.photos/seed/example/300/200 1x, https://picsum.photos/seed/example/600/400 2x"
+    />
+  )
+}
+
+ImageWSrcSet.story = {
+  name: "Image + srcSet + BlurHash",
+}
+
 export const ImageLazyLoadSrcSetBlurHash = () => {
   return (
     <Image

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -76,3 +76,20 @@ export const ImageLazyLoadSrcSet = () => {
 ImageLazyLoadSrcSet.story = {
   name: "Image + lazyLoad + srcSet",
 }
+
+export const ImageLazyLoadSrcSetBlurHash = () => {
+  return (
+    <Image
+      lazyLoad
+      width="300px"
+      height="200px"
+      blurhash="LWF$66t6IUV@?wR*NFoKb_oJaeW;"
+      src="https://picsum.photos/seed/example/300/200"
+      srcSet="https://picsum.photos/seed/example/300/200 1x, https://picsum.photos/seed/example/600/400 2x"
+    />
+  )
+}
+
+ImageWSrcSet.story = {
+  name: "Image + lazyLoad + srcSet + BlurHash",
+}

--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -89,7 +89,7 @@ export const ImageSrcSetBlurHash = () => {
   )
 }
 
-ImageWSrcSet.story = {
+ImageSrcSetBlurHash.story = {
   name: "Image + srcSet + BlurHash",
 }
 
@@ -106,6 +106,6 @@ export const ImageLazyLoadSrcSetBlurHash = () => {
   )
 }
 
-ImageWSrcSet.story = {
+ImageLazyLoadSrcSetBlurHash.story = {
   name: "Image + lazyLoad + srcSet + BlurHash",
 }

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -27,6 +27,7 @@ export interface ImageProps
   lazyLoad?: boolean
   /** Flag indicating that right clicks should be prevented */
   preventRightClick?: boolean
+  blurhash?: string
 }
 
 // @ts-expect-error  MIGRATE_STRICT_MODE

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -70,7 +70,17 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   } = props
 
   if (preload) {
-    return <ImageComponent {...props} />
+    return (
+      <SkeletonImage
+        width={width}
+        height={height}
+        borderRadius={borderRadius}
+        blurhash={hideBlurhash ? undefined : blurhash}
+        {...containerProps}
+      >
+        <ImageComponent onLoad={() => setHideBlurhash(true)} {...props} />
+      </SkeletonImage>
+    )
   }
 
   const handleLoad = () => {

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -8,7 +8,7 @@ import {
   WidthProps,
 } from "styled-system"
 import { CleanTag, omitProps } from "../CleanTag"
-import { SkeletonBox } from "../Skeleton"
+import { SkeletonBox, SkeletonImage } from "../Skeleton"
 import { ImageProps } from "./Image"
 import { BaseImage as Image } from "./Image"
 
@@ -52,6 +52,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
   ...props
 }) => {
   const [isImageLoaded, setImageLoaded] = useState(false)
+  const [hideBlurhash, setHideBlurhash] = useState(false)
 
   const {
     src,
@@ -64,6 +65,7 @@ export const LazyImage: React.FC<LazyImageProps> = ({
     borderRadius,
     style,
     onError,
+    blurhash,
     ...containerProps
   } = props
 
@@ -71,7 +73,45 @@ export const LazyImage: React.FC<LazyImageProps> = ({
     return <ImageComponent {...props} />
   }
 
-  const handleLoad = () => setImageLoaded(true)
+  const handleLoad = () => {
+    setImageLoaded(true)
+    setTimeout(() => {
+      setHideBlurhash(true)
+    }, 500)
+  }
+
+  if (blurhash) {
+    return (
+      <SkeletonImage
+        width={width}
+        height={height}
+        borderRadius={borderRadius}
+        blurhash={hideBlurhash ? undefined : blurhash}
+        {...containerProps}
+      >
+        <InnerLazyImage
+          omitFromProps={imagePropsToOmit}
+          onError={onError}
+          src={src}
+          srcSet={srcSet}
+          title={title}
+          alt={alt}
+          aria-label={ariaLabel}
+          borderRadius={borderRadius}
+          width="100%"
+          height="100%"
+          style={{
+            ...style,
+            opacity: isImageLoaded ? "1" : "0",
+          }}
+          onLoad={handleLoad}
+        />
+        <noscript>
+          <ImageComponent {...props} />
+        </noscript>
+      </SkeletonImage>
+    )
+  }
 
   return (
     <SkeletonBox

--- a/packages/palette/src/elements/Skeleton/Skeleton.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.tsx
@@ -1,5 +1,6 @@
 import { themeGet } from "@styled-system/theme-get"
 import React from "react"
+import { BlurhashCanvas } from "react-blurhash"
 import styled, { keyframes, StyledComponentClass } from "styled-components"
 import { border, BorderProps } from "styled-system"
 import { splitProps } from "../../utils/splitProps"
@@ -72,6 +73,34 @@ export const Skeleton: React.FC<SkeletonProps> = ({ children, ...rest }) => {
       {children}
 
       <SkeletonFade position="absolute" top={0} right={0} bottom={0} left={0} />
+    </Box>
+  )
+}
+
+export const SkeletonImage: React.FC<SkeletonProps & { blurhash?: string }> = ({
+  children,
+  blurhash,
+  ...rest
+}) => {
+  return (
+    <Box position="relative" {...rest}>
+      {!!blurhash && (
+        <BlurhashCanvas
+          hash={blurhash}
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            width: "100%",
+            height: "100%",
+            zIndex: -1,
+          }}
+        />
+      )}
+
+      {children}
     </Box>
   )
 }

--- a/packages/palette/src/elements/Skeleton/Skeleton.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.tsx
@@ -95,7 +95,7 @@ export const SkeletonImage: React.FC<SkeletonProps & { blurhash?: string }> = ({
             right: 0,
             width: "100%",
             height: "100%",
-            zIndex: -1,
+            zIndex: 99,
           }}
         />
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6150,6 +6150,11 @@ bluebird@^3.3.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+blurhash@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-2.0.5.tgz#efde729fc14a2f03571a6aa91b49cba80d1abe4b"
+  integrity sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==
+
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
@@ -13769,6 +13774,11 @@ raw-loader@^4.0.2:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+react-blurhash@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/react-blurhash/-/react-blurhash-0.3.0.tgz#f125801d052644f74420c79b05981691d17c9705"
+  integrity sha512-XlKr4Ns1iYFRnk6DkAblNbAwN/bTJvxTVoxMvmTcURdc5oLoXZwqAF9N3LZUh/HT+QFlq5n6IS6VsDGsviYAiQ==
 
 react-clientside-effect@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
> [!NOTE]
> This PR is part of [#hack13-blurhash](https://artsy.slack.com/archives/C06E4ND6EBV) 🔒


### Description
This PR adds BlurHash to the Image component

### Demo
https://github.com/artsy/palette/assets/20655703/397eb971-75fa-43d3-91ed-8534d1186824





<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@36.3.5-canary.1358.30038.0
  npm install @artsy/palette@37.3.5-canary.1358.30038.0
  # or 
  yarn add @artsy/palette-charts@36.3.5-canary.1358.30038.0
  yarn add @artsy/palette@37.3.5-canary.1358.30038.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
