### PR TITLE
feat(EMI-1904): add onClose prop to banner

### DIFF
--- a/packages/palette/src/elements/Banner/Banner.test.tsx
+++ b/packages/palette/src/elements/Banner/Banner.test.tsx
@@ -32,4 +32,15 @@ describe("Button", () => {
     wrapper.find("Clickable").simulate("click")
     expect(wrapper.find("Clickable")).toHaveLength(0)
   })
+
+  it("calls 'onClose' when dismissed", () => {
+    const onClose = jest.fn()
+    const wrapper = mount(
+      <Banner dismissable onClose={onClose}>
+        There was an error.
+      </Banner>
+    )
+    wrapper.find("Clickable").simulate("click")
+    expect(onClose).toHaveBeenCalled()
+  })
 })

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -11,17 +11,22 @@ export type BannerVariant = keyof typeof BANNER_VARIANTS
 export interface BannerProps extends FlexProps {
   variant?: BannerVariant
   dismissable?: boolean
+  onClose?: () => void
 }
 
 /** A banner */
 export const Banner: React.FC<BannerProps> = ({
   dismissable = false,
+  onClose,
   children,
   ...rest
 }) => {
   const [dismissed, setDismissed] = useState(false)
 
   const handleClick = () => {
+    if (onClose) {
+      onClose()
+    }
     setDismissed(true)
   }
 


### PR DESCRIPTION
[EMI-1904](https://artsyproduct.atlassian.net/browse/EMI-1904)

This PR adds an`onClose` prop to the `Banner.tsx` component so we can dismiss a one-time banner. 

[EMI-1904]: https://artsyproduct.atlassian.net/browse/EMI-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ