### PR TITLE
fix: Update v3Dark colors `black60` and `black30`

### DIFF
--- a/packages/palette-tokens/src/themes/v3Dark.tsx
+++ b/packages/palette-tokens/src/themes/v3Dark.tsx
@@ -4,9 +4,9 @@ const COLORS: Colors = {
   /** Suitable for text on black10 and lighter */
   black100: "#ffffff",
   /** Suitable for text on black5 and lighter */
-  black60: "#949494",
+  black60: "#707070",
   /** Background only */
-  black30: "#4d4d4d",
+  black30: "#C2C2C2",
   /** Background only */
   black15: "#404040",
   /** Background only */


### PR DESCRIPTION
Addresses [ONYX-1635]

* [Figma Design](https://www.figma.com/design/gZNkyqLT8AU3T61tluVJyB/Design-System-Foundations-3.1?node-id=18332-8584&m=dev)

## Description

This updates the v3Dark colors `black60` & `black30`, following up on this conversation https://github.com/artsy/eigen/pull/11851#issuecomment-2785560437


**black60:**

<img width="947" alt="Bildschirmfoto 2025-04-09 um 15 45 49" src="https://github.com/user-attachments/assets/a8615244-c9ef-4774-aafb-f372f468be2d" />


**black30:**
<img width="988" alt="Bildschirmfoto 2025-04-09 um 15 46 47" src="https://github.com/user-attachments/assets/3edd4985-56ac-4b7b-ba3d-07880037e1e5" />

[ONYX-1635]: https://artsyproduct.atlassian.net/browse/ONYX-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ