### PR TITLE
feat: Display selected options on MultiSelect

### DIFF
--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -1,18 +1,17 @@
 import { themeGet } from "@styled-system/theme-get"
 import React, { useEffect, useState } from "react"
-import styled from "styled-components"
-import { css } from "styled-components"
+import styled, { css } from "styled-components"
 import { FORM_ELEMENT_TRANSITION } from "../../helpers"
+import { RequiredField } from "../../shared/RequiredField"
 import { useClickOutside, usePosition } from "../../utils"
 import { useUpdateEffect } from "../../utils/useUpdateEffect"
 import { useWidthOf } from "../../utils/useWidthOf"
 import { Box, BoxProps } from "../Box"
 import { Checkbox } from "../Checkbox"
+import { Clickable } from "../Clickable"
 import { caretMixin, Option } from "../Select"
 import { Text } from "../Text"
 import { Tooltip } from "../Tooltip"
-import { Clickable } from "../Clickable"
-import { RequiredField } from "../../shared/RequiredField"
 import { MULTISELECT_STATES } from "./tokens"
 
 export interface MultiSelectProps extends BoxProps {
@@ -127,8 +126,10 @@ export const MultiSelect: React.FC<
         visible={visible}
         {...rest}
       >
-        <Text variant="sm" lineHeight={1}>
-          {selection.length > 0 ? `${selection.length} selected` : name}
+        <Text variant="sm" lineHeight={1} overflowEllipsis>
+          {selection.length > 0
+            ? selection.map((s) => s.text).join(", ")
+            : name}
         </Text>
 
         {!!title && <StyledLabel htmlFor={name}>{title}</StyledLabel>}


### PR DESCRIPTION
Resolves https://artsy.slack.com/archives/C9XJKPY9W/p1746542983418539

## Description

Display selected options on MultiSelect.

| Before | After |
| --- | --- |
|<img width="425" alt="Bildschirmfoto 2025-05-07 um 16 14 28" src="https://github.com/user-attachments/assets/94dc91eb-115c-4725-bb4a-73c591852e49" /> | <img width="360" alt="Bildschirmfoto 2025-05-07 um 16 13 06" src="https://github.com/user-attachments/assets/54adff77-1ac7-4815-a881-0b798719c066" />|



