### PR TITLE
feat(modaldialog): supports fully custom title components

### DIFF
--- a/packages/palette/src/elements/ModalDialog/ModalDialogContent.story.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialogContent.story.tsx
@@ -10,6 +10,10 @@ import { Button } from "../Button"
 import { Input } from "../Input"
 import { Join } from "../Join"
 import { Spacer } from "../Spacer"
+import { Box } from "../Box"
+import ChevronLeftIcon from "@artsy/icons/ChevronLeftIcon"
+import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
+import CloseIcon from "@artsy/icons/CloseIcon"
 
 export default {
   title: "Components/ModalDialogContent",
@@ -72,6 +76,20 @@ export const Default = () => {
             "Modal Title with a longer title or headline text that runs on for mutliple lines",
           hasLogo: true,
           footer: <Button width="100%">Confirm</Button>,
+        },
+        {
+          title: (
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="space-between"
+              p={2}
+            >
+              <ChevronLeftIcon />
+              <ArtsyLogoIcon height={30} />
+              <CloseIcon />
+            </Box>
+          ),
         },
       ]}
     >

--- a/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react"
+import React, { FC, isValidElement } from "react"
 import { Clickable, ClickableProps } from "../Clickable"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
@@ -13,14 +13,14 @@ import { useTheme } from "../../Theme"
 
 export interface ModalDialogContentProps
   extends BoxProps,
-    React.HTMLAttributes<HTMLDivElement> {
+    Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   children: React.ReactNode
   footer?: React.ReactNode
   hasLogo?: boolean
   leftPanel?: React.ReactNode
   onClose: () => void
   rightPanel?: React.ReactNode
-  title?: string
+  title?: React.ReactNode
   header?: React.ReactNode
 }
 
@@ -65,25 +65,29 @@ export const ModalDialogContent: React.FC<ModalDialogContentProps> = ({
             boxShadow: isAtTop ? theme.effects.dropShadow : undefined,
           }}
         >
-          <Flex alignItems="flex-start" justifyContent="space-between">
-            {(title || hasLogo) && (
-              <Box m={2}>
-                {hasLogo && (
-                  <ArtsyLogoIcon display="block" width={75} height={26} />
-                )}
+          {isValidElement(title) ? (
+            title
+          ) : (
+            <Flex alignItems="flex-start" justifyContent="space-between">
+              {(title || hasLogo) && (
+                <Box m={2}>
+                  {hasLogo && (
+                    <ArtsyLogoIcon display="block" width={75} height={26} />
+                  )}
 
-                {hasLogo && title && <Spacer y={2} />}
+                  {hasLogo && title && <Spacer y={2} />}
 
-                {title && (
-                  <Text variant="lg-display" lineClamp={6} hyphenate>
-                    {title}
-                  </Text>
-                )}
-              </Box>
-            )}
+                  {title && (
+                    <Text variant="lg-display" lineClamp={6} hyphenate>
+                      {title}
+                    </Text>
+                  )}
+                </Box>
+              )}
 
-            <ModalClose onClick={onClose} />
-          </Flex>
+              <ModalClose onClick={onClose} />
+            </Flex>
+          )}
 
           {header && (
             <Box px={2} pb={2}>


### PR DESCRIPTION
New auth dialog has an unusual title section wherein a back button gets displayed. This PR adds support for passing in a fully custom title area.

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-09-03-08-40-11.81-Kl86AkQ9B5WtpRom7z8Rpmvnz47I1xzM19IgUeIKOoGtZZ8qUcfnvLa4YxZV1v403sldNYufUu0RDrzCE2VLQqIgRHE90eivGuzz.png)