### PR TITLE
fix(popover): prevents layout thrashing at specific zoom levels

### DIFF
--- a/packages/palette/src/elements/Popover/Popover.story.tsx
+++ b/packages/palette/src/elements/Popover/Popover.story.tsx
@@ -235,3 +235,67 @@ export const PopoverActions = () => {
     </States>
   )
 }
+
+export const CrashAtSpecificZoomLevels = () => {
+  return (
+    <>
+      <Box height={100}>Zoom to 90% in Chrome, click, then scroll.</Box>
+
+      <Box height={2000} bg="black5">
+        <Box height={200} />
+
+        <Popover
+          placement="top"
+          popover={({ onHide, onDismiss }) => {
+            return (
+              <>
+                <Text variant="xs" width={300}>
+                  {CONTENT}
+                </Text>
+
+                <Spacer y={2} />
+
+                <Flex>
+                  <Button
+                    flex={1}
+                    size="small"
+                    variant="secondaryBlack"
+                    onClick={onHide}
+                  >
+                    Hide
+                  </Button>
+
+                  <Spacer x={1} />
+
+                  <Button
+                    flex={1}
+                    size="small"
+                    variant="secondaryBlack"
+                    onClick={onDismiss}
+                  >
+                    Dismiss
+                  </Button>
+                </Flex>
+              </>
+            )
+          }}
+        >
+          {({ onVisible, anchorRef }) => {
+            return (
+              <Box textAlign="center">
+                <Button
+                  ref={anchorRef}
+                  variant="secondaryBlack"
+                  size="small"
+                  onClick={onVisible}
+                >
+                  Click to display popover
+                </Button>
+              </Box>
+            )
+          }}
+        </Popover>
+      </Box>
+    </>
+  )
+}

--- a/packages/palette/src/utils/usePosition.ts
+++ b/packages/palette/src/utils/usePosition.ts
@@ -71,9 +71,19 @@ export const usePosition = ({
     const { current: tooltip } = tooltipRef
     const { current: anchor } = anchorRef
 
-    setState(
-      placeTooltip({ anchor, tooltip, position, offset, flip, clamp, padding })
-    )
+    requestAnimationFrame(() => {
+      setState(
+        placeTooltip({
+          anchor,
+          tooltip,
+          position,
+          offset,
+          flip,
+          clamp,
+          padding,
+        })
+      )
+    })
   }
 
   // Re-position when there's any change to the tooltip
@@ -96,17 +106,19 @@ export const usePosition = ({
     tooltip.style.left = "0"
 
     const handleScroll = () => {
-      setState(
-        placeTooltip({
-          anchor,
-          tooltip,
-          position,
-          offset,
-          flip,
-          clamp,
-          padding,
-        })
-      )
+      requestAnimationFrame(() => {
+        setState(
+          placeTooltip({
+            anchor,
+            tooltip,
+            position,
+            offset,
+            flip,
+            clamp,
+            padding,
+          })
+        )
+      })
     }
 
     document.addEventListener("scroll", handleScroll, {
@@ -114,17 +126,19 @@ export const usePosition = ({
     })
 
     const handleResize = () => {
-      setState(
-        placeTooltip({
-          anchor,
-          tooltip,
-          position,
-          offset,
-          flip,
-          clamp,
-          padding,
-        })
-      )
+      requestAnimationFrame(() => {
+        setState(
+          placeTooltip({
+            anchor,
+            tooltip,
+            position,
+            offset,
+            flip,
+            clamp,
+            padding,
+          })
+        )
+      })
     }
 
     window.addEventListener("resize", handleResize, { passive: true })


### PR DESCRIPTION
We discovered that displaying a popover at certain zoom levels causes the page to crash. Investigation revealed this is caused by layout thrashing when the browser repeatedly reads and writes fractional pixel values in the `MutationObserver` callback. `placeTooltip` performs a read of the DOM and then subsequently uses that measurement to write a transform.

By wrapping these state updates in `requestAnimationFrame` we can just batch them into a single pass, preventing the self-triggering loop.