### PR TITLE
fix: replaces lodash with es-toolkit

### DIFF
--- a/packages/palette/.eslintrc.js
+++ b/packages/palette/.eslintrc.js
@@ -36,5 +36,12 @@ module.exports = {
     "react-hooks/exhaustive-deps": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react/prop-types": 0,
+    "no-restricted-imports": [
+      "error",
+      {
+        name: "lodash",
+        message: "Please use `es-toolkit` instead.",
+      },
+    ],
   },
 }

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -121,7 +121,7 @@
     "@artsy/palette-tokens": "^6.0.3",
     "@seznam/compose-react-refs": "^1.0.6",
     "@styled-system/theme-get": "^5.1.2",
-    "lodash": "^4.17.21",
+    "es-toolkit": "^1.16.0",
     "proportional-scale": "^4.0.0",
     "react-focus-on": "^3.7.0",
     "react-lazy-load-image-component": "1.5.5",

--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
@@ -1,4 +1,3 @@
-import { reject } from "lodash"
 import React, {
   createContext,
   useContext,
@@ -95,9 +94,9 @@ const filterSelectReducer = (state: FilterSelectState, action: Action) => {
 
       let selectedItems
       if (isFound) {
-        selectedItems = reject(state.selectedItems, {
-          value: action.payload.item.value,
-        })
+        selectedItems = state.selectedItems.filter(
+          (item) => item.value !== action.payload.item.value
+        )
       } else {
         selectedItems = state.multiselect
           ? [...state.selectedItems, action.payload.item]

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -1,4 +1,4 @@
-import { intersection, orderBy, uniqBy } from "lodash"
+import { intersection, orderBy, uniqBy } from "es-toolkit"
 import * as React from "react"
 import { ShowMore } from "../ShowMore"
 import { Flex } from "../Flex"
@@ -6,6 +6,7 @@ import { FilterSelectResultItem } from "./Components/FilterSelectResultItem"
 import {
   FilterSelectContextProvider,
   FilterSelectState,
+  Items,
   useFilterSelectContext,
 } from "./Components/FilterSelectContext"
 import { FilterInput } from "./Components/FilterInput"
@@ -54,12 +55,12 @@ const _FilterSelect: React.FC = () => {
     return null
   }
 
-  const orderItems = (items) => orderBy(items, order[0], order[1])
+  const orderItems = (items: Items) => orderBy([...items], order[0], order[1])
   const itemsOrdered = orderItems(items)
   const filterdItemsOrdered = orderItems(filteredItems)
   const itemsSorted = multiselect
     ? // Move selected items to the top
-      uniqBy(selectedItems.concat(itemsOrdered), "value")
+      uniqBy(selectedItems.concat(itemsOrdered), (x) => x.value)
     : itemsOrdered
   const expanded = isBelowTheFoldSelected(selectedItems, itemsSorted)
   const showNoResults = filteredItems.length === 0 && query !== ""

--- a/packages/palette/src/themes/Themes.story.tsx
+++ b/packages/palette/src/themes/Themes.story.tsx
@@ -28,7 +28,7 @@ import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 import { THEME_DARK } from "@artsy/palette-tokens/dist/themes/v3Dark"
 import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
 import CloseFillIcon from "@artsy/icons/CloseFillIcon"
-import { debounce } from "lodash"
+import { debounce } from "es-toolkit"
 
 export default {
   title: "Theme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8132,6 +8132,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es-toolkit@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.16.0.tgz#add09e46d52ea75531a94280f261dfc57b131984"
+  integrity sha512-eNJh3zF1KmAHRYd1D8rFi1cMFMCjrC6tumBfwuuZdSur97mED/ifyeBoGzxS11L4owCMx3XSmWTo6oxJQkdGng==
+
 es5-shim@^4.5.13:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.6.4.tgz#10ce5f06c7bccfdd60b4e08edf95c7e2fbc1dc2a"


### PR DESCRIPTION
Re: [DIA-790](https://artsyproduct.atlassian.net/browse/DIA-790)

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-08-19-09-29-57.88-EhaqGrp2NEGrAeJNfyuV025L6QFZH22VC3Jx38HbFATjS68A8iHPK6UFdo3JybtC11CO9epOIe678dWWvKPk4PIW7AqM4vHKN7Vx.png)

lodash is currently 16% of palette's size.

[es-toolkit](https://es-toolkit.slash.page/) is a replacement for lodash that is [much smaller](https://es-toolkit.slash.page/bundle-size.html).

We shouldn't be importing all of lodash for a few utility functions.

We should attempt [to do this in Force](https://es-toolkit.slash.page/compatibility.html) as well. Thoughts?

[DIA-790]: https://artsyproduct.atlassian.net/browse/DIA-790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ