### PR TITLE
feat(dropdown): ability to assign zIndex to dropdown

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -39,6 +39,8 @@ export interface DropdownProps extends Omit<BoxProps, "children"> {
           "onHide" | "onVisible" | "setVisible" | "visible"
         >
       ) => void)
+  /** Custom zIndex to assign to the dropdown panel */
+  dropdownZIndex?: number
   /** Distance in pixels from anchor */
   offset?: number
   /** Should the dropdown panel always be present in the DOM (vs removed when invisible) */
@@ -58,6 +60,7 @@ export const Dropdown = ({
   children,
   offset = 10,
   dropdown,
+  dropdownZIndex = 1,
   openDropdownByClick,
   transition: _transition = true,
   ...rest
@@ -279,7 +282,7 @@ export const Dropdown = ({
             aria-label="Press escape to close"
             tabIndex={0}
             ref={panelRef as any}
-            zIndex={1}
+            zIndex={dropdownZIndex}
             display="inline-block"
             placement={placement}
             style={{


### PR DESCRIPTION
When working on something with some z-index complexity I noticed that there was no way to position the dropdown above something that has `position: relative` with a zIndex, because the assigned zIndex is always 1. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@39.4.0-canary.1420.31535.0
  npm install @artsy/palette@40.5.0-canary.1420.31535.0
  # or 
  yarn add @artsy/palette-charts@39.4.0-canary.1420.31535.0
  yarn add @artsy/palette@40.5.0-canary.1420.31535.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
