### PR TITLE
feat(dia-1259): implements fitting for dropdowns

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -247,27 +247,47 @@ export const OverflowingContent = () => {
     </Text>
   )
 
+  const [placement, setPlacement] = useState<Position>("bottom")
+
   return (
     <>
       <Box height={200} bg="black10" />
 
       <Spacer y={2} />
 
-      <Dropdown dropdown={dropdown} openDropdownByClick placement="bottom">
-        {({ anchorRef, anchorProps }) => {
-          return (
-            <Button
-              ref={anchorRef}
-              variant="secondaryBlack"
-              size="small"
-              mr={1}
-              {...anchorProps}
-            >
-              Click to display dropdown
-            </Button>
-          )
-        }}
-      </Dropdown>
+      {["bottom", "top", "left", "right"].map((p) => {
+        return (
+          <Pill
+            key={p}
+            size="small"
+            mr={1}
+            mb={1}
+            selected={placement === p}
+            onClick={() => setPlacement(p as Position)}
+          >
+            {p}
+          </Pill>
+        )
+      })}
+
+      <Spacer y={2} />
+
+      <Flex alignItems="center" justifyContent="center">
+        <Dropdown dropdown={dropdown} openDropdownByClick placement={placement}>
+          {({ anchorRef, anchorProps }) => {
+            return (
+              <Button
+                ref={anchorRef}
+                variant="secondaryBlack"
+                size="small"
+                {...anchorProps}
+              >
+                Click to display dropdown
+              </Button>
+            )
+          }}
+        </Dropdown>
+      </Flex>
 
       <Spacer y={2} />
 

--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -9,6 +9,7 @@ import { Clickable } from "../Clickable"
 import { Flex } from "../Flex"
 import { Pill } from "../Pill"
 import ChevronSmallDownIcon from "@artsy/icons/ChevronSmallDownIcon"
+import { Spacer } from "../Spacer"
 
 export default {
   title: "Components/Dropdown",
@@ -247,13 +248,12 @@ export const OverflowingContent = () => {
   )
 
   return (
-    <Flex>
-      <Dropdown
-        dropdown={dropdown}
-        openDropdownByClick
-        flip={false}
-        placement="bottom"
-      >
+    <>
+      <Box height={200} bg="black10" />
+
+      <Spacer y={2} />
+
+      <Dropdown dropdown={dropdown} openDropdownByClick placement="bottom">
         {({ anchorRef, anchorProps }) => {
           return (
             <Button
@@ -268,7 +268,11 @@ export const OverflowingContent = () => {
           )
         }}
       </Dropdown>
-    </Flex>
+
+      <Spacer y={2} />
+
+      <Box height={5000} bg="black10" />
+    </>
   )
 }
 

--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -248,7 +248,12 @@ export const OverflowingContent = () => {
 
   return (
     <Flex>
-      <Dropdown dropdown={dropdown} openDropdownByClick>
+      <Dropdown
+        dropdown={dropdown}
+        openDropdownByClick
+        flip={false}
+        placement="bottom"
+      >
         {({ anchorRef, anchorProps }) => {
           return (
             <Button

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import styled from "styled-components"
-import { Position, usePosition } from "../../utils"
+import { calculateMaxHeight, Position, usePosition } from "../../utils"
 import { usePortal } from "../../utils/usePortal"
 import { Box, BoxProps } from "../Box"
 import { FocusOn } from "react-focus-on"
 import { themeGet } from "@styled-system/theme-get"
+import { debounce } from "es-toolkit"
 
 export interface DropdownActions {
   /** Call to show dropdown */
@@ -124,6 +125,7 @@ export const Dropdown = ({
     offset: 0,
     active: visible,
     flip,
+    padding: offset,
   })
 
   useEffect(() => {
@@ -269,6 +271,31 @@ export const Dropdown = ({
   const isPointer = !openDropdownByClick && pointerRef.current
   const focusEnabled = visible && !isPointer
 
+  const [maxHeight, setMaxHeight] = useState(0)
+
+  useEffect(() => {
+    const calculate = debounce(() => {
+      if (!anchorRef.current) return
+
+      const nextMaxHeight = calculateMaxHeight({
+        anchorRect: anchorRef.current.getBoundingClientRect(),
+        position: placement,
+        offset,
+      })
+
+      setMaxHeight(nextMaxHeight)
+    }, 500)
+
+    window.addEventListener("resize", calculate, { passive: true })
+    window.addEventListener("scroll", calculate, { passive: true })
+    calculate()
+
+    return () => {
+      window.removeEventListener("resize", calculate)
+      window.removeEventListener("scroll", calculate)
+    }
+  }, [anchorRef, offset, placement, visible])
+
   return (
     <>
       {(children as any)?.({
@@ -300,14 +327,13 @@ export const Dropdown = ({
                   onMouseEnter: handleMouseEnter,
                   onMouseLeave: handleMouseLeave,
                 })}
+            maxHeight={maxHeight + offset}
             {...padding}
             {...rest}
           >
             <Panel
-              bg="white100"
-              border="1px solid"
-              borderColor="black10"
               transition={_transition}
+              maxHeight={maxHeight}
               style={
                 transition
                   ? // In
@@ -346,12 +372,14 @@ const Container = styled(Box)<{ placement: Position } & BoxProps>`
   outline: 0;
 `
 
-const Panel = styled(Box)<{ transition: boolean }>`
+const Panel = styled(Box)<{ transition: boolean; maxHeight: number }>`
   transition: ${({ transition }) =>
     transition ? "opacity 250ms ease-out, transform 250ms ease-out" : "none"};
-  box-shadow: ${themeGet("effects.flatShadow")};
   > div {
-    max-height: 100vh;
+    max-height: ${({ maxHeight }) => (maxHeight ? `${maxHeight}px` : "100vh")};
+    box-shadow: ${themeGet("effects.flatShadow")};
+    background-color: ${themeGet("colors.white100")};
+    border: 1px solid ${themeGet("colors.black10")};
     overflow-y: auto;
   }
 `

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -47,6 +47,8 @@ export interface DropdownProps extends Omit<BoxProps, "children"> {
   keepInDOM?: boolean
   openDropdownByClick?: boolean
   children: Children
+  /** Optionally disable flipping (default: `true`) */
+  flip?: boolean
 }
 
 /**
@@ -63,6 +65,7 @@ export const Dropdown = ({
   dropdownZIndex = 1,
   openDropdownByClick,
   transition: _transition = true,
+  flip = true,
   ...rest
 }: DropdownProps) => {
   const [visible, setVisible] = useState(false)
@@ -120,6 +123,7 @@ export const Dropdown = ({
     position: placement,
     offset: 0,
     active: visible,
+    flip,
   })
 
   useEffect(() => {

--- a/packages/palette/src/utils/__tests__/usePosition.test.ts
+++ b/packages/palette/src/utils/__tests__/usePosition.test.ts
@@ -5,6 +5,7 @@ import {
   POSITION,
   shouldFlip,
   translateWithOffset,
+  calculateMaxHeight,
 } from "../usePosition"
 
 const positions = Object.keys(POSITION) as Position[]
@@ -72,7 +73,7 @@ describe("getPosition", () => {
 
     expect(
       positions.map((position) =>
-        getPosition(elementRect, tooltipRect, position)
+        getPosition({ elementRect, tooltipRect, position })
       )
     ).toEqual([
       { x: 0, y: -200 }, // top-start
@@ -165,5 +166,157 @@ describe("shouldFlip", () => {
       true,
       true,
     ])
+  })
+})
+
+describe("calculateMaxHeight", () => {
+  let originalInnerHeight: number
+
+  beforeEach(() => {
+    // Store original window.innerHeight
+    originalInnerHeight = window.innerHeight
+    // Mock window.innerHeight
+    Object.defineProperty(window, "innerHeight", {
+      value: 800,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    // Restore original window.innerHeight
+    Object.defineProperty(window, "innerHeight", {
+      value: originalInnerHeight,
+    })
+  })
+
+  it("calculates max height for top placement", () => {
+    const anchorRect = {
+      top: 300,
+      bottom: 400,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 300,
+    } as DOMRect
+
+    const result = calculateMaxHeight({
+      anchorRect,
+      position: "top",
+      offset: 10,
+    })
+
+    // For top placement: anchorRect.top - offset * 2
+    // 300 - 10 * 2 = 280
+    expect(result).toBe(280)
+  })
+
+  it("calculates max height for bottom placement", () => {
+    const anchorRect = {
+      top: 300,
+      bottom: 400,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 300,
+    } as DOMRect
+
+    const result = calculateMaxHeight({
+      anchorRect,
+      position: "bottom",
+      offset: 10,
+    })
+
+    // For bottom placement: viewportHeight - anchorRect.bottom - offset * 2
+    // 800 - 400 - 10 * 2 = 380
+    expect(result).toBe(380)
+  })
+
+  it("calculates max height for side placements", () => {
+    const anchorRect = {
+      top: 300,
+      bottom: 400,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 300,
+    } as DOMRect
+
+    const result = calculateMaxHeight({
+      anchorRect,
+      position: "left",
+      offset: 10,
+    })
+
+    // For side placements: viewportHeight - offset * 2
+    // 800 - 10 * 2 = 780
+    expect(result).toBe(780)
+  })
+
+  it("uses default offset of 0 when not provided", () => {
+    const anchorRect = {
+      top: 300,
+      bottom: 400,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 300,
+    } as DOMRect
+
+    const result = calculateMaxHeight({
+      anchorRect,
+      position: "top",
+    })
+
+    // For top placement with default offset: anchorRect.top - 0 * 2
+    // 300 - 0 = 300
+    expect(result).toBe(300)
+  })
+
+  it("handles all position variants correctly", () => {
+    const anchorRect = {
+      top: 300,
+      bottom: 400,
+      left: 100,
+      right: 200,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 300,
+    } as DOMRect
+
+    // Test all position variants
+    const topPositions: Position[] = ["top-start", "top", "top-end"]
+    const bottomPositions: Position[] = ["bottom-start", "bottom", "bottom-end"]
+    const sidePositions: Position[] = [
+      "left-start",
+      "left",
+      "left-end",
+      "right-start",
+      "right",
+      "right-end",
+    ]
+
+    // All top positions should return the same value
+    topPositions.forEach((position) => {
+      expect(calculateMaxHeight({ anchorRect, position })).toBe(300)
+    })
+
+    // All bottom positions should return the same value
+    bottomPositions.forEach((position) => {
+      expect(calculateMaxHeight({ anchorRect, position })).toBe(400)
+    })
+
+    // All side positions should return the same value
+    sidePositions.forEach((position) => {
+      expect(calculateMaxHeight({ anchorRect, position })).toBe(800)
+    })
   })
 })

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -378,3 +378,68 @@ const isWithin = (elementRect: DOMRect, boundaryRect: DOMRect) => {
     boundaryRect.right > elementRect.left
   )
 }
+
+/**
+ * Calculate the maximum height available for a tooltip based on its placement and viewport constraints.
+ */
+export const calculateMaxHeight = ({
+  anchorRect,
+  position,
+  offset = 0,
+}: {
+  anchorRect: DOMRect
+  position: Position
+  offset?: number
+}): number => {
+  const viewportHeight = window.innerHeight
+
+  // Ensure a reasonable minimum height
+  const minimumHeight = 50
+
+  // Use a smaller viewport padding to avoid excessive constraints
+  const viewportPadding = Math.min(offset, 10)
+
+  let availableHeight: number
+  let topEdgeDistance: number
+  let bottomEdgeDistance: number
+
+  switch (position) {
+    case "top-start":
+    case "top":
+    case "top-end":
+      // Space from top of anchor to top of viewport
+      availableHeight = anchorRect.top - viewportPadding
+      break
+    case "bottom-start":
+    case "bottom":
+    case "bottom-end":
+      // Space from bottom of anchor to bottom of viewport
+      availableHeight = viewportHeight - anchorRect.bottom - viewportPadding
+      break
+    case "left-start":
+    case "left":
+    case "left-end":
+    case "right-start":
+    case "right":
+    case "right-end":
+      // For side placements, use the more generous of the two calculations
+      topEdgeDistance = anchorRect.top - viewportPadding
+      bottomEdgeDistance =
+        viewportHeight -
+        Math.max(anchorRect.top, anchorRect.bottom) -
+        viewportPadding
+      // Allow a reasonable height for side placements
+      availableHeight = Math.max(
+        topEdgeDistance + anchorRect.height,
+        bottomEdgeDistance + anchorRect.height,
+        minimumHeight
+      )
+      break
+    default:
+      // Default to viewport height minus minimal padding
+      availableHeight = viewportHeight - viewportPadding * 2
+  }
+
+  // Ensure we always return at least the minimum height
+  return Math.max(minimumHeight, availableHeight)
+}


### PR DESCRIPTION
Re: https://github.com/artsy/force/pull/15387 — here we implement a better implementation of dropdown fitting for all dropdowns.

Let's see how the canary looks in Force. Will probably want to also allow for opting out of this behavior as one can imagine dropdowns on scrollable elements that you may want to flip instead of fit.