### PR TITLE
fix(image): prevents image collapse when lazyload without geometry

### DIFF
--- a/packages/palette/src/elements/Image/Image.story.tsx
+++ b/packages/palette/src/elements/Image/Image.story.tsx
@@ -133,3 +133,11 @@ export const WithCustomStyle = () => {
     </Box>
   )
 }
+
+export const EnsuresImageDoesNotCollapse = () => {
+  return (
+    <Box width={300} height={200} bg="red">
+      <Image src="https://picsum.photos/seed/example/300/200" lazyLoad />
+    </Box>
+  )
+}

--- a/packages/palette/src/elements/Image/Image.tsx
+++ b/packages/palette/src/elements/Image/Image.tsx
@@ -61,8 +61,8 @@ export const Image: React.FC<ImageProps> = ({
       <Box
         className={className}
         position="relative"
-        width={width}
-        height={height}
+        width={width || "100%"}
+        height={height || "100%"}
         bg={lazyLoad && !placeHolderURL ? "mono10" : undefined}
         {...boxProps}
         style={{


### PR DESCRIPTION
<del>Let's see if this locates any other collapsing images. Seems like a reasonable change for the type.</del>

If you're lazy loading you've got a block level container anyway so we just fallback to 100% for width and height.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@40.1.2-canary.1439.31919.0
  npm install @artsy/palette@41.1.2-canary.1439.31919.0
  # or 
  yarn add @artsy/palette-charts@40.1.2-canary.1439.31919.0
  yarn add @artsy/palette@41.1.2-canary.1439.31919.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
