### PR TITLE
chore(react-18): Upgrade libs to React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     ]
   },
   "resolutions": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "webpack": "5.52.1"
   },
   "devDependencies": {

--- a/packages/palette-charts/package.json
+++ b/packages/palette-charts/package.json
@@ -40,8 +40,8 @@
     "colors": "1.4.0"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^18",
+    "react-dom": "^18",
     "styled-components": "^4"
   },
   "devDependencies": {
@@ -69,8 +69,8 @@
     "@types/enzyme": "3.10.8",
     "@types/jest": "^28.0.0",
     "@types/node": "14.14.27",
-    "@types/react": "17.0.2",
-    "@types/react-dom": "17.0.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@types/react-lazy-load-image-component": "1.3.0",
     "@types/react-test-renderer": "16.8.1",
     "@types/semver": "5.5.0",
@@ -97,8 +97,8 @@
     "lint-staged": "8.1.5",
     "mock-raf": "1.0.1",
     "prettier": "2.2.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-powerplug": "1.0.0",
     "react-test-renderer": "16.8.6",
     "regenerator-runtime": "0.13.5",

--- a/packages/palette-charts/package.json
+++ b/packages/palette-charts/package.json
@@ -154,7 +154,13 @@
       "node_modules",
       "<rootDir>/src"
     ],
+    "moduleNameMapper": {
+      "^react$": "react-17",
+      "^react-dom$": "react-dom-17",
+      "^react-dom/test-utils$": "react-dom-17/test-utils"
+    },
     "setupFilesAfterEnv": [
+      "<rootDir>/src/jestShim.js",
       "<rootDir>/setupTests.ts"
     ],
     "snapshotSerializers": [

--- a/packages/palette-charts/src/elements/DataVis/ChartTooltip.tsx
+++ b/packages/palette-charts/src/elements/DataVis/ChartTooltip.tsx
@@ -32,7 +32,7 @@ export const coerceTooltipWithoutPadding = (
 export interface ChartTooltipProps extends FlexProps {
   title: React.ReactNode
   description: React.ReactNode
-  noPadding: boolean
+  noPadding?: boolean
 }
 
 // tslint:disable-next-line:completed-docs

--- a/packages/palette-charts/src/elements/DataVis/MousePositionContext.tsx
+++ b/packages/palette-charts/src/elements/DataVis/MousePositionContext.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react"
 export const MousePositionContext = React.createContext({ x: 0, y: 0 })
 
 // tslint:disable-next-line:completed-docs
-export const ProvideMousePosition: React.SFC = ({ children }) => {
+export const ProvideMousePosition: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const [state, setState] = useState({ x: 0, y: 0 })
 
   useEffect(() => {

--- a/packages/palette-charts/src/elements/DataVis/useIntersectionObserver.ts
+++ b/packages/palette-charts/src/elements/DataVis/useIntersectionObserver.ts
@@ -1,3 +1,4 @@
+import { useDidMount } from "@artsy/palette"
 import { RefObject, useEffect, useRef, useState } from "react"
 
 interface UseIntersectionObserverProperties {
@@ -19,6 +20,8 @@ export const useIntersectionObserver = ({
   onIntersection,
   onOffIntersection,
 }: UseIntersectionObserverProperties) => {
+  const isClient = useDidMount()
+
   const ref = useRef<HTMLElement | null>(null)
 
   const handleIntersect = (entries: IntersectionObserverEntry[]) => {
@@ -51,9 +54,7 @@ export const useIntersectionObserver = ({
   }
 
   const [observer] = useState(() =>
-    isClientSide
-      ? new IntersectionObserver(handleIntersect, options)
-      : undefined
+    isClient ? new IntersectionObserver(handleIntersect, options) : undefined
   )
 
   useEffect(() => {
@@ -68,5 +69,3 @@ export const useIntersectionObserver = ({
 
   return { ref }
 }
-
-const isClientSide = typeof window !== "undefined"

--- a/packages/palette-charts/src/elements/DonutChart/DonutChart.tsx
+++ b/packages/palette-charts/src/elements/DonutChart/DonutChart.tsx
@@ -23,7 +23,7 @@ export interface DonutChartProps extends ChartProps {
  * DonutChart is a component that displays data points with donut shaped arcs.
  * Good for illustrating numerical proportions.
  */
-export const DonutChart: React.FC<DonutChartProps> = ({
+export const DonutChart: React.FC<React.PropsWithChildren<DonutChartProps>> = ({
   points,
   margin = space(2), // FIXME: This whole
 }) => {

--- a/packages/palette-charts/src/elements/LineChart/LineChart.tsx
+++ b/packages/palette-charts/src/elements/LineChart/LineChart.tsx
@@ -19,7 +19,7 @@ export interface LineChartProps extends ChartProps {
  * LineChart is a component that displays some data points connected by lines.
  * Useful for visualizing a time series, etc.
  */
-export const LineChart: React.FC<LineChartProps> = ({
+export const LineChart: React.FC<React.PropsWithChildren<LineChartProps>> = ({
   points,
   height = DEFAULT_HEIGHT,
 }: LineChartProps) => {
@@ -82,7 +82,7 @@ interface HoverHandlerProps {
   setHoverIndex: React.Dispatch<React.SetStateAction<number>>
 }
 
-const HoverHandler: React.FC<HoverHandlerProps> = ({
+const HoverHandler: React.FC<React.PropsWithChildren<HoverHandlerProps>> = ({
   children,
   index,
   hoverIndex,

--- a/packages/palette-charts/src/elements/LineChart/LineChart.tsx
+++ b/packages/palette-charts/src/elements/LineChart/LineChart.tsx
@@ -62,7 +62,7 @@ export const LineChart: React.FC<React.PropsWithChildren<LineChartProps>> = ({
                     last={i === points.length - 1}
                   >
                     <AxisLabelX color="black60" variant="xs">
-                      {axisLabelX}
+                      {axisLabelX as any}
                     </AxisLabelX>
                   </BarAxisLabelContainer>
                 ))}

--- a/packages/palette-charts/src/elements/LineChart/LineChartSVG.tsx
+++ b/packages/palette-charts/src/elements/LineChart/LineChartSVG.tsx
@@ -19,7 +19,7 @@ interface LineChartSVGProps {
 /**
  * Component rendering the SVG part of the line chart (e.g line and points)
  */
-export const LineChartSVG: React.FC<LineChartSVGProps> = ({
+export const LineChartSVG: React.FC<React.PropsWithChildren<LineChartSVGProps>> = ({
   width,
   height,
   margin,

--- a/packages/palette-charts/src/jestShim.js
+++ b/packages/palette-charts/src/jestShim.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-undef */
+import { TextEncoder, TextDecoder } from "util"
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder

--- a/packages/palette-charts/src/jestShim.js
+++ b/packages/palette-charts/src/jestShim.js
@@ -1,4 +1,4 @@
 /* eslint-disable no-undef */
-import { TextEncoder, TextDecoder } from "util"
+const { TextEncoder, TextDecoder } = require("util")
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder

--- a/packages/palette/.eslintrc.js
+++ b/packages/palette/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         caughtErrorsIgnorePattern: "^_",
       },
     ],
+    "@typescript-eslint/no-explicit-any": 0,
     "react-hooks/exhaustive-deps": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react/prop-types": 0,

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -102,7 +102,9 @@
     "nodemon": "^2.0.22",
     "prettier": "2.2.1",
     "react": "^18.3.1",
+    "react-17": "npm:react@17.0.2",
     "react-dom": "^18.3.1",
+    "react-dom-17": "npm:react-dom@17.0.2",
     "react-powerplug": "1.0.0",
     "react-test-renderer": "16.8.6",
     "regenerator-runtime": "0.13.5",
@@ -162,7 +164,13 @@
       "node_modules",
       "<rootDir>/src"
     ],
+    "moduleNameMapper": {
+      "^react$": "react-17",
+      "^react-dom$": "react-dom-17",
+      "^react-dom/test-utils$": "react-dom-17/test-utils"
+    },
     "setupFilesAfterEnv": [
+      "<rootDir>/src/utils/jestShim.js",
       "<rootDir>/setupTests.ts"
     ],
     "snapshotSerializers": [

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -39,8 +39,8 @@
   },
   "homepage": "https://github.com/artsy/palette#readme",
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^18",
+    "react-dom": "^18",
     "styled-components": "^6"
   },
   "devDependencies": {
@@ -66,8 +66,8 @@
     "@types/enzyme": "3.10.8",
     "@types/jest": "^28.0.0",
     "@types/node": "14.14.27",
-    "@types/react": "17.0.2",
-    "@types/react-dom": "17.0.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@types/react-lazy-load-image-component": "1.3.0",
     "@types/react-test-renderer": "16.8.1",
     "@types/semver": "5.5.0",
@@ -101,8 +101,8 @@
     "mock-raf": "1.0.1",
     "nodemon": "^2.0.22",
     "prettier": "2.2.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-powerplug": "1.0.0",
     "react-test-renderer": "16.8.6",
     "regenerator-runtime": "0.13.5",

--- a/packages/palette/src/Theme.tsx
+++ b/packages/palette/src/Theme.tsx
@@ -21,7 +21,7 @@ interface ThemeProps {
 /**
  * A wrapper component for passing down the Artsy theme context
  */
-export const Theme: React.FC<ThemeProps> = ({ children, theme = "light" }) => {
+export const Theme: React.FC<React.PropsWithChildren<ThemeProps>> = ({ children, theme = "light" }) => {
   const selectedTheme = THEMES[theme]
   return <ThemeProvider theme={selectedTheme}>{children}</ThemeProvider>
 }

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -74,7 +74,7 @@ export interface AutocompleteInputProps<T extends AutocompleteInputOptionType>
   flip?: boolean
   footer?:
     | React.ReactNode
-    | ((dropdownActions: AutocompleteFooterActions) => void)
+    | ((dropdownActions: AutocompleteFooterActions) => React.ReactNode)
   /** Ref to the input; workaround generics */
   forwardRef?: React.Ref<HTMLInputElement>
   /** on <enter> when no option is selected */

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInputOption.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInputOption.tsx
@@ -8,9 +8,10 @@ export interface AutocompleteInputOptionProps extends ClickableProps {
   selected: boolean
 }
 
-export const AutocompleteInputOption: React.ForwardRefExoticComponent<
-  AutocompleteInputOptionProps & { ref?: React.Ref<HTMLButtonElement> }
-> = forwardRef(({ children, selected, ...rest }, forwardedRef) => {
+export const AutocompleteInputOption = forwardRef<
+  HTMLButtonElement,
+  AutocompleteInputOptionProps
+>(({ children, selected, ...rest }, forwardedRef) => {
   const ref = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {

--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInputOptionLabel.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInputOptionLabel.tsx
@@ -5,7 +5,7 @@ export interface AutocompleteInputOptionLabelProps extends TextProps {
   text: string
 }
 
-export const AutocompleteInputOptionLabel: React.FC<AutocompleteInputOptionLabelProps> = ({
+export const AutocompleteInputOptionLabel: React.FC<React.PropsWithChildren<AutocompleteInputOptionLabelProps>> = ({
   text,
   ...rest
 }) => {

--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -42,7 +42,7 @@ const TOKENS = {
 }
 
 /** An circular Avatar component containing an image or initials */
-export const Avatar: React.FC<AvatarProps> = ({
+export const Avatar: React.FC<React.PropsWithChildren<AvatarProps>> = ({
   src,
   initials,
   size = "md",

--- a/packages/palette/src/elements/Banner/Banner.tsx
+++ b/packages/palette/src/elements/Banner/Banner.tsx
@@ -15,7 +15,7 @@ export interface BannerProps extends FlexProps {
 }
 
 /** A banner */
-export const Banner: React.FC<BannerProps> = ({
+export const Banner: React.FC<React.PropsWithChildren<BannerProps>> = ({
   dismissable = false,
   onClose,
   children,

--- a/packages/palette/src/elements/BaseTabs/BaseTab.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTab.tsx
@@ -8,7 +8,7 @@ import { STATES } from "./tokens"
  * Utilize as="a" or as={Component} to alter functionality
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type BaseTabProps<C extends React.ComponentType = any> = TextProps & {
+export type BaseTabProps<C extends React.ComponentType<React.PropsWithChildren<unknown>> = any> = TextProps & {
   active?: boolean
   focus?: boolean
   hover?: boolean

--- a/packages/palette/src/elements/BaseTabs/BaseTabs.story.tsx
+++ b/packages/palette/src/elements/BaseTabs/BaseTabs.story.tsx
@@ -8,7 +8,7 @@ import { BaseTabProps } from "./BaseTab"
 import { BaseTabsProps } from "./BaseTabs"
 
 // Fake `RouterLink`
-const RouterLink: React.FC<{ to: string }> = ({ to, children, ...rest }) => {
+const RouterLink: React.FC<React.PropsWithChildren<{ to: string }>> = ({ to, children, ...rest }) => {
   return (
     <a href={to} {...rest}>
       {children}

--- a/packages/palette/src/elements/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/palette/src/elements/Breadcrumbs/Breadcrumbs.tsx
@@ -39,7 +39,7 @@ export type BreadcrumbsProps = BoxProps
  * a website or web application. Breadcrumbs are often placed horizontally
  * before a page's main content.
  */
-export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
+export const Breadcrumbs: React.FC<React.PropsWithChildren<BreadcrumbsProps>> = ({
   children,
   ...rest
 }) => {

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -38,7 +38,7 @@ export interface ButtonProps
   /** Forces success state */
   success?: boolean
   /** Optional icon slot */
-  Icon?: React.FunctionComponent<BoxProps & { fill?: ResponsiveValue<string> }>
+  Icon?: React.FunctionComponent<React.PropsWithChildren<BoxProps & { fill?: ResponsiveValue<string> }>>
 }
 
 export const Button: React.ForwardRefExoticComponent<

--- a/packages/palette/src/elements/Button/Button.tsx
+++ b/packages/palette/src/elements/Button/Button.tsx
@@ -38,12 +38,12 @@ export interface ButtonProps
   /** Forces success state */
   success?: boolean
   /** Optional icon slot */
-  Icon?: React.FunctionComponent<React.PropsWithChildren<BoxProps & { fill?: ResponsiveValue<string> }>>
+  Icon?: React.FunctionComponent<
+    React.PropsWithChildren<BoxProps & { fill?: ResponsiveValue<string> }>
+  >
 }
 
-export const Button: React.ForwardRefExoticComponent<
-  ButtonProps & { ref?: React.Ref<HTMLElement> }
-> = React.forwardRef(
+export const Button = React.forwardRef<HTMLElement, ButtonProps>(
   (
     {
       children,

--- a/packages/palette/src/elements/Cards/Card.tsx
+++ b/packages/palette/src/elements/Cards/Card.tsx
@@ -18,7 +18,7 @@ export interface CardProps extends BoxProps {
  * `Card` is a card with one image one tall image, and text for title
  * and subtitle at the bottom.
  */
-export const Card: React.FC<CardProps> = ({
+export const Card: React.FC<React.PropsWithChildren<CardProps>> = ({
   image,
   title,
   subtitle,

--- a/packages/palette/src/elements/Cards/TriptychCard.tsx
+++ b/packages/palette/src/elements/Cards/TriptychCard.tsx
@@ -24,7 +24,7 @@ export const isArrayOfStrings = (images: Images): images is string[] =>
  * at the bottom.
  */
 
-export const TriptychCard: React.FC<TriptychCardProps> = ({
+export const TriptychCard: React.FC<React.PropsWithChildren<TriptychCardProps>> = ({
   images,
   title,
   subtitle,

--- a/packages/palette/src/elements/Carousel/Carousel.tsx
+++ b/packages/palette/src/elements/Carousel/Carousel.tsx
@@ -79,9 +79,9 @@ const Viewport = styled(Box)`
 export interface CarouselProps extends BoxProps {
   initialIndex?: number
   children: React.ReactNode
-  Next?: typeof CarouselNext | React.FC<CarouselNavigationProps>
-  Previous?: typeof CarouselPrevious | React.FC<CarouselNavigationProps>
-  Rail?: typeof CarouselRail | React.FC<CarouselRailProps>
+  Next?: typeof CarouselNext | React.FC<React.PropsWithChildren<CarouselNavigationProps>>
+  Previous?: typeof CarouselPrevious | React.FC<React.PropsWithChildren<CarouselNavigationProps>>
+  Rail?: typeof CarouselRail | React.FC<React.PropsWithChildren<CarouselRailProps>>
   /**
    * If providing a custom `Cell` you must forward a ref so
    * that cell widths can be calculated.
@@ -98,7 +98,7 @@ export interface CarouselProps extends BoxProps {
  * of the viewport, it presents navigation arrows and allows a user to page
  * through them.
  */
-export const Carousel: React.FC<CarouselProps> = ({
+export const Carousel: React.FC<React.PropsWithChildren<CarouselProps>> = ({
   initialIndex = 0,
   children,
   Previous = CarouselPrevious,

--- a/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
+++ b/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
@@ -106,7 +106,7 @@ describe("Carousel", () => {
 
     expect(html).toContain("I have 3 beautiful children")
     // @ts-expect-error  MIGRATE_STRICT_MODE
-    expect(html.match(/\<li\s/g).length).toBe(3)
+    expect(html.match(/<li\s/g).length).toBe(3)
   })
 
   it("accepts a customizable Cell", () => {

--- a/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
+++ b/packages/palette/src/elements/Carousel/__tests__/Carousel.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Box } from "../../Box"
+import { Box, BoxProps } from "../../Box"
 import { Carousel } from "../Carousel"
 
 jest.mock("../paginate", () => ({
@@ -110,16 +110,20 @@ describe("Carousel", () => {
   })
 
   it("accepts a customizable Cell", () => {
+    const Cell = React.forwardRef<any, React.PropsWithChildren<BoxProps>>(
+      ({ children, ...rest }, ref) => {
+        return (
+          <Box ref={ref as any} {...rest}>
+            beautiful number {children}
+          </Box>
+        )
+      }
+    )
+
+    Cell.displayName = "Cell"
+
     const wrapper = mount(
-      <Carousel
-        Cell={React.forwardRef(({ children, ...rest }, ref) => {
-          return (
-            <Box ref={ref as any} {...rest}>
-              beautiful number {children}
-            </Box>
-          )
-        })}
-      >
+      <Carousel Cell={Cell}>
         <>1</>
         <>2</>
         <>3</>

--- a/packages/palette/src/elements/CarouselBar/CarouselBar.tsx
+++ b/packages/palette/src/elements/CarouselBar/CarouselBar.tsx
@@ -3,7 +3,7 @@ import { ProgressBar, ProgressBarProps } from "../ProgressBar"
 
 export type CarouselBarProps = ProgressBarProps
 
-export const CarouselBar: React.FC<CarouselBarProps> = (props) => {
+export const CarouselBar: React.FC<React.PropsWithChildren<CarouselBarProps>> = (props) => {
   return (
     <ProgressBar
       height="1px"

--- a/packages/palette/src/elements/Checkbox/Check.tsx
+++ b/packages/palette/src/elements/Checkbox/Check.tsx
@@ -13,7 +13,7 @@ export interface CheckProps {
 }
 
 /** Toggeable check mark */
-export const Check: React.FC<CheckProps> = ({
+export const Check: React.FC<React.PropsWithChildren<CheckProps>> = ({
   disabled,
   selected,
   ...rest

--- a/packages/palette/src/elements/Checkbox/Checkbox.tsx
+++ b/packages/palette/src/elements/Checkbox/Checkbox.tsx
@@ -25,7 +25,7 @@ export interface CheckboxProps
 }
 
 /** A checkbox */
-export const Checkbox: React.FC<CheckboxProps> = ({
+export const Checkbox: React.FC<React.PropsWithChildren<CheckboxProps>> = ({
   selected = false,
   children,
   error,

--- a/packages/palette/src/elements/CleanTag/CleanTag.tsx
+++ b/packages/palette/src/elements/CleanTag/CleanTag.tsx
@@ -61,7 +61,7 @@ export const omit = (obj: object = {}, keys: string[]) => {
   return next
 }
 
-type ComponentSpecifier = string | FunctionComponent<any> | ComponentClass<any>
+type ComponentSpecifier = string | FunctionComponent<React.PropsWithChildren<any>> | ComponentClass<any>
 
 export interface TagProps {
   omitFromProps?: string[]

--- a/packages/palette/src/elements/Collapse/Collapse.tsx
+++ b/packages/palette/src/elements/Collapse/Collapse.tsx
@@ -6,7 +6,9 @@ export interface CollapseProps {
 /**
  * Collapse component for the web
  */
-export class Collapse extends React.Component<CollapseProps> {
+export class Collapse extends React.Component<
+  React.PropsWithChildren<CollapseProps>
+> {
   // @ts-expect-error  MIGRATE_STRICT_MODE
   wrapperModifyTimeout: ReturnType<typeof setTimeout>
   wrapperRef: HTMLDivElement | null = null

--- a/packages/palette/src/elements/Drawer/Drawer.story.tsx
+++ b/packages/palette/src/elements/Drawer/Drawer.story.tsx
@@ -10,7 +10,7 @@ export default {
   },
 }
 
-const Layout: React.FC<{ anchor: "left" | "right" }> = ({ anchor }) => {
+const Layout: React.FC<React.PropsWithChildren<{ anchor: "left" | "right" }>> = ({ anchor }) => {
   const [open, setOpen] = useState(false)
 
   return (

--- a/packages/palette/src/elements/Drawer/Drawer.tsx
+++ b/packages/palette/src/elements/Drawer/Drawer.tsx
@@ -14,7 +14,7 @@ export interface DrawerProps {
   onClose?(): void
 }
 
-export const Drawer: FC<DrawerProps> = ({
+export const Drawer: FC<React.PropsWithChildren<DrawerProps>> = ({
   children,
   anchor = "right",
   zIndex = DEFAULT_DRAWER_Z_INDEX,

--- a/packages/palette/src/elements/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/palette/src/elements/Drawer/__tests__/Drawer.test.tsx
@@ -4,7 +4,7 @@ import { Drawer } from "../Drawer"
 import { Button } from "../../Button"
 import { Text } from "../../Text"
 
-const DrawerContent: React.FC = () => {
+const DrawerContent: React.FC<React.PropsWithChildren<unknown>> = () => {
   const [open, setOpen] = React.useState(false)
 
   return (

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -47,7 +47,7 @@ export interface DropdownProps extends BoxProps {
  * A `Dropdown` is a small modal-type element which is anchored, and can be
  * positioned relative to, another element and designed to be transitioned in on hover or on click.
  */
-export const Dropdown: React.FC<DropdownProps> = ({
+export const Dropdown: React.FC<React.PropsWithChildren<DropdownProps>> = ({
   placement = "top",
   visible: _visible = false,
   keepInDOM,

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -21,7 +21,11 @@ export interface DropdownActions {
   visible: boolean
 }
 
-export interface DropdownProps extends BoxProps {
+type Children =
+  | React.ReactNode
+  | ((dropdownActions: DropdownActions) => React.ReactNode)
+
+export interface DropdownProps extends Omit<BoxProps, "children"> {
   placement?: Position
   /** Intially visible by default? */
   visible?: boolean
@@ -40,14 +44,14 @@ export interface DropdownProps extends BoxProps {
   /** Should the dropdown panel always be present in the DOM (vs removed when invisible) */
   keepInDOM?: boolean
   openDropdownByClick?: boolean
-  children: (dropdownActions: DropdownActions) => JSX.Element
+  children: Children
 }
 
 /**
  * A `Dropdown` is a small modal-type element which is anchored, and can be
  * positioned relative to, another element and designed to be transitioned in on hover or on click.
  */
-export const Dropdown: React.FC<React.PropsWithChildren<DropdownProps>> = ({
+export const Dropdown = ({
   placement = "top",
   visible: _visible = false,
   keepInDOM,
@@ -57,7 +61,7 @@ export const Dropdown: React.FC<React.PropsWithChildren<DropdownProps>> = ({
   openDropdownByClick,
   transition: _transition = true,
   ...rest
-}) => {
+}: DropdownProps) => {
   const [visible, setVisible] = useState(false)
 
   // If prop updates/set initial visibility.
@@ -260,7 +264,7 @@ export const Dropdown: React.FC<React.PropsWithChildren<DropdownProps>> = ({
 
   return (
     <>
-      {children({
+      {(children as any)?.({
         anchorRef: anchorRef as any,
         anchorProps,
         onVisible,
@@ -314,7 +318,12 @@ export const Dropdown: React.FC<React.PropsWithChildren<DropdownProps>> = ({
                 onClickOutside={onHide}
               >
                 {typeof dropdown === "function"
-                  ? dropdown({ onVisible, onHide, setVisible, visible })
+                  ? (dropdown as any)({
+                      onVisible,
+                      onHide,
+                      setVisible,
+                      visible,
+                    })
                   : dropdown}
               </FocusOn>
             </Panel>

--- a/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
+++ b/packages/palette/src/elements/EntityHeader/EntityHeader.tsx
@@ -24,7 +24,7 @@ export interface EntityHeaderProps extends FlexProps {
  * @deprecated: Use EntityHeader fragment container patterns within Force instead
  */
 
-export const EntityHeader: React.FC<EntityHeaderProps> = ({
+export const EntityHeader: React.FC<React.PropsWithChildren<EntityHeaderProps>> = ({
   name,
   href,
   meta,

--- a/packages/palette/src/elements/Expandable/Expandable.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.tsx
@@ -17,7 +17,7 @@ export interface ExpandableProps extends ClickableProps {
 /**
  * A toggleable component used to show / hide content
  */
-export const Expandable: React.FC<ExpandableProps> = ({
+export const Expandable: React.FC<React.PropsWithChildren<ExpandableProps>> = ({
   label,
   expanded: defaultExpanded,
   children,

--- a/packages/palette/src/elements/Expandable/Expandable.tsx
+++ b/packages/palette/src/elements/Expandable/Expandable.tsx
@@ -7,17 +7,22 @@ import { Clickable, ClickableProps } from "../Clickable"
 import { Flex } from "../Flex"
 import { Text } from "../Text"
 
-export interface ExpandableProps extends ClickableProps {
+type ChildrenFunction = (props: {
+  setExpanded: React.Dispatch<React.SetStateAction<boolean | undefined>>
+  expanded: boolean
+}) => React.ReactNode
+
+export interface ExpandableProps extends Omit<ClickableProps, "children"> {
   label?: string | JSX.Element
   expanded?: boolean
-  children: React.ReactNode
+  children: React.ReactNode | ChildrenFunction
   onToggle?: (isExpanded: boolean) => void
 }
 
 /**
  * A toggleable component used to show / hide content
  */
-export const Expandable: React.FC<React.PropsWithChildren<ExpandableProps>> = ({
+export const Expandable = ({
   label,
   expanded: defaultExpanded,
   children,
@@ -26,7 +31,7 @@ export const Expandable: React.FC<React.PropsWithChildren<ExpandableProps>> = ({
   onToggle,
   borderColor = "black60",
   ...rest
-}) => {
+}: ExpandableProps) => {
   const [expanded, setExpanded] = useState(defaultExpanded)
 
   const [boxProps, clickableProps] = splitBoxProps(rest)
@@ -88,7 +93,7 @@ export const Expandable: React.FC<React.PropsWithChildren<ExpandableProps>> = ({
 
       {expanded &&
         (typeof children === "function"
-          ? children({ setExpanded, expanded })
+          ? (children as ChildrenFunction)({ setExpanded, expanded })
           : children)}
     </Box>
   )

--- a/packages/palette/src/elements/FilterSelect/Components/FilterInput.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterInput.tsx
@@ -9,7 +9,7 @@ import { useFilterSelectContext } from "./FilterSelectContext"
 
 export type FilterInputProps = InputProps
 
-export const FilterInput: React.FC<InputProps> = (props) => {
+export const FilterInput: React.FC<React.PropsWithChildren<InputProps>> = (props) => {
   const { query, setQuery, placeholder } = useFilterSelectContext()
   const ref = useRef<HTMLInputElement | null>(null)
 
@@ -23,28 +23,28 @@ export const FilterInput: React.FC<InputProps> = (props) => {
   }
 
   return (
-    <LabeledInput
+    (<LabeledInput
       ref={ref}
       role="search"
       label={
         query !== "" ? (
           // Active state
-          <Clickable
+          (<Clickable
             display="flex"
             onClick={handleClick}
             aria-label="Clear search input"
           >
             <CloseStrokeIcon />
-          </Clickable>
+          </Clickable>)
         ) : (
           // Resting state
-          <SearchIcon style={{ pointerEvents: "none" }} />
+          (<SearchIcon style={{ pointerEvents: "none" }} />)
         )
       }
       onChange={handleChange}
       value={query}
       placeholder={placeholder}
       {...props}
-    />
-  )
+    />)
+  );
 }

--- a/packages/palette/src/elements/FilterSelect/Components/FilterInput.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterInput.tsx
@@ -9,7 +9,9 @@ import { useFilterSelectContext } from "./FilterSelectContext"
 
 export type FilterInputProps = InputProps
 
-export const FilterInput: React.FC<React.PropsWithChildren<InputProps>> = (props) => {
+export const FilterInput: React.FC<React.PropsWithChildren<InputProps>> = (
+  props
+) => {
   const { query, setQuery, placeholder } = useFilterSelectContext()
   const ref = useRef<HTMLInputElement | null>(null)
 
@@ -23,28 +25,28 @@ export const FilterInput: React.FC<React.PropsWithChildren<InputProps>> = (props
   }
 
   return (
-    (<LabeledInput
+    <LabeledInput
       ref={ref}
       role="search"
       label={
         query !== "" ? (
           // Active state
-          (<Clickable
+          <Clickable
             display="flex"
             onClick={handleClick}
             aria-label="Clear search input"
           >
             <CloseStrokeIcon />
-          </Clickable>)
+          </Clickable>
         ) : (
           // Resting state
-          (<SearchIcon style={{ pointerEvents: "none" }} />)
+          <SearchIcon style={{ pointerEvents: "none" }} />
         )
       }
       onChange={handleChange}
       value={query}
       placeholder={placeholder}
       {...props}
-    />)
-  );
+    />
+  )
 }

--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
@@ -136,9 +136,7 @@ const initialState: FilterSelectState = {
 
 const FilterSelectContext = createContext<FilterSelectContextProps>({} as any)
 
-export const FilterSelectContextProvider: React.FC<
-  Partial<FilterSelectState>
-> = ({ children, ...props }) => {
+export const FilterSelectContextProvider: React.FC<React.PropsWithChildren<Partial<FilterSelectState>>> = ({ children, ...props }) => {
   const [state, dispatch] = useReducer(filterSelectReducer, {
     ...initialState,
     ...props,

--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectResultItem.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectResultItem.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from "../../Checkbox"
 import { Item, useFilterSelectContext } from "./FilterSelectContext"
 import { Radio } from "../../Radio"
 
-export const FilterSelectResultItem: React.FC<Item> = (props) => {
+export const FilterSelectResultItem: React.FC<React.PropsWithChildren<Item>> = (props) => {
   const {
     renderItemLabel,
     selectedItems,

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -17,7 +17,7 @@ import { useUpdateEffect } from "../../utils"
 
 export type FilterSelectProps = Partial<FilterSelectState>
 
-export const FilterSelect: React.FC<FilterSelectProps> = (props) => {
+export const FilterSelect: React.FC<React.PropsWithChildren<FilterSelectProps>> = (props) => {
   return (
     <FilterSelectContextProvider {...props}>
       <_FilterSelect />
@@ -25,7 +25,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = (props) => {
   )
 }
 
-const _FilterSelect: React.FC = () => {
+const _FilterSelect: React.FC<React.PropsWithChildren<unknown>> = () => {
   const {
     filteredItems,
     initialItemsToShow,

--- a/packages/palette/src/elements/GridColumns/GridColumns.tsx
+++ b/packages/palette/src/elements/GridColumns/GridColumns.tsx
@@ -41,7 +41,7 @@ export type ColumnProps = CellProps & {
  * A column sits within the GridColumns and spans the columns,
  * sitting between gutters.
  */
-export const Column: React.FC<ColumnProps> = ({
+export const Column: React.FC<React.PropsWithChildren<ColumnProps>> = ({
   span,
   start,
   wrap,
@@ -59,7 +59,7 @@ export const Column: React.FC<ColumnProps> = ({
   )
 }
 
-const ColumnWrap: React.FC<{ gridColumnValue: string[] }> = ({
+const ColumnWrap: React.FC<React.PropsWithChildren<{ gridColumnValue: string[] }>> = ({
   gridColumnValue,
 }) => {
   return (

--- a/packages/palette/src/elements/HTML/HTML.tsx
+++ b/packages/palette/src/elements/HTML/HTML.tsx
@@ -56,7 +56,7 @@ Container.defaultProps = {
  * If `html` prop is passed; it's set as innerHTML, otherwise contents are wrapped
  * with default HTML styling.
  */
-export const HTML: React.FC<HTMLProps> = (props) => {
+export const HTML: React.FC<React.PropsWithChildren<HTMLProps>> = (props) => {
   if ("html" in props) {
     const { html, ...htmlRest } = props
     return (

--- a/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
+++ b/packages/palette/src/elements/HorizontalOverflow/HorizontalOverflow.tsx
@@ -55,9 +55,10 @@ const Rail = styled(Box)`
 
 export type HorizontalOverflowProps = BoxProps & { children: React.ReactNode }
 
-export const HorizontalOverflow: React.ForwardRefExoticComponent<
-  HorizontalOverflowProps & React.RefAttributes<HTMLDivElement>
-> = forwardRef(({ children, ...rest }, forwardedRef) => {
+export const HorizontalOverflow = forwardRef<
+  HTMLDivElement,
+  HorizontalOverflowProps
+>(({ children, ...rest }, forwardedRef) => {
   const ref = useRef<HTMLDivElement | null>()
 
   useEffect(() => {
@@ -68,6 +69,8 @@ export const HorizontalOverflow: React.ForwardRefExoticComponent<
     }
   }, [])
 
+  // FIXME: REACT_18_UPGRADE
+  // @ts-ignore
   const [railProps, { ref: _ref, ...boxProps }] = splitRailProps(rest)
 
   const [atEnd, setAtEnd] = useState(false)

--- a/packages/palette/src/elements/Image/LazyImage.tsx
+++ b/packages/palette/src/elements/Image/LazyImage.tsx
@@ -47,7 +47,7 @@ interface LazyImageProps
 }
 
 /** LazyImage */
-export const LazyImage: React.FC<LazyImageProps> = ({
+export const LazyImage: React.FC<React.PropsWithChildren<LazyImageProps>> = ({
   preload = false,
   imageComponent: ImageComponent = Image,
   ...props

--- a/packages/palette/src/elements/Input/Input.tsx
+++ b/packages/palette/src/elements/Input/Input.tsx
@@ -28,9 +28,7 @@ export interface InputProps
 }
 
 /** Input component */
-export const Input: React.ForwardRefExoticComponent<
-  InputProps & { ref?: React.Ref<HTMLInputElement> }
-> = React.forwardRef(
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (
     {
       children,

--- a/packages/palette/src/elements/Join/Join.story.tsx
+++ b/packages/palette/src/elements/Join/Join.story.tsx
@@ -12,9 +12,9 @@ const NonBlankFunction = () => {
   return <Text variant="sm-display">Non-blank Function</Text>
 }
 
-const BlankFC: React.FC = () => null
+const BlankFC: React.FC<React.PropsWithChildren<unknown>> = () => null
 
-const NonBlankFC: React.FC = () => (
+const NonBlankFC: React.FC<React.PropsWithChildren<unknown>> = () => (
   <Text variant="sm-display">Non-blank Functional component</Text>
 )
 

--- a/packages/palette/src/elements/Join/Join.tsx
+++ b/packages/palette/src/elements/Join/Join.tsx
@@ -25,7 +25,7 @@ interface JoinProps {
  * <SomeComponent/>
  * <child3/>
  */
-export const Join: React.FC<JoinProps> = ({ separator, children }) => {
+export const Join: React.FC<React.PropsWithChildren<JoinProps>> = ({ separator, children }) => {
   const elements = flattenChildren(children)
 
   return (

--- a/packages/palette/src/elements/Label/Label.tsx
+++ b/packages/palette/src/elements/Label/Label.tsx
@@ -26,7 +26,7 @@ export interface LabelProps extends BoxProps {
   children: React.ReactNode
 }
 
-export const Label: React.FC<LabelProps> = ({ children, ...rest }) => {
+export const Label: React.FC<React.PropsWithChildren<LabelProps>> = ({ children, ...rest }) => {
   return (
     <Container display="inline-flex" maxWidth="100%" {...rest}>
       <Text variant="xs" px={0.5} overflowEllipsis>

--- a/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
+++ b/packages/palette/src/elements/LabeledInput/LabeledInput.tsx
@@ -10,55 +10,54 @@ export interface LabeledInputProps extends InputProps {
 }
 
 /** Input with a right-aligned or left-aligned label */
-export const LabeledInput: React.ForwardRefExoticComponent<
-  LabeledInputProps & { ref?: React.Ref<HTMLInputElement> }
-> = React.forwardRef(
-  ({ label, height, variant = "suffix", ...rest }, forwardedRef) => {
-    const labelRef = useRef<HTMLDivElement | null>(null)
-    const [offset, setOffset] = useState(0)
+export const LabeledInput = React.forwardRef<
+  HTMLInputElement,
+  LabeledInputProps
+>(({ label, height, variant = "suffix", ...rest }, forwardedRef) => {
+  const labelRef = useRef<HTMLDivElement | null>(null)
+  const [offset, setOffset] = useState(0)
 
-    useEffect(() => {
-      if (labelRef.current === null) return
-      setOffset(labelRef.current.offsetWidth)
-    }, [])
+  useEffect(() => {
+    if (labelRef.current === null) return
+    setOffset(labelRef.current.offsetWidth)
+  }, [])
 
-    const [boxProps, inputProps] = splitBoxProps(rest)
+  const [boxProps, inputProps] = splitBoxProps(rest)
 
-    const isText = _isText(label)
+  const isText = _isText(label)
 
-    const isPrefix = variant === "prefix"
+  const isPrefix = variant === "prefix"
 
-    return (
-      <Box position="relative" {...boxProps}>
-        <Input
-          ref={forwardedRef}
-          height={height}
-          labelOffset={isPrefix ? offset + 15 : undefined}
-          style={{ [isPrefix ? "paddingLeft" : "paddingRight"]: offset + 15 }}
-          {...inputProps}
+  return (
+    <Box position="relative" {...boxProps}>
+      <Input
+        ref={forwardedRef}
+        height={height}
+        labelOffset={isPrefix ? offset + 15 : undefined}
+        style={{ [isPrefix ? "paddingLeft" : "paddingRight"]: offset + 15 }}
+        {...inputProps}
+      >
+        <Box
+          ref={labelRef as any}
+          position="absolute"
+          display="flex"
+          alignItems="center"
+          top={0}
+          bottom={0}
+          style={{ pointerEvents: isText ? "none" : undefined }}
+          {...{ [isPrefix ? "left" : "right"]: 1 }}
         >
-          <Box
-            ref={labelRef as any}
-            position="absolute"
-            display="flex"
-            alignItems="center"
-            top={0}
-            bottom={0}
-            style={{ pointerEvents: isText ? "none" : undefined }}
-            {...{ [isPrefix ? "left" : "right"]: 1 }}
-          >
-            {isText ? (
-              <Text variant="sm-display" color="black60" lineHeight={1}>
-                {label}
-              </Text>
-            ) : (
-              label
-            )}
-          </Box>
-        </Input>
-      </Box>
-    )
-  }
-)
+          {isText ? (
+            <Text variant="sm-display" color="black60" lineHeight={1}>
+              {label}
+            </Text>
+          ) : (
+            label
+          )}
+        </Box>
+      </Input>
+    </Box>
+  )
+})
 
 LabeledInput.displayName = "LabeledInput"

--- a/packages/palette/src/elements/Marquee/Marquee.tsx
+++ b/packages/palette/src/elements/Marquee/Marquee.tsx
@@ -58,7 +58,7 @@ export interface MarqueeProps extends BoxProps {
   divider?: boolean
 }
 
-export const Marquee: React.FC<MarqueeProps> = ({
+export const Marquee: React.FC<React.PropsWithChildren<MarqueeProps>> = ({
   marqueeText,
   divider = true,
   speed = "10s",

--- a/packages/palette/src/elements/Message/Message.tsx
+++ b/packages/palette/src/elements/Message/Message.tsx
@@ -50,7 +50,7 @@ const Container = styled(Flex)<MessageProps>`
  * comments within flows. Additionally, they can be used to highlight particular
  * messaging within a specific section of a page or screen.
  */
-export const Message: React.FC<MessageProps> = ({
+export const Message: React.FC<React.PropsWithChildren<MessageProps>> = ({
   children,
   title,
   variant,

--- a/packages/palette/src/elements/Modal/ModalBase.story.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.story.tsx
@@ -7,14 +7,12 @@ import { Join } from "../Join"
 import { Spacer } from "../Spacer"
 import { ModalBase, ModalBaseProps } from "./ModalBase"
 
-const Example: React.FC<
-  ModalBaseProps & {
-    dialogChildren?: JSX.Element
-    bodyChildren?: JSX.Element
-    /** Simulates an input being added after render */
-    defer?: boolean
-  }
-> = ({ bodyChildren, dialogChildren, defer, ...rest } = {}) => {
+const Example: React.FC<React.PropsWithChildren<ModalBaseProps & {
+  dialogChildren?: JSX.Element
+  bodyChildren?: JSX.Element
+  /** Simulates an input being added after render */
+  defer?: boolean
+}>> = ({ bodyChildren, dialogChildren, defer, ...rest } = {}) => {
   const [open, setOpen] = useState(false)
   const label = open ? "opened" : "open"
   const handleClose = () => setOpen(false)

--- a/packages/palette/src/elements/Modal/ModalBase.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.tsx
@@ -4,6 +4,7 @@ import { zIndex as systemZIndex, ZIndexProps } from "styled-system"
 import { usePortal } from "../../utils/usePortal"
 import { Flex, FlexProps } from "../Flex"
 import { FocusOn } from "react-focus-on"
+import { useDidMount } from "../../utils"
 
 const Focus = styled(FocusOn)`
   width: 100%;
@@ -60,8 +61,12 @@ export const DEFAULT_MODAL_Z_INDEX = 9999
  * Low-level modal that has no opinions about layout/overlay
  * Modals content using a portal, locks scroll.
  */
-export const ModalBase: React.FC<React.PropsWithChildren<ModalBaseProps>> = (props) => {
-  if (typeof window === "undefined") {
+export const ModalBase: React.FC<React.PropsWithChildren<ModalBaseProps>> = (
+  props
+) => {
+  const isClient = useDidMount()
+
+  if (!isClient) {
     return null
   }
   return <_ModalBase {...props} />

--- a/packages/palette/src/elements/Modal/ModalBase.tsx
+++ b/packages/palette/src/elements/Modal/ModalBase.tsx
@@ -60,14 +60,14 @@ export const DEFAULT_MODAL_Z_INDEX = 9999
  * Low-level modal that has no opinions about layout/overlay
  * Modals content using a portal, locks scroll.
  */
-export const ModalBase: React.FC<ModalBaseProps> = (props) => {
+export const ModalBase: React.FC<React.PropsWithChildren<ModalBaseProps>> = (props) => {
   if (typeof window === "undefined") {
     return null
   }
   return <_ModalBase {...props} />
 }
 
-export const _ModalBase: React.FC<ModalBaseProps> = ({
+export const _ModalBase: React.FC<React.PropsWithChildren<ModalBaseProps>> = ({
   children,
   zIndex = DEFAULT_MODAL_Z_INDEX,
   dialogProps = {},

--- a/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialog.tsx
@@ -14,7 +14,7 @@ export type ModalDialogProps = Omit<ModalBaseProps, "title"> &
     rightPanel?: React.ReactNode
   }
 
-export const ModalDialog: React.FC<ModalDialogProps> = ({
+export const ModalDialog: React.FC<React.PropsWithChildren<ModalDialogProps>> = ({
   children,
   footer,
   hasLogo,

--- a/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
+++ b/packages/palette/src/elements/ModalDialog/ModalDialogContent.tsx
@@ -24,7 +24,7 @@ export interface ModalDialogContentProps
   header?: React.ReactNode
 }
 
-export const ModalDialogContent: React.FC<ModalDialogContentProps> = ({
+export const ModalDialogContent: React.FC<React.PropsWithChildren<ModalDialogContentProps>> = ({
   children,
   footer,
   hasLogo,
@@ -128,7 +128,7 @@ export const ModalDialogContent: React.FC<ModalDialogContentProps> = ({
 
 export type ModalCloseProps = ClickableProps
 
-export const ModalClose: FC<ModalCloseProps> = (props) => {
+export const ModalClose: FC<React.PropsWithChildren<ModalCloseProps>> = (props) => {
   return (
     <Close p={2} ml="auto" aria-label="Close" {...props}>
       <CloseIcon fill="currentColor" display="block" />

--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -31,7 +31,7 @@ export interface MultiSelectProps extends BoxProps {
 }
 
 /** A drop-down multi-select menu */
-export const MultiSelect: React.FC<MultiSelectProps> = ({
+export const MultiSelect: React.FC<React.PropsWithChildren<MultiSelectProps>> = ({
   complete,
   description,
   disabled,

--- a/packages/palette/src/elements/Pagination/Pagination.tsx
+++ b/packages/palette/src/elements/Pagination/Pagination.tsx
@@ -38,7 +38,7 @@ export interface PaginationProps extends FlexProps {
 }
 
 /** Pagination */
-export const Pagination: React.FC<PaginationProps> = ({
+export const Pagination: React.FC<React.PropsWithChildren<PaginationProps>> = ({
   getHref,
   hasNextPage,
   onClick,
@@ -128,7 +128,7 @@ interface PageProps extends BoxProps {
   pageCursor: PageCursor
 }
 
-const Page: React.FC<PageProps> = ({
+const Page: React.FC<React.PropsWithChildren<PageProps>> = ({
   getHref,
   onClick,
   pageCursor: { cursor, isCurrent, page },
@@ -167,7 +167,7 @@ export interface NextPrevButtonProps extends BoxProps {
   page?: number
 }
 
-const NextPrevButton: React.FC<NextPrevButtonProps> = ({
+const NextPrevButton: React.FC<React.PropsWithChildren<NextPrevButtonProps>> = ({
   disabled,
   getHref,
   onClick,
@@ -228,7 +228,7 @@ const PaginationContainer = styled(Text).attrs({
   line-height: 1;
 `
 
-export const PaginationSkeleton: FC = () => {
+export const PaginationSkeleton: FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <PaginationContainer aria-hidden>
       <NextPrevButton disabled pr={0.5}>

--- a/packages/palette/src/elements/PasswordInput/PasswordInput.tsx
+++ b/packages/palette/src/elements/PasswordInput/PasswordInput.tsx
@@ -9,7 +9,7 @@ export interface PasswordInputProps extends InputProps {
   defaultVisibility?: boolean
 }
 
-export const PasswordInput: React.FC<PasswordInputProps> = ({
+export const PasswordInput: React.FC<React.PropsWithChildren<PasswordInputProps>> = ({
   defaultVisibility = false,
   ...rest
 }) => {

--- a/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
@@ -40,9 +40,7 @@ export interface PhoneInputProps extends Omit<InputProps, "onSelect"> {
   inputValue?: string
 }
 
-export const PhoneInput: React.ForwardRefExoticComponent<
-  PhoneInputProps & { ref?: React.Ref<HTMLInputElement> }
-> = React.forwardRef(
+export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
   (
     {
       className,

--- a/packages/palette/src/elements/Pill/Pill.tsx
+++ b/packages/palette/src/elements/Pill/Pill.tsx
@@ -32,7 +32,7 @@ export type PillState =
 
 /** PillProps */
 export type PillProps = ClickableProps & {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType
+  as?: keyof JSX.IntrinsicElements | React.ComponentType<React.PropsWithChildren<unknown>>
   /** Forces focus state */
   focus?: boolean
   /** Forces hover state */
@@ -42,7 +42,7 @@ export type PillProps = ClickableProps & {
   /** Forces selected state. Use this state to denote the selected state */
   selected?: boolean
   /** Optional icon slot */
-  Icon?: React.FunctionComponent<BoxProps & { fill?: ResponsiveValue<string> }>
+  Icon?: React.FunctionComponent<React.PropsWithChildren<BoxProps & { fill?: ResponsiveValue<string> }>>
   /** Optional: Icon positioning */
   iconPosition?: "left" | "right"
 } & (

--- a/packages/palette/src/elements/Pointer/Pointer.tsx
+++ b/packages/palette/src/elements/Pointer/Pointer.tsx
@@ -28,7 +28,7 @@ export interface PointerProps {
 /**
  * Internal-use component for displaying a triangular pointer to an anchor node
  */
-export const Pointer: FC<PointerProps> = ({
+export const Pointer: FC<React.PropsWithChildren<PointerProps>> = ({
   anchorRef,
   tooltipRef,
   isFlipped,

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -57,7 +57,7 @@ export interface PopoverProps extends BoxProps {
  * A `Popover` is a small modal-type element which is anchored, and can be
  * positioned relative to, another element.
  */
-export const Popover: React.FC<PopoverProps> = ({
+export const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   children,
   ignoreClickOutside = false,
   manageFocus = true,

--- a/packages/palette/src/elements/Popover/Popover.tsx
+++ b/packages/palette/src/elements/Popover/Popover.tsx
@@ -57,7 +57,7 @@ export interface PopoverProps extends BoxProps {
  * A `Popover` is a small modal-type element which is anchored, and can be
  * positioned relative to, another element.
  */
-export const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
+export const Popover = ({
   children,
   ignoreClickOutside = false,
   manageFocus = true,
@@ -71,7 +71,7 @@ export const Popover: React.FC<React.PropsWithChildren<PopoverProps>> = ({
   visible: _visible = false,
   zIndex = 1,
   ...rest
-}) => {
+}: PopoverProps) => {
   const [visible, setVisible] = useState(false)
 
   // If prop updates/set initial visibility.

--- a/packages/palette/src/elements/ProgressBar/ProgressBar.tsx
+++ b/packages/palette/src/elements/ProgressBar/ProgressBar.tsx
@@ -10,7 +10,7 @@ export interface ProgressBarProps extends BoxProps {
 }
 
 /** ProgressBar */
-export const ProgressBar: React.FC<ProgressBarProps> = ({
+export const ProgressBar: React.FC<React.PropsWithChildren<ProgressBarProps>> = ({
   percentComplete,
   highlight = "brand",
   showBackground = true,

--- a/packages/palette/src/elements/ProgressDots/ProgressDots.tsx
+++ b/packages/palette/src/elements/ProgressDots/ProgressDots.tsx
@@ -30,7 +30,7 @@ export interface ProgressDotsProps extends BoxProps {
 /**
  * Renders an `amount` of dots and announces progress when updated
  */
-export const ProgressDots: React.FC<ProgressDotsProps> = ({
+export const ProgressDots: React.FC<React.PropsWithChildren<ProgressDotsProps>> = ({
   activeIndex,
   amount,
   variant: indicatorVariant = "dot",

--- a/packages/palette/src/elements/Range/Range.tsx
+++ b/packages/palette/src/elements/Range/Range.tsx
@@ -18,7 +18,7 @@ export interface RangeProps extends BoxProps {
   onChange?: (range: [number, number]) => void
 }
 
-export const Range: React.FC<RangeProps> = ({
+export const Range: React.FC<React.PropsWithChildren<RangeProps>> = ({
   ariaLabels,
   min,
   max,

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -16,7 +16,7 @@ export interface ReadMoreProps {
 }
 
 /** ReadMore */
-export const ReadMore: React.FC<ReadMoreProps> = ({
+export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
   content: expandedHTML,
   disabled,
   inlineReadMoreLink = true,

--- a/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.story.tsx
+++ b/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.story.tsx
@@ -10,7 +10,7 @@ import {
   ResponsiveBoxProps,
 } from "./ResponsiveBox"
 
-const Measure: React.FC<ResponsiveBoxProps> = (props) => {
+const Measure: React.FC<React.PropsWithChildren<ResponsiveBoxProps>> = (props) => {
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 })
 
   const ref = useRef<null | HTMLDivElement>(null)
@@ -119,7 +119,7 @@ const Masonry = styled(Box)`
 
 export const ColumnsWithResponsiveImages = () => {
   return (
-    <Masonry>
+    (<Masonry>
       {new Array(12).fill(0).map((_, i) => {
         const orientation = i % 3 === 0 ? "portrait" : "landscape"
         const width = orientation === "portrait" ? 200 : 300
@@ -127,7 +127,7 @@ export const ColumnsWithResponsiveImages = () => {
 
         return (
           // Simply being wrapped in an extra `Box` causes a image loading bug in Chrome
-          <Box key={i}>
+          (<Box key={i}>
             <ResponsiveBox
               aspectWidth={width}
               aspectHeight={height}
@@ -145,9 +145,9 @@ export const ColumnsWithResponsiveImages = () => {
                 }/${height * 2} 2x`}
               />
             </ResponsiveBox>
-          </Box>
-        )
+          </Box>)
+        );
       })}
-    </Masonry>
-  )
+    </Masonry>)
+  );
 }

--- a/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.tsx
+++ b/packages/palette/src/elements/ResponsiveBox/ResponsiveBox.tsx
@@ -45,7 +45,7 @@ export type ResponsiveBoxProps = Omit<BoxProps, "maxWidth" | "maxHeight"> &
   ResponsiveBoxMaxDimensions
 
 /** ResponsiveBox */
-export const ResponsiveBox: React.FC<ResponsiveBoxProps> = ({
+export const ResponsiveBox: React.FC<React.PropsWithChildren<ResponsiveBoxProps>> = ({
   aspectWidth,
   aspectHeight,
   children,

--- a/packages/palette/src/elements/Select/Select.tsx
+++ b/packages/palette/src/elements/Select/Select.tsx
@@ -1,10 +1,5 @@
 import { themeGet } from "@styled-system/theme-get"
-import React, {
-  forwardRef,
-  ForwardRefExoticComponent,
-  Ref,
-  useState,
-} from "react"
+import React, { forwardRef, useState } from "react"
 import styled, { css, ExecutionContext } from "styled-components"
 import { FORM_ELEMENT_TRANSITION } from "../../helpers"
 import { RequiredField } from "../../shared/RequiredField"
@@ -35,9 +30,7 @@ export interface SelectProps
 }
 
 /** A drop-down select menu */
-export const Select: ForwardRefExoticComponent<
-  SelectProps & { ref?: Ref<HTMLElement> }
-> = forwardRef(
+export const Select = forwardRef<HTMLElement, SelectProps>(
   (
     {
       description,

--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -30,7 +30,7 @@ export type ShelfProps = BoxProps & {
 /**
  * A Shelf is a new kind of carousel...
  */
-export const Shelf: React.FC<ShelfProps> = ({
+export const Shelf: React.FC<React.PropsWithChildren<ShelfProps>> = ({
   alignItems = "flex-end",
   showProgress = true,
   snap = "none",

--- a/packages/palette/src/elements/Shelf/ShelfNavigation.tsx
+++ b/packages/palette/src/elements/Shelf/ShelfNavigation.tsx
@@ -73,7 +73,7 @@ const Arrow = styled(Clickable)<ShelfNavigationProps>`
 /**
  * Default next button
  */
-export const ShelfNext: React.FC<ShelfNavigationProps> = (props) => {
+export const ShelfNext: React.FC<React.PropsWithChildren<ShelfNavigationProps>> = (props) => {
   return (
     <Arrow {...props}>
       <ChevronRightIcon width={15} height={15} />
@@ -84,7 +84,7 @@ export const ShelfNext: React.FC<ShelfNavigationProps> = (props) => {
 /**
  * Default previous button
  */
-export const ShelfPrevious: React.FC<ShelfNavigationProps> = (props) => {
+export const ShelfPrevious: React.FC<React.PropsWithChildren<ShelfNavigationProps>> = (props) => {
   return (
     <Arrow {...props}>
       <ChevronLeftIcon width={15} height={15} />

--- a/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
+++ b/packages/palette/src/elements/Shelf/ShelfScrollBar.tsx
@@ -14,7 +14,7 @@ interface ShelfScrollBarProps extends BoxProps {
 /**
  * A synthetic scrollbar
  */
-export const ShelfScrollBar: React.FC<ShelfScrollBarProps> = React.memo(
+export const ShelfScrollBar: React.FC<React.PropsWithChildren<ShelfScrollBarProps>> = React.memo(
   ({ viewport, ...rest }) => {
     const [
       { scrollLeft, scrollWidth, clientWidth },

--- a/packages/palette/src/elements/ShowMore/ShowMore.tsx
+++ b/packages/palette/src/elements/ShowMore/ShowMore.tsx
@@ -14,7 +14,7 @@ export interface ShowMoreProps
 
 export const INITIAL_ITEMS_TO_SHOW = 6
 
-export const ShowMore: React.FC<ShowMoreProps> = ({
+export const ShowMore: React.FC<React.PropsWithChildren<ShowMoreProps>> = ({
   initial = INITIAL_ITEMS_TO_SHOW,
   children,
   expanded = false,

--- a/packages/palette/src/elements/Skeleton/Skeleton.story.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.story.tsx
@@ -54,7 +54,7 @@ export const _SkeletonText = () => {
   )
 }
 
-const ExampleArtworkSkeleton: React.FC<{ i: number }> = ({ i }) => {
+const ExampleArtworkSkeleton: React.FC<React.PropsWithChildren<{ i: number }>> = ({ i }) => {
   return (
     <>
       <SkeletonBox width={200} height={[200, 300, 250, 275][i % 4]} />

--- a/packages/palette/src/elements/Skeleton/Skeleton.tsx
+++ b/packages/palette/src/elements/Skeleton/Skeleton.tsx
@@ -31,7 +31,7 @@ const SkeletonTextOverlay = styled(SkeletonBox)`
 /**
  * Allows you to create boxes the exact dimensions of a given piece of text
  */
-export const SkeletonText: React.FC<SkeletonTextProps> = ({
+export const SkeletonText: React.FC<React.PropsWithChildren<SkeletonTextProps>> = ({
   children,
   ...rest
 }) => {
@@ -64,7 +64,7 @@ export type SkeletonProps = BoxProps
 /**
  * Animated wrapper for Skeletons
  */
-export const Skeleton: React.FC<SkeletonProps> = ({ children, ...rest }) => {
+export const Skeleton: React.FC<React.PropsWithChildren<SkeletonProps>> = ({ children, ...rest }) => {
   return (
     <Box position="relative" {...rest}>
       {children}

--- a/packages/palette/src/elements/Spinner/Spinner.tsx
+++ b/packages/palette/src/elements/Spinner/Spinner.tsx
@@ -42,7 +42,7 @@ export interface SpinnerProps
 }
 
 /** Generic Spinner component */
-export const Spinner: React.FC<SpinnerProps> = ({ delay, color, ...rest }) => {
+export const Spinner: React.FC<React.PropsWithChildren<SpinnerProps>> = ({ delay, color, ...rest }) => {
   const [show, setShow] = useState(delay === 0)
 
   useEffect(() => {

--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -15,7 +15,7 @@ export interface StepperProps extends TabsProps {
 }
 
 /** Stepper */
-export const Stepper: React.FC<StepperProps> = ({
+export const Stepper: React.FC<React.PropsWithChildren<StepperProps>> = ({
   currentStepIndex,
   disableNavigation,
   initialTabIndex = 0,
@@ -78,7 +78,7 @@ export type StepProps = TabProps
  * An individual step.
  * Does nothing on its own; props are dealt with inside of Steps.
  */
-export const Step: React.FC<StepProps> = ({ children }) => <>{children}</>
+export const Step: React.FC<React.PropsWithChildren<StepProps>> = ({ children }) => <>{children}</>
 
 Stepper.defaultProps = {
   mb: 2,

--- a/packages/palette/src/elements/Swiper/Swiper.tsx
+++ b/packages/palette/src/elements/Swiper/Swiper.tsx
@@ -58,7 +58,7 @@ export type SwiperProps = BoxProps & {
   initialIndex?: number
   snap?: ScrollSnapAlign
   children: React.ReactNode
-  Rail?: typeof SwiperRail | React.FC<SwiperRailProps>
+  Rail?: typeof SwiperRail | React.FC<React.PropsWithChildren<SwiperRailProps>>
   /**
    * If providing a custom `Cell` you must forward a ref so
    * that cell widths can be calculated.
@@ -74,7 +74,7 @@ export type SwiperProps = BoxProps & {
  * horizontal rail and when the width exceeds the width of the viewport, allows
  * for horitonzal swiping (or scrolling) with the option to snap to elements.
  */
-export const Swiper: React.FC<SwiperProps> = ({
+export const Swiper: React.FC<React.PropsWithChildren<SwiperProps>> = ({
   initialIndex = 0,
   children,
   snap = "none",

--- a/packages/palette/src/elements/Swiper/__tests__/Swiper.test.tsx
+++ b/packages/palette/src/elements/Swiper/__tests__/Swiper.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from "enzyme"
-import React from "react"
+import React, { forwardRef, PropsWithChildren } from "react"
 import { Box } from "../../Box"
-import { Swiper } from "../Swiper"
+import { Swiper, SwiperCellProps } from "../Swiper"
 
 describe("Swiper", () => {
   it("renders correctly", () => {
@@ -46,20 +46,24 @@ describe("Swiper", () => {
     const html: any = wrapper.html()
 
     expect(html).toContain("I have 3 beautiful children")
-    expect(html.match(/\<li\s/g).length).toBe(3)
+    expect(html.match(/<li\s/g).length).toBe(3)
   })
 
   it("accepts a customizable Cell", () => {
+    const Cell = forwardRef<any, PropsWithChildren<SwiperCellProps>>(
+      ({ children, ...rest }, ref) => {
+        return (
+          <Box ref={ref as any} {...rest}>
+            beautiful number {children}
+          </Box>
+        )
+      }
+    )
+
+    Cell.displayName = "Cell"
+
     const wrapper = mount(
-      <Swiper
-        Cell={React.forwardRef(({ children, ...rest }, ref) => {
-          return (
-            <Box ref={ref as any} {...rest}>
-              beautiful number {children}
-            </Box>
-          )
-        })}
-      >
+      <Swiper Cell={Cell}>
         <>1</>
         <>2</>
         <>3</>

--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -109,7 +109,7 @@ export const useTabs = ({
 }
 
 /** A tab bar navigation component */
-export const Tabs: React.FC<TabsProps> = ({
+export const Tabs: React.FC<React.PropsWithChildren<TabsProps>> = ({
   children,
   initialTabIndex = 0,
   onChange,
@@ -164,4 +164,4 @@ export interface TabProps {
  * An individual tab.
  * Does nothing on its own; props are dealt with inside of Tabs.
  */
-export const Tab: React.FC<TabProps> = ({ children }) => <>{children}</>
+export const Tab: React.FC<React.PropsWithChildren<TabProps>> = ({ children }) => <>{children}</>

--- a/packages/palette/src/elements/Text/Text.story.tsx
+++ b/packages/palette/src/elements/Text/Text.story.tsx
@@ -28,10 +28,10 @@ const Table = styled.table`
   }
 `
 
-const Specification: React.FC<{
+const Specification: React.FC<React.PropsWithChildren<{
   size?: "small" | "large" | "default"
   treatment: any
-}> = ({ size, treatment }) => {
+}>> = ({ size, treatment }) => {
   const textColor =
     {
       small: ["purple100", "black60"] as Color[],

--- a/packages/palette/src/elements/TextArea/TextArea.tsx
+++ b/packages/palette/src/elements/TextArea/TextArea.tsx
@@ -34,9 +34,7 @@ export interface TextAreaChange {
 }
 
 /** TextArea */
-export const TextArea: React.ForwardRefExoticComponent<
-  TextAreaProps & { ref?: React.Ref<HTMLTextAreaElement> }
-> = React.forwardRef(
+export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
     {
       error,

--- a/packages/palette/src/elements/Toasts/Toast.tsx
+++ b/packages/palette/src/elements/Toasts/Toast.tsx
@@ -20,7 +20,7 @@ export interface ToastProps extends BoxProps {
   variant?: ToastVariant
 }
 
-export const Toast: React.FC<ToastProps> = ({
+export const Toast: React.FC<React.PropsWithChildren<ToastProps>> = ({
   id,
   action,
   description,

--- a/packages/palette/src/elements/Toasts/Toasts.tsx
+++ b/packages/palette/src/elements/Toasts/Toasts.tsx
@@ -10,7 +10,7 @@ export interface ToastsProps extends BoxProps {
   limit?: number
 }
 
-export const Toasts: React.FC<ToastsProps> = ({ limit = 5, ...rest }) => {
+export const Toasts: React.FC<React.PropsWithChildren<ToastsProps>> = ({ limit = 5, ...rest }) => {
   const { toasts } = useToasts()
 
   return (

--- a/packages/palette/src/elements/Toasts/useToasts.tsx
+++ b/packages/palette/src/elements/Toasts/useToasts.tsx
@@ -59,7 +59,7 @@ export const ToastsContext = createContext<{
   },
 })
 
-export const ToastsProvider: React.FC = ({ children }) => {
+export const ToastsProvider: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, { toasts: [] })
 
   const activeToasts = useRef<

--- a/packages/palette/src/elements/Toggle/Toggle.tsx
+++ b/packages/palette/src/elements/Toggle/Toggle.tsx
@@ -18,7 +18,7 @@ export interface ToggleProps
 }
 
 /** A toggle */
-export const Toggle: React.FC<ToggleProps> = ({
+export const Toggle: React.FC<React.PropsWithChildren<ToggleProps>> = ({
   selected = false,
   disabled,
   hover,

--- a/packages/palette/src/elements/Tooltip/Tooltip.tsx
+++ b/packages/palette/src/elements/Tooltip/Tooltip.tsx
@@ -36,7 +36,7 @@ export interface TooltipProps extends BoxProps {
 /**
  * A tooltip
  */
-export const Tooltip: React.FC<TooltipProps> = ({
+export const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
   children,
   content,
   width = 230,

--- a/packages/palette/src/shared/RequiredField.tsx
+++ b/packages/palette/src/shared/RequiredField.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Text, TextProps } from "../elements"
 
-export const RequiredField: React.FC<TextProps & { disabled?: boolean }> = (
+export const RequiredField: React.FC<React.PropsWithChildren<TextProps & { disabled?: boolean }>> = (
   props
 ) => {
   return (

--- a/packages/palette/src/themes/Themes.story.tsx
+++ b/packages/palette/src/themes/Themes.story.tsx
@@ -995,11 +995,11 @@ export const ContrastRatios = () => {
   )
 }
 
-const ContrastRatioSwatch: FC<{
+const ContrastRatioSwatch: FC<React.PropsWithChildren<{
   name: string
   value: string
   theme: typeof THEME
-}> = ({ name, value: _value, theme }) => {
+}>> = ({ name, value: _value, theme }) => {
   const [value, setValue] = useState(_value)
   const debouncedSetValue = useMemo(() => {
     return debounce(setValue, 500)

--- a/packages/palette/src/utils/jestShim.js
+++ b/packages/palette/src/utils/jestShim.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-undef */
+import { TextEncoder, TextDecoder } from "util"
+global.TextEncoder = TextEncoder
+global.TextDecoder = TextDecoder

--- a/packages/palette/src/utils/jestShim.js
+++ b/packages/palette/src/utils/jestShim.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-undef */
-import { TextEncoder, TextDecoder } from "util"
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { TextEncoder, TextDecoder } = require("util")
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder

--- a/packages/palette/src/utils/usePortal.ts
+++ b/packages/palette/src/utils/usePortal.ts
@@ -1,7 +1,10 @@
 import React, { useEffect, useRef, useCallback } from "react"
 import { createPortal as __createPortal__ } from "react-dom"
+import { useDidMount } from "./useDidMount"
 
 export const usePortal = () => {
+  const isClient = useDidMount()
+
   const appendEl = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -21,7 +24,7 @@ export const usePortal = () => {
 
   const createPortal = useCallback(
     (children: React.ReactNode): React.ReactPortal | null => {
-      if (typeof window === "undefined") return null
+      if (!isClient) return null
 
       // May execute before effect runs and appendEl is set
       const el = appendEl.current ?? document.createElement("div")
@@ -29,7 +32,7 @@ export const usePortal = () => {
 
       return __createPortal__(children, el)
     },
-    []
+    [isClient]
   )
 
   return { createPortal }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5048,27 +5048,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
-  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.3.12":
+"@types/react@*", "@types/react@^18.3.12":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
   integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/semver@5.5.0":
   version "5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13908,6 +13908,14 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+"react-17@npm:react@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 react-clientside-effect@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz#29f9b14e944a376b03fb650eed2a754dd128ea3a"
@@ -13940,6 +13948,15 @@ react-docgen@^5.0.0:
     neo-async "^2.6.1"
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
+
+"react-dom-17@npm:react-dom@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
 
 react-dom@^18.3.1:
   version "18.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5019,10 +5019,10 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/react-dom@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.1.tgz#d92d77d020bfb083e07cc8e0ac9f933599a4d56a"
-  integrity sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
+"@types/react-dom@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
+  integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
   dependencies:
     "@types/react" "*"
 
@@ -5057,10 +5057,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
-  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
+"@types/react@^18.3.12":
+  version "18.3.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
+  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -13955,14 +13955,13 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+react-dom@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.1"
+    scheduler "^0.23.2"
 
 react-draggable@^4.4.3:
   version "4.4.4"
@@ -14184,13 +14183,12 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+react@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-cmd-shim@^3.0.0:
   version "3.0.1"
@@ -14774,13 +14772,20 @@ scheduler@^0.13.6:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.20.1, scheduler@^0.20.2:
+scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
   integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 schema-utils@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
Addresses [DIA-955] 

This upgrades everything to React 18 and adjusts all the types. Again, because of Enzyme tests, had to point our test runner at React 17 tho. 

Due to major breaking changes in `@types/react@18` all palette consumers must upgrade to React 18, or remain on the previous major version. 

Deploying a canary for work in Force and we'll wait to merge this until Force upgrade is ready.

cc @artsy/diamond-devs 

[DIA-955]: https://artsyproduct.atlassian.net/browse/DIA-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@39.0.0-canary.1408.31348.0
  npm install @artsy/palette@40.0.0-canary.1408.31348.0
  # or 
  yarn add @artsy/palette-charts@39.0.0-canary.1408.31348.0
  yarn add @artsy/palette@40.0.0-canary.1408.31348.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
