### PR TITLE
chore: Move shared deps to peerDeps

### DIFF
--- a/packages/palette-charts/package.json
+++ b/packages/palette-charts/package.json
@@ -40,9 +40,12 @@
     "colors": "1.4.0"
   },
   "peerDependencies": {
+    "@artsy/palette": "^40",
+    "@styled-system/theme-get": "^5",
     "react": "^18",
     "react-dom": "^18",
-    "styled-components": "^4"
+    "styled-components": "^6",
+    "styled-system": "^5"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",
@@ -114,12 +117,9 @@
     "typescript-styled-plugin": "0.10.0"
   },
   "dependencies": {
-    "@artsy/palette": "^40.2.0",
     "@seznam/compose-react-refs": "^1.0.6",
-    "@styled-system/theme-get": "^5.1.2",
     "d3-interpolate": "^1.3.2",
-    "d3-shape": "^1.3.5",
-    "styled-system": "^5.1.5"
+    "d3-shape": "^1.3.5"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
All of these deps will certainly be installed in whatever consuming app so lets move them to peerDeps. Caught this via 

https://app.relative-ci.com/projects/zNeNymVCPwxxOLTcM9qt/jobs/1330-55dq9GnCGbFfs0QVh1uZ/packages?bp=%7B%22filters%22%3A%22changed-1_duplicate-1%22%7D&dt=table&dtg=