### PR TITLE
fix(textarea): Fix placeholder visibility

### DIFF
--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -182,7 +182,7 @@ const StyledTextArea = styled.textarea<StyledTextAreaProps>`
   border-radius: 3px;
   font-family: ${themeGet("fonts.sans")};
 
-  ::placeholder {
+  &::placeholder {
     transition: color 0.25s, opacity 0.25s;
   }
 
@@ -212,6 +212,10 @@ const StyledTextArea = styled.textarea<StyledTextAreaProps>`
           ${!!props.placeholder && TEXTAREA_STATES.active}
           ${props.error && TEXTAREA_STATES.error}
         }
+
+        &::placeholder {
+          opacity: 1;
+        }
       }
 
       &:disabled {
@@ -221,7 +225,7 @@ const StyledTextArea = styled.textarea<StyledTextAreaProps>`
 
       ${props.title &&
       css`
-        ::placeholder {
+        &::placeholder {
           opacity: 0;
         }
       `}


### PR DESCRIPTION
Similar to #1405, this fixes the placeholders in the textarea:

Before:

https://github.com/user-attachments/assets/3a3736b1-84d1-40a0-982f-dcaa9e9ccb15

After:

https://github.com/user-attachments/assets/c16032a4-cd37-4945-8b93-15e803c94f0b

