### PR TITLE
fix(EMI-1755): fix toggle hover

### DIFF
--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -21,6 +21,7 @@ export interface ToggleProps
 export const Toggle: React.FC<ToggleProps> = ({
   selected = false,
   disabled,
+  hover,
   onSelect,
   onClick,
   ...rest
@@ -55,6 +56,7 @@ export const Toggle: React.FC<ToggleProps> = ({
       aria-checked={selected}
       selected={selected}
       disabled={disabled}
+      hover={hover}
       {...rest}
     >
       <Switch selected={selected} />
@@ -96,6 +98,10 @@ const Container = styled(Box)<{
       (props.selected
         ? TOGGLE_STATES.disabled.selected
         : TOGGLE_STATES.disabled.default)}
+
+      &:hover {
+        ${TOGGLE_STATES.hover}
+      }
     `
   }}
 `


### PR DESCRIPTION
[EMI-1755](https://artsyproduct.atlassian.net/browse/EMI-1755)

This makes it so the toggle `hover` is always applied, as previously it was only when the `hover` prop was `true`. 

[EMI-1755]: https://artsyproduct.atlassian.net/browse/EMI-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ