### PR TITLE
fix(tabs): prevents stale rendering of tabs

### DIFF
--- a/packages/palette/src/elements/Stepper/Stepper.tsx
+++ b/packages/palette/src/elements/Stepper/Stepper.tsx
@@ -23,7 +23,7 @@ export const Stepper: React.FC<React.PropsWithChildren<StepperProps>> = ({
   mb = 2,
   ...rest
 }) => {
-  const { tabs, activeTab, activeTabIndex, handleClick, ref } = useTabs({
+  const { tabs, activeTabIndex, handleClick, ref } = useTabs({
     children,
     initialTabIndex,
   })
@@ -67,7 +67,7 @@ export const Stepper: React.FC<React.PropsWithChildren<StepperProps>> = ({
         })}
       </BaseTabs>
 
-      {activeTab.current.child}
+      {tabs[activeTabIndex].child}
     </>
   )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.story.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.story.tsx
@@ -6,6 +6,7 @@ import { Tab, Tabs, TabsProps } from "./"
 import { Box } from "../Box"
 import { useCursor } from "use-cursor"
 import { Button } from "../Button"
+import { Input } from "../Input"
 
 export default {
   title: "Components/Tabs",
@@ -211,5 +212,24 @@ export const Cached = () => {
         <Tab name="Third">Third — count: {count}</Tab>
       </Tabs>
     </>
+  )
+}
+
+export const WithInputs = () => {
+  const [value, setValue] = useState("")
+  const [value2, setValue2] = useState("")
+
+  return (
+    <Tabs>
+      <Tab name="First">
+        <pre>{JSON.stringify({ value })}</pre>
+        <Input value={value} onChange={(e) => setValue(e.target.value)} />
+      </Tab>
+
+      <Tab name="Second">
+        <pre>{JSON.stringify({ value2 })}</pre>
+        <Input value={value2} onChange={(e) => setValue2(e.target.value)} />
+      </Tab>
+    </Tabs>
   )
 }

--- a/packages/palette/src/elements/Tabs/Tabs.tsx
+++ b/packages/palette/src/elements/Tabs/Tabs.tsx
@@ -54,16 +54,10 @@ export const useTabs = ({
   const previousInitialTabIndex = usePrevious(initialTabIndex)
   const [activeTabIndex, setActiveTabIndex] = useState<number>(initialTabIndex)
 
-  // Wraps active tab in a ref to prevent re-rendering.
-  // This means that we need to update the active tab before the index state change
-  // to catch the re-render.
-  const activeTab = useRef(tabs[activeTabIndex])
-
   // If the `initialTabIndex` changes; update the active one
   useUpdateEffect(() => {
     // Only update if the `initialTabIndex` has changed externally
     if (initialTabIndex === previousInitialTabIndex) return
-    activeTab.current = tabs[initialTabIndex]
     setActiveTabIndex(initialTabIndex)
   }, [initialTabIndex, tabs])
 
@@ -73,7 +67,7 @@ export const useTabs = ({
   // Scroll to active tab when `activeTabIndex` changes
   useEffect(() => {
     if (!ref.current) return
-    const tab = activeTab.current.ref.current
+    const tab = tabs[activeTabIndex].ref.current
     if (!tab) return
     const position = tab.offsetLeft
     ref.current.scrollTo?.({ left: position, behavior: "smooth" })
@@ -84,7 +78,6 @@ export const useTabs = ({
       return () => {
         if (index === activeTabIndex) return
 
-        activeTab.current = tabs[index]
         setActiveTabIndex(index)
 
         if (!onChange) return
@@ -100,7 +93,6 @@ export const useTabs = ({
   )
 
   return {
-    activeTab,
     activeTabIndex,
     handleClick,
     ref,
@@ -116,7 +108,7 @@ export const Tabs: React.FC<React.PropsWithChildren<TabsProps>> = ({
   onChange,
   ...rest
 }) => {
-  const { tabs, activeTab, activeTabIndex, handleClick, ref } = useTabs({
+  const { tabs, activeTabIndex, handleClick, ref } = useTabs({
     children,
     initialTabIndex,
     onChange,
@@ -142,7 +134,7 @@ export const Tabs: React.FC<React.PropsWithChildren<TabsProps>> = ({
         })}
       </BaseTabs>
 
-      {activeTab.current.child}
+      {tabs[activeTabIndex].child}
     </>
   )
 }


### PR DESCRIPTION
## Problem
The `Tabs` component was using a ref to cache the active tab content in an attempt to prevent re-rendering. This caching mechanism was causing issues with form inputs within tab content, as their state updates weren't being reflected properly.

## Solution
Removed the `activeTab` ref and now directly render the active tab content using `tabs[activeTabIndex].child`. This maintains all existing functionality (tab switching, scrolling, etc.) while ensuring proper state updates for form inputs and other interactive elements within tab content. All stories still pass.