### PR TITLE
fix(dropdown): keeps pointer state in sync with visibility

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -268,37 +268,41 @@ export const OverflowingContent = () => {
 }
 
 export const DisabledTransition = () => {
-  const dropdown = (
-    <Text variant="sm-display">
-      <Clickable display="block" width="100%" py={1} px={2}>
-        First
-      </Clickable>
-      <Clickable display="block" width="100%" py={1} px={2}>
-        Second
-      </Clickable>
-      <Clickable display="block" width="100%" py={1} px={2}>
-        Third
-      </Clickable>
-    </Text>
-  )
-
   return (
     <Flex>
-      <Dropdown dropdown={dropdown} openDropdownByClick transition={false}>
-        {({ anchorRef, anchorProps }) => {
-          return (
-            <Button
-              ref={anchorRef}
-              variant="secondaryBlack"
-              size="small"
-              mr={1}
-              {...anchorProps}
-            >
-              Click for non-animated dropdown
-            </Button>
-          )
-        }}
-      </Dropdown>
+      {[1, 2, 3].map((num) => {
+        const dropdown = (
+          <Text variant="sm-display" width="100vw" bg={`color-b${num}00`} p={2}>
+            <Clickable display="block" width="100%" py={1} px={2}>
+              Panel {num}: First Item
+            </Clickable>
+            <Clickable display="block" width="100%" py={1} px={2}>
+              Panel {num}: Second Item
+            </Clickable>
+            <Clickable display="block" width="100%" py={1} px={2}>
+              Panel {num}: Third Item
+            </Clickable>
+          </Text>
+        )
+
+        return (
+          <Dropdown key={num} dropdown={dropdown} transition={false}>
+            {({ anchorRef, anchorProps }) => {
+              return (
+                <Button
+                  ref={anchorRef}
+                  variant="secondaryBlack"
+                  size="small"
+                  mr={1}
+                  {...anchorProps}
+                >
+                  Hover for dropdown {num}
+                </Button>
+              )
+            }}
+          </Dropdown>
+        )
+      })}
     </Flex>
   )
 }


### PR DESCRIPTION
After investigating the issue, I identified that when implemented in Force, the focus states have increased visibility. This was causing a flickering effect when the mouse exited because the pointer status and visibility weren't properly synchronized, which triggered the focus isolation. The fix simply maintains synchronization between these two states to resolve the issue.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@38.0.5-canary.1411.31331.0
  npm install @artsy/palette@39.0.5-canary.1411.31331.0
  # or 
  yarn add @artsy/palette-charts@38.0.5-canary.1411.31331.0
  yarn add @artsy/palette@39.0.5-canary.1411.31331.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
