### PR TITLE
fix(input): Fix placeholder visibility

### DIFF
--- a/packages/palette/src/elements/Input/Input.story.tsx
+++ b/packages/palette/src/elements/Input/Input.story.tsx
@@ -13,13 +13,13 @@ export const Default = () => {
     <States<InputProps>
       states={[
         {},
+        { title: "Your offer", name: "offer" },
         { focus: true },
         { hover: true },
         { active: true },
         { error: "Something went wrong." },
         { disabled: true },
         { disabled: true, value: "Example value" },
-        { title: "Your offer", name: "offer" },
         { title: "Your offer with a big title", name: "offer-big-title" },
         {
           title: "Your offer with a really really long title",

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -168,6 +168,11 @@ const StyledInput = styled.input<StyledInputProps>`
         outline: none;
         ${INPUT_STATES.focus}
 
+        &::placeholder {
+          transition: ${FORM_ELEMENT_TRANSITION};
+          opacity: 1;
+        }
+
         :not(:placeholder-shown) {
           ${INPUT_STATES.active}
           ${props.error && INPUT_STATES.error}
@@ -181,7 +186,8 @@ const StyledInput = styled.input<StyledInputProps>`
 
       ${props.title &&
       css`
-        ::placeholder {
+        &::placeholder {
+          transition: ${FORM_ELEMENT_TRANSITION};
           opacity: 0;
         }
       `}


### PR DESCRIPTION
It looks like there were some specificity changes with styled components 6 and certain elements could no longer be targeted without an `&`. This fixes the placeholders in the inputs:

Before:

https://github.com/user-attachments/assets/83020796-cd89-45d5-bc1e-1432a58d0adb

After: 

https://github.com/user-attachments/assets/38216faf-6ca4-4259-adbc-766b0f622612

