### PR TITLE
fix(avatar): prevents avatar from deforming

### DIFF
--- a/packages/palette/src/elements/Avatar/Avatar.story.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.story.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import { States } from "storybook-states"
 import { Avatar, AvatarProps } from "./Avatar"
+import { Box } from "../Box"
+import { Stack } from "../Stack"
+import { Text } from "../Text"
 
 export default {
   title: "Components/Avatar",
@@ -52,6 +55,27 @@ export const WithBrokenImage = () => {
         srcSet="https://example.com/broken.jpg 1x, https://example.com/broken.jpg 2x"
         initials="TK"
       />
+    </States>
+  )
+}
+
+export const WithTightContainer = () => {
+  return (
+    <States>
+      <Box
+        maxWidth={150}
+        border="1px solid"
+        borderColor="mono15"
+        overflow="hidden"
+        p={1}
+      >
+        <Stack gap={1} flexDirection="row" alignItems="center">
+          <Avatar size="xs" initials="TK" />
+          <Text size="sm-display" hyphenate>
+            example@longemailaddress.com
+          </Text>
+        </Stack>
+      </Box>
     </States>
   )
 }

--- a/packages/palette/src/elements/Avatar/Avatar.tsx
+++ b/packages/palette/src/elements/Avatar/Avatar.tsx
@@ -66,6 +66,7 @@ export const Avatar: React.FC<React.PropsWithChildren<AvatarProps>> = ({
       justifyContent="center"
       position="relative"
       overflow="hidden"
+      flexShrink={0}
       {...boxProps}
     >
       {initials && (


### PR DESCRIPTION
If an avatar is in the same container as some element that doesn't shrink it will shrink/deform. It should always remain a circle and the same size. Text should be adjusted to accommodate/shrink (Will open a corresponding Force PR)