### PR TITLE
fix: improves contrast ratio of black60 in dark mode; default message variant

### DIFF
--- a/packages/palette-tokens/src/themes/v3.tsx
+++ b/packages/palette-tokens/src/themes/v3.tsx
@@ -36,7 +36,7 @@ const BREAKPOINTS_SCALE = Object.assign(
 const COLORS = {
   /** Suitable for text on black10 and lighter */
   black100: "#000000",
-  /** Suitable for text on black10 and lighter */
+  /** Suitable for text on black5 and lighter */
   black60: "#707070",
   /** Background only */
   black30: "#C2C2C2",

--- a/packages/palette-tokens/src/themes/v3Dark.tsx
+++ b/packages/palette-tokens/src/themes/v3Dark.tsx
@@ -3,8 +3,8 @@ import { Colors, Effects, THEME as THEME_LIGHT } from "./v3";
 const COLORS: Colors = {
   /** Suitable for text on black10 and lighter */
   black100: "#ffffff",
-  /** Suitable for text on black10 and lighter */
-  black60: "#7d7d7d",
+  /** Suitable for text on black5 and lighter */
+  black60: "#949494",
   /** Background only */
   black30: "#4d4d4d",
   /** Background only */

--- a/packages/palette/src/elements/Message/Message.tsx
+++ b/packages/palette/src/elements/Message/Message.tsx
@@ -6,7 +6,7 @@ import { Text } from "../Text"
 
 export const MESSAGE_VARIANTS = {
   default: {
-    backgroundColor: "black10",
+    backgroundColor: "black5",
     color: "black100",
   },
   info: {


### PR DESCRIPTION
Improves contrast ratios. Re: dark mode Q/A
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@37.11.2-canary.1388.30720.0
  npm install @artsy/palette-tokens@6.0.2-canary.1388.30720.0
  npm install @artsy/palette@38.11.2-canary.1388.30720.0
  # or 
  yarn add @artsy/palette-charts@37.11.2-canary.1388.30720.0
  yarn add @artsy/palette-tokens@6.0.2-canary.1388.30720.0
  yarn add @artsy/palette@38.11.2-canary.1388.30720.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
