### PR TITLE
feat(EMI-1813): TextArea character limit helper text 

### DIFF
--- a/packages/palette/src/elements/TextArea/TextArea.story.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.story.tsx
@@ -21,6 +21,11 @@ export const Default = () => {
         { title: "Note" },
         { title: "Note", required: true },
         { characterLimit: 10 },
+        {
+          characterLimit: 10,
+          characterLimitHelper: true,
+          required: true,
+        },
         { characterLimit: 10, defaultValue: "hello" },
         { characterLimit: 10, defaultValue: "hello world" },
         { name: "my-text-area" },

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -16,6 +16,7 @@ export interface TextAreaProps
     > {
   active?: boolean
   characterLimit?: number
+  characterLimitHelper?: boolean
   defaultValue?: string
   description?: React.ReactNode
   required?: boolean
@@ -43,6 +44,7 @@ export const TextArea: React.ForwardRefExoticComponent<
       focus,
       hover,
       characterLimit,
+      characterLimitHelper,
       title,
       description,
       defaultValue = "",
@@ -63,6 +65,13 @@ export const TextArea: React.ForwardRefExoticComponent<
       [characterLimit]
     )
 
+    const characterLimitReached = useCallback(
+      (text: string) => {
+        return Boolean(characterLimit && text.length >= characterLimit)
+      },
+      [characterLimit]
+    )
+
     const handleChange = useCallback(
       (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         const nextValue = event.currentTarget.value
@@ -79,6 +88,11 @@ export const TextArea: React.ForwardRefExoticComponent<
       () => Boolean(error || characterLimitExceeded(value)),
       [characterLimitExceeded, error, value]
     )
+
+    const showCharacterLimitReached =
+      characterLimitHelper &&
+      typeof characterLimit !== "undefined" &&
+      characterLimitReached(value)
 
     return (
       <Box width="100%" {...boxProps}>
@@ -115,7 +129,15 @@ export const TextArea: React.ForwardRefExoticComponent<
 
         {(required || characterLimit) && !(error && typeof error === "string") && (
           <Box display="flex" mt={0.5} mx={1}>
-            {required && <RequiredField flex={1} disabled={disabled} />}
+            {required && !showCharacterLimitReached && (
+              <RequiredField flex={1} disabled={disabled} />
+            )}
+
+            {showCharacterLimitReached && (
+              <Text flex={1} variant="xs" color="black60" textAlign="left">
+                Character limit reached
+              </Text>
+            )}
 
             {typeof characterLimit !== "undefined" && (
               <Text

--- a/packages/palette/src/elements/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/palette/src/elements/TextArea/__tests__/TextArea.test.tsx
@@ -164,4 +164,18 @@ describe("TextArea", () => {
     const wrapper = getWrapper({ name: "my-input" })
     expect(wrapper.find("textarea[name='my-input']")).toHaveLength(1)
   })
+
+  it("displays character limit helper text when character limit is reached", () => {
+    const wrapper = getWrapper({
+      characterLimit: 5,
+      characterLimitHelper: true,
+    })
+    expect(wrapper.text()).toContain("0/5")
+    expect(wrapper.text()).not.toContain("Character limit reached")
+
+    simulateTyping(wrapper, "hello")
+
+    expect(wrapper.text()).toContain("5/5")
+    expect(wrapper.text()).toContain("Character limit reached")
+  })
 })


### PR DESCRIPTION
[EMI-1813](https://artsyproduct.atlassian.net/browse/EMI-1813)

@artsy/emerald-devs 

This PR adds a the `Character limit reached` helper text to the TextArea that will show when the character limit has been reached, replacing the `*required` text when available. 

This is enabled using the prop `characterLimitHelper`, however, once this gets officially added to the design system we will implement this change globally. 


https://github.com/artsy/palette/assets/50849237/8f28c3dc-57e4-4123-83e3-0c3a9b187e35



[EMI-1813]: https://artsyproduct.atlassian.net/browse/EMI-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ