### PR TITLE
fix: Update color red100 and red10

### DIFF
--- a/packages/palette-tokens/src/themes/v3.tsx
+++ b/packages/palette-tokens/src/themes/v3.tsx
@@ -86,7 +86,7 @@ const COLORS = {
   /** Hover/down state and suitable for text on red10 */
   red150: "#510B0B",
   /** Suitable for text on red10, black10, and lighter */
-  red100: "#C82400",
+  red100: "#BB392D",
   /** Background only */
   red10: "#F4E4E3",
 };

--- a/packages/palette-tokens/src/themes/v3.tsx
+++ b/packages/palette-tokens/src/themes/v3.tsx
@@ -88,7 +88,7 @@ const COLORS = {
   /** Suitable for text on red10, black10, and lighter */
   red100: "#BB392D",
   /** Background only */
-  red10: "#F4E4E3",
+  red10: "#FEF2EF",
 };
 
 export type Colors = typeof COLORS;


### PR DESCRIPTION
Resolves [Figma comment](https://www.figma.com/design/UyNOc2vz3bf9k6Cw2itqwd/Home-Feed-(App)?node-id=0-1&node-type=canvas&t=92ePCBF66k3VotOH-0)

## Description

This updates the colors `red100` and `red10` to match the color in the [design system](https://www.figma.com/design/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System?node-id=6726-1370&node-type=text&m=dev).