### PR TITLE
fix(modaldialog): passes in z-index correctly

### DIFF
--- a/packages/palette/src/elements/ModalDialog/ModalDialog.story.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialog.story.tsx
@@ -118,6 +118,10 @@ export const Default = () => {
           ),
           footer: <Button width="100%">Confirm</Button>,
         },
+        {
+          title: "With custom z-index",
+          zIndex: 1000,
+        },
       ]}
     >
       {(props) => <Demo {...props} />}

--- a/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
@@ -23,6 +23,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = ({
   rightPanel,
   title,
   header,
+  zIndex,
   ...rest
 }) => {
   const isMounted = useDidMount({ clearCallStack: true })
@@ -43,6 +44,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = ({
           : { backgroundColor: "transparent" }
       }
       dialogProps={{ width: width ?? 480 }}
+      zIndex={zIndex}
       {...modalProps}
     >
       <ModalDialogContent


### PR DESCRIPTION
First step in removing the massive z-index: supporting one correctly via props.