### PR TITLE
feat: adjust and expand red palette

### DIFF
--- a/packages/palette-tokens/src/themes/v3.tsx
+++ b/packages/palette-tokens/src/themes/v3.tsx
@@ -86,7 +86,9 @@ const COLORS = {
   /** Hover/down state and suitable for text on red10 */
   red150: "#510B0B",
   /** Suitable for text on red10, black10, and lighter */
-  red100: "#BB392D",
+  red100: "#D71023",
+  /** Suitable for importance/urgency indicators */
+  red50: "#FF1023",
   /** Background only */
   red10: "#FEF2EF",
 };

--- a/packages/palette-tokens/src/themes/v3Dark.tsx
+++ b/packages/palette-tokens/src/themes/v3Dark.tsx
@@ -51,11 +51,13 @@ const COLORS: Colors = {
   orange10: "#2b1d12",
 
   /** Hover/down state and suitable for text on red10 */
-  red150: "#f4aeae",
+  red150: "#f9d2d2",
   /** Suitable for text on red10, black10, and lighter */
-  red100: "#ff5b37",
+  red100: "#f68e98",
+  /** Suitable for importance/urgency indicators */
+  red50: "#d60012",
   /** Background only */
-  red10: "#533332",
+  red10: "#561406",
 };
 
 const EFFECTS: Effects = {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1462

Introduces `red50` as a new color intended for urgency/importance indicators, and adjusts `red100` accordingly.

From [Figma](https://www.figma.com/design/zRKGxOWHhq3kcNiNAZCig3/OtH-App%3A-Alerts-and-Activity?node-id=334-23331&m=dev):

<img width=400 src="https://github.com/user-attachments/assets/b883e942-a001-495e-891f-465f126701d4" />

## Before and after

<table>
<tr valign="top"><th>Before</th><th>After</th></tr>
<tr valign="top"><td><img width=400 src="https://github.com/user-attachments/assets/4bb9b959-cad4-4cd2-9a39-cfeb5c387e87" /></td><td><img width=400 src="https://github.com/user-attachments/assets/2beaccfb-3a74-4a38-a85c-ff42ea9c3464" /></td></tr>
</table>

## Accessibility

**Light mode**: I've kept the colors as spec'd in the Figma.

**Dark mode**: I've improvised with https://webaim.org/resources/contrastchecker (similar to what @dzucconi did in https://github.com/artsy/palette/pull/1376).

![theme](https://github.com/user-attachments/assets/677eeede-f05c-44eb-96ff-da8c469ec597)
