### PR TITLE
fix: fixes long press on AutocompleteInputOption

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -186,7 +186,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     dispatch({ type: "OPEN" })
   }
 
-  const handleMouseDown = (option: T, i: number) => () => {
+  const handleInputOptionClick = (option: T, i: number) => () => {
     handleSelect(option, i)
     resetUI()
   }
@@ -382,7 +382,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
                   aria-selected={i === index}
                   aria-posinset={i + 1}
                   aria-setsize={options.length}
-                  onMouseDown={handleMouseDown(option, i)}
+                  onClick={handleInputOptionClick(option, i)}
                   onMouseEnter={handleMouseEnter(i)}
                   selected={i === index}
                   tabIndex={-1}

--- a/packages/palette/src/elements/AutocompleteInput/__tests__/Autocomplete.test.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/__tests__/Autocomplete.test.tsx
@@ -100,7 +100,7 @@ describe("Autocomplete", () => {
     expect(wrapper.html()).toContain('aria-expanded="true"')
 
     act(() => {
-      wrapper.find("button").at(1).simulate("mousedown")
+      wrapper.find("button").at(1).simulate("click")
       jest.runAllTimers()
     })
 


### PR DESCRIPTION
PR that originated this issue: https://github.com/artsy/force/pull/13396

The problem is that when user presses on an option, in handleMouseDown function UI gets cleared (dropdown destroyed) after 100ms delay. If user keeps mouse pressed - dropdown UI is cleared before user releases the mouse button. But seems like router links (that are inside options) start handling redirect only after user releases mouse. But at this point of time there are no links in DOM, so redirects are not handled.

onClick will wait until user releases the mouse button, and only after that will clear UI.