### PR TITLE
chore: Update local development docs to use `yarn lerna` instead of `lerna`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you'd like to add a new component to Palette please raise the need in our `#d
 In the project root run the following:
 
 ```sh
-$ lerna bootstrap
+$ yarn lerna bootstrap
 $ yarn storybook
 ```
 


### PR DESCRIPTION

## Description

This updates the local development docs to use `yarn lerna` instead of `lerna` (which didn't work).
