### PR TITLE
fix: Update v3Dark blue10

### DIFF
--- a/packages/palette-tokens/src/themes/v3Dark.tsx
+++ b/packages/palette-tokens/src/themes/v3Dark.tsx
@@ -27,7 +27,7 @@ const COLORS: Colors = {
   /** Background only */
   blue15: "#474d8a",
   /** Background only */
-  blue10: "#e6e7f5",
+  blue10: "#31335e",
 
   /** Hover/down state and suitable for text on green10 */
   green150: "#c8fff0",


### PR DESCRIPTION
Addresses [ONYX-1635]

## Description

This updates the v3Dark color `blue10`. It's currently very light, and it's unclear to me why it was updated (https://github.com/artsy/palette/pull/1421/files). Light colors should be very dark within `v3Dark`.

<img width="999" alt="Bildschirmfoto 2025-04-09 um 15 50 44" src="https://github.com/user-attachments/assets/4e71b959-ac48-4631-922b-1d18b7dc3e9b" />

**Mobile-pallete's Message component**
| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 16 - 2025-04-09 at 15 51 14](https://github.com/user-attachments/assets/40452d7b-91b1-4f65-9e8c-7ff9abfd2b05) | ![Simulator Screenshot - iPhone 16 - 2025-04-09 at 15 50 52](https://github.com/user-attachments/assets/f1584046-e19b-4f48-9f18-6e0daa822819)|




[ONYX-1635]: https://artsyproduct.atlassian.net/browse/ONYX-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ