### PR TITLE
fix(stackable-box): Fix css specificity on borders

### DIFF
--- a/packages/palette/src/elements/StackableBorderBox/StackableBorderBox.story.tsx
+++ b/packages/palette/src/elements/StackableBorderBox/StackableBorderBox.story.tsx
@@ -1,5 +1,8 @@
 import React from "react"
 import { StackableBorderBox } from "./StackableBorderBox"
+import { Avatar } from "../Avatar/Avatar"
+import { Flex } from "../Flex"
+import { Button } from "../Button"
 
 export default {
   title: "Components/StackableBorderBox",
@@ -8,7 +11,23 @@ export default {
 export const Default = () => {
   return (
     <>
-      <StackableBorderBox>1</StackableBorderBox>
+      <StackableBorderBox>
+        <Flex>
+          <Flex>
+            <Avatar
+              size="xs"
+              src="https://picsum.photos/seed/example/110/110"
+            />
+          </Flex>
+          <Flex>
+            <Avatar
+              size="xs"
+              src="https://picsum.photos/seed/example/110/110"
+            />
+          </Flex>
+          <Button>Click me</Button>
+        </Flex>
+      </StackableBorderBox>
       <StackableBorderBox>2</StackableBorderBox>
       <StackableBorderBox>3</StackableBorderBox>
       <StackableBorderBox>4</StackableBorderBox>

--- a/packages/palette/src/elements/StackableBorderBox/StackableBorderBox.tsx
+++ b/packages/palette/src/elements/StackableBorderBox/StackableBorderBox.tsx
@@ -7,11 +7,11 @@ export type StackableBorderBoxProps = BorderBoxProps
  * A stackable border box is a BorderBox that shares borders with its siblings.
  */
 export const StackableBorderBox = styled(BorderBox)<BorderBoxProps>`
-  :not(:first-child) {
+  &:not(:first-child) {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }
-  :not(:last-child) {
+  &:not(:last-child) {
     border-bottom: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;


### PR DESCRIPTION
Noticed some strange issues inside of StackableBorderBox components. Needed to fix the css specifificity:

before / after:

<img width="385" alt="Screenshot 2024-10-21 at 3 50 47 PM" src="https://github.com/user-attachments/assets/3cd1a420-c5be-4bfa-81a4-b01f6b6af004">

<img width="335" alt="Screenshot 2024-10-21 at 3 50 40 PM" src="https://github.com/user-attachments/assets/00f59d75-9597-4d22-bdb5-909961709084">
