### PR TITLE
fix: Update v3Dark black60 and black30

### DIFF
--- a/packages/palette-tokens/src/themes/v3Dark.tsx
+++ b/packages/palette-tokens/src/themes/v3Dark.tsx
@@ -4,9 +4,9 @@ const COLORS: Colors = {
   /** Suitable for text on black10 and lighter */
   black100: "#ffffff",
   /** Suitable for text on black5 and lighter */
-  black60: "#949494",
+  black60: "#C2C2C2",
   /** Background only */
-  black30: "#4d4d4d",
+  black30: "#707070",
   /** Background only */
   black15: "#404040",
   /** Background only */


### PR DESCRIPTION
Addresses [ONYX-1635]

* [Figma Design](https://www.figma.com/design/gZNkyqLT8AU3T61tluVJyB/Design-System-Foundations-3.1?node-id=18332-8584&m=dev)

## Description

This updates the v3Dark colors `black60` & `black30` to match this  [Figma Design](https://www.figma.com/design/gZNkyqLT8AU3T61tluVJyB/Design-System-Foundations-3.1?node-id=18332-8584&m=dev).



## Contrast Ratios

**Before:**
<img width="1806" alt="Bildschirmfoto 2025-04-10 um 11 43 48" src="https://github.com/user-attachments/assets/f19578bd-6cbe-464c-8152-177b337373b8" />

**After:**
<img width="1808" alt="Bildschirmfoto 2025-04-10 um 11 43 13" src="https://github.com/user-attachments/assets/d607b56e-496c-4318-8005-eb3b7cdf2b9f" />

## Color Updates

**black60:**

<img width="998" alt="Bildschirmfoto 2025-04-09 um 16 28 18" src="https://github.com/user-attachments/assets/a44f42e9-24a5-4fc8-92d4-05d515c0663b" />

**black30:**

<img width="986" alt="Bildschirmfoto 2025-04-09 um 16 28 36" src="https://github.com/user-attachments/assets/a957c824-0944-45f2-a745-41de51d4d51d" />

[ONYX-1635]: https://artsyproduct.atlassian.net/browse/ONYX-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ