### PR TITLE
chore: bump @artsy/palette to v40.3.0

### DIFF
--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/palette",
-  "version": "40.2.0",
+  "version": "40.3.0",
   "description": "Design system library for react components",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
Due to some breakage in our release pipeline I made a semi-manual release of `@artsy/palette@40.3.0`

See [thread](https://artsy.slack.com/archives/C2TQ4PT8R/p1738253121649049)