### PR TITLE
fix: revert slow-click fix from 1361

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -186,7 +186,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
     dispatch({ type: "OPEN" })
   }
 
-  const handleInputOptionClick = (option: T, i: number) => () => {
+  const handleMouseDown = (option: T, i: number) => () => {
     handleSelect(option, i)
     resetUI()
   }
@@ -382,7 +382,7 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
                   aria-selected={i === index}
                   aria-posinset={i + 1}
                   aria-setsize={options.length}
-                  onClick={handleInputOptionClick(option, i)}
+                  onMouseDown={handleMouseDown(option, i)}
                   onMouseEnter={handleMouseEnter(i)}
                   selected={i === index}
                   tabIndex={-1}

--- a/packages/palette/src/elements/AutocompleteInput/__tests__/Autocomplete.test.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/__tests__/Autocomplete.test.tsx
@@ -100,7 +100,7 @@ describe("Autocomplete", () => {
     expect(wrapper.html()).toContain('aria-expanded="true"')
 
     act(() => {
-      wrapper.find("button").at(1).simulate("click")
+      wrapper.find("button").at(1).simulate("mousedown")
       jest.runAllTimers()
     })
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-779

This reverts commit 36cfa119503edf04189062d2bc2f29d76fba9752.

The short version:

- #1361 was the last step in a [sequence of fixes](https://artsy.slack.com/archives/C05EQL4R5N0/p1710338279935239?thread_ts=1710255056.226949&cid=C05EQL4R5N0) that attempted to workaround the non-<code>&lt;a&gt;</code>-like behavior of the navigational links in the global search dropdown in Force.

- The reverted PR addressed a real glitch, but at the cost of introducing a more common one that was discovered much later, so we are reverting it.

- We hope to fix this more fundamentally in Palette by allowing Autocomplete to render options as `<a>`'s when appropriate

---

**Demo** of Safari versions 14–17 (via Browserstack, testing against local Force using a canary version of this PR) working as expected upon Autocomplete click:


https://github.com/artsy/palette/assets/140521/966c3b4e-9be2-4efe-9ff1-1cf1b18d33d1



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@37.2.0-canary.1373.30447.0
  npm install @artsy/palette@38.2.0-canary.1373.30447.0
  # or 
  yarn add @artsy/palette-charts@37.2.0-canary.1373.30447.0
  yarn add @artsy/palette@38.2.0-canary.1373.30447.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
