### PR TITLE
fix: toggle flex shrink

### DIFF
--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -86,6 +86,7 @@ const Container = styled(Box)<{
   border-radius: 100px;
   width: 51px;
   height: 31px;
+  flex-shrink: 0;
 
   ${(props) => {
     return css`


### PR DESCRIPTION
I noticed a small issue with the toggle for smaller / mobile screens. 

**Before**

<img width="448" alt="Screenshot 2024-03-11 at 12 03 21 PM" src="https://github.com/artsy/palette/assets/50849237/b53aae67-1628-44b4-936c-5c39e6a93efd">

**After** 

<img width="446" alt="Screenshot 2024-03-11 at 12 03 31 PM" src="https://github.com/artsy/palette/assets/50849237/6568d80c-c6ea-4206-826d-555f5d6093b0">
