### PR TITLE
fix(yalc): Make sure yalc properly syncs changes to Force

### DIFF
--- a/packages/palette/scripts/yalc-sync-after-change
+++ b/packages/palette/scripts/yalc-sync-after-change
@@ -13,4 +13,4 @@ then
     exit
 fi
 
-yarn concurrently 'yarn watch' 'nodemon -w dist --exec "yalc push --changed" --delay 1'
+yarn concurrently 'yarn watch' 'nodemon -w dist --exec "yalc push --changed --sig" --delay 1'


### PR DESCRIPTION
Noticed that when using `yarn local-palette-dev` things weren't properly updating in Force, and doing some investigation found https://github.com/wclr/yalc/issues/195. Seems like force's webpack cache was breaking things.