### PR TITLE
fix(dropdown): only manage focus when keyboard navigating

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -211,6 +211,18 @@ export const Dropdown: React.FC<DropdownProps> = ({
     }
   }, [placement, isFlipped, offset])
 
+  const pointerRef = useRef(false)
+
+  const handlePointerVisible = () => {
+    pointerRef.current = true
+    onVisible()
+  }
+
+  const handlePointerHide = () => {
+    pointerRef.current = false
+    onHide()
+  }
+
   const anchorProps: React.HTMLAttributes<HTMLElement> = {
     "aria-expanded": visible,
     "aria-haspopup": true,
@@ -219,13 +231,15 @@ export const Dropdown: React.FC<DropdownProps> = ({
           onClick: onToggleVisibility,
         }
       : {
-          onMouseEnter: onVisible,
-          onMouseLeave: onHide,
+          onMouseEnter: handlePointerVisible,
+          onMouseLeave: handlePointerHide,
           onClick: onVisible,
         }),
   }
 
   const { createPortal } = usePortal()
+
+  const isPointer = !openDropdownByClick && pointerRef.current
 
   return (
     <>
@@ -276,7 +290,11 @@ export const Dropdown: React.FC<DropdownProps> = ({
                     }
               }
             >
-              <FocusOn noIsolation enabled={visible} onClickOutside={onHide}>
+              <FocusOn
+                noIsolation
+                enabled={visible && !isPointer}
+                onClickOutside={onHide}
+              >
                 {typeof dropdown === "function"
                   ? dropdown({ onVisible, onHide, setVisible, visible })
                   : dropdown}


### PR DESCRIPTION
Closes [DIA-409](https://artsyproduct.atlassian.net/browse/DIA-409)

A bit of a subtle problem: we don't want to manage focus when using a dropdown with a pointer device, only when keyboard navigating.

An illustration of the behavior this PR implements, where `enabled` is referring to focus isolation.

https://github.com/artsy/palette/assets/112297/ea05292e-ad73-45a2-9ec6-a99175d15259



[DIA-409]: https://artsyproduct.atlassian.net/browse/DIA-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ