### PR TITLE
chore: allow null | undefined for image prop in Card

### DIFF
--- a/packages/palette/src/elements/Cards/Card.tsx
+++ b/packages/palette/src/elements/Cards/Card.tsx
@@ -6,7 +6,7 @@ import { ResponsiveBox } from "../ResponsiveBox"
 import { useTheme } from "../../Theme"
 
 export interface CardProps extends BoxProps {
-  image: string | ImageProps
+  image: string | ImageProps | null | undefined
   title?: string | null
   subtitle?: string | null
   status?: string | null


### PR DESCRIPTION
This is supported/works, w/ a storybook entry - https://github.com/artsy/palette/blob/4f75e5bbea5cb5c9d70b54f044b82e342dede675/packages/palette/src/elements/Cards/Cards.story.tsx#L17 - but the typing wasn't right.