### PR TITLE
feat(dropdown): handles potentially overflowing content

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -252,3 +252,35 @@ export const FilterExample = () => {
     </Dropdown>
   )
 }
+
+export const OverflowingContent = () => {
+  const dropdown = (
+    <Text variant="sm-display">
+      {new Array(100).fill(null).map((_, i) => (
+        <Clickable key={i} display="block" width="100%" py={1} px={2}>
+          Item {i}
+        </Clickable>
+      ))}
+    </Text>
+  )
+
+  return (
+    <Flex>
+      <Dropdown dropdown={dropdown} openDropdownByClick>
+        {({ anchorRef, anchorProps }) => {
+          return (
+            <Button
+              ref={anchorRef}
+              variant="secondaryBlack"
+              size="small"
+              mr={1}
+              {...anchorProps}
+            >
+              Click to display dropdown
+            </Button>
+          )
+        }}
+      </Dropdown>
+    </Flex>
+  )
+}

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -315,4 +315,8 @@ const Container = styled(Box)<{ placement: Position } & BoxProps>`
 const Panel = styled(Box)`
   transition: opacity 250ms ease-out, transform 250ms ease-out;
   box-shadow: ${themeGet("effects.flatShadow")};
+  > div {
+    max-height: 100vh;
+    overflow-y: auto;
+  }
 `


### PR DESCRIPTION
This just ensures that in cases where a dropdown might be taller than the screen, all content can still be accessed.

https://github.com/artsy/palette/assets/112297/dc25ba8b-f0bc-4ecd-9e2b-769cb5ceda2e

