### PR TITLE
feat(read-more): Add `inlineReadMoreLink` prop

### DIFF
--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { HTML } from "../HTML"
 import { ReadMore } from "./ReadMore"
+import { Box } from "../Box"
 
 export default {
   title: "Components/ReadMore",
@@ -182,4 +183,30 @@ export const CharacterCapWithHtmlDisabled = () => {
 
 CharacterCapWithHtmlDisabled.story = {
   name: "Character cap with html (disabled)",
+}
+
+export const WithBottomReadMore = () => {
+  return (
+    <Box textAlign="center" width={600}>
+      <HTML variant="lg">
+        <ReadMore
+          inlineReadMoreLink={false}
+          maxChars={280}
+          content={`<div>
+          Donald Judd, widely regarded as one of the most significant American
+          artists of <a href="#">the post-war period</a>, is perhaps best-known
+          for the large-scale outdoor installations and long, spacious interiors
+          he designed in Marfa. Donald Judd, widely regarded as one of the most
+          significant American artists of the post-war period, is perhaps
+          best-known for the large-scale outdoor installations and long,
+          spacious interiors he designed in Marfa.
+        </div>`}
+        />
+      </HTML>
+    </Box>
+  )
+}
+
+WithBottomReadMore.story = {
+  name: "With bottom placed 'Read More'",
 }

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -8,6 +8,7 @@ import { Box } from "../Box"
 export interface ReadMoreProps {
   content: string
   disabled?: boolean
+  inlineReadMoreLink?: boolean
   isExpanded?: boolean
   maxChars?: number
   onReadLessClicked?: () => void
@@ -18,6 +19,7 @@ export interface ReadMoreProps {
 export const ReadMore: React.FC<ReadMoreProps> = ({
   content: expandedHTML,
   disabled,
+  inlineReadMoreLink = true,
   isExpanded,
   maxChars = Infinity,
   onReadLessClicked,
@@ -70,7 +72,14 @@ export const ReadMore: React.FC<ReadMoreProps> = ({
         </>
       ) : (
         <Clickable onClick={handleClick}>
-          <span dangerouslySetInnerHTML={{ __html: truncatedHTML }} />{" "}
+          {inlineReadMoreLink ? (
+            <>
+              <span dangerouslySetInnerHTML={{ __html: truncatedHTML }} />{" "}
+            </>
+          ) : (
+            <Box dangerouslySetInnerHTML={{ __html: truncatedHTML }} />
+          )}
+
           <Text
             as="span"
             variant="xs"


### PR DESCRIPTION
Updates the `<ReadMore>` link with a new `inlineReadMoreLink` prop defaulting to true. We need this on some of the new private artworks designs:


https://github.com/artsy/palette/assets/236943/db09916a-ec6b-46dc-a52b-ced294aab86f

cc @artsy/amber-devs 

