### PR TITLE
fix: moves focus-visible styling into global styles

### DIFF
--- a/packages/palette/src/helpers/injectGlobalStyles.tsx
+++ b/packages/palette/src/helpers/injectGlobalStyles.tsx
@@ -19,6 +19,14 @@ export function injectGlobalStyles<P>(
       box-sizing: inherit;
     }
 
+    &:focus {
+      outline: 0;
+    }
+
+    &:focus-visible {
+      outline: 1px solid ${themeGet("colors.blue100")};
+    }
+
     ::selection {
       background-color: ${themeGet("colors.blue15")};
       color: ${themeGet("colors.black100")};


### PR DESCRIPTION
We're removing the [focus-visible polyfill from force](https://github.com/artsy/force/blob/main/src/Components/FocusVisible.tsx), where this styling was previously defined.