### PR TITLE
fix(modaldialog): corrects type for title

### DIFF
--- a/packages/palette/src/elements/ModalDialog/ModalDialog.story.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialog.story.tsx
@@ -122,6 +122,9 @@ export const Default = () => {
           title: "With custom z-index",
           zIndex: 1000,
         },
+        {
+          title: <Box bg="red">Custom title</Box>,
+        },
       ]}
     >
       {(props) => <Demo {...props} />}

--- a/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
@@ -8,7 +8,7 @@ import { splitBoxProps } from "../Box"
 import { useDidMount } from "../../utils/useDidMount"
 import { useTheme } from "../../Theme"
 
-export type ModalDialogProps = ModalBaseProps &
+export type ModalDialogProps = Omit<ModalBaseProps, "title"> &
   ModalDialogContentProps & {
     leftPanel?: React.ReactNode
     rightPanel?: React.ReactNode


### PR DESCRIPTION
`ModalBaseProps` was extending a base HTML element's title prop, which was interfering here.