### PR TITLE
fix(theme): returns the default theme if none is provided

### DIFF
--- a/packages/palette/src/Theme.tsx
+++ b/packages/palette/src/Theme.tsx
@@ -17,6 +17,8 @@ const THEMES = {
   dark: THEME_DARK,
 }
 
+const DEFAULT_THEME = THEME
+
 interface ThemeProps {
   children?: React.ReactNode
   theme?: "light" | "dark"
@@ -32,6 +34,6 @@ export const Theme: React.FC<ThemeProps> = ({ children, theme = "light" }) => {
 
 /** Returns the current theme */
 export const useTheme = <T extends TTheme>() => {
-  const theme: T = useContext(ThemeContext)
+  const theme: T = useContext(ThemeContext) || DEFAULT_THEME
   return { theme }
 }

--- a/packages/palette/src/__tests__/Theme.test.tsx
+++ b/packages/palette/src/__tests__/Theme.test.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { mount } from "enzyme"
+import { Theme, useTheme } from "../Theme"
+
+const Example = () => {
+  const { theme } = useTheme()
+  return <div>{theme.name}</div>
+}
+
+describe("useTheme", () => {
+  it("returns the current theme if one is provided", () => {
+    const wrapper = mount(
+      <Theme theme="dark">
+        <Example />
+      </Theme>
+    )
+    expect(wrapper.text()).toEqual("dark")
+  })
+
+  it("returns the default theme if none is provided", () => {
+    const wrapper = mount(<Example />)
+    expect(wrapper.text()).toEqual("light")
+  })
+})


### PR DESCRIPTION
I'm not sure why I didn't think of this when I was upgrading Force.... 😞 

This just makes it much easier to test: tests may not have a component wrapped with a theme provider and if you're using a component that makes use of the theme, then these will fail. 99% of the time, this doesn't matter at all. So just return the default theme if there isn't one provided.

Re: https://github.com/artsy/volt-v2/pull/1244