### PR TITLE
feat: Add autoOpen prop to MultiSelect

### DIFF
--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -21,8 +21,6 @@ export interface MultiSelectProps extends BoxProps {
   error?: string | boolean
   focus?: boolean
   hover?: boolean
-  /** Whether the option dropdown is visible immediately (default: false) */
-  isVisible?: boolean
   /** Initial values to be selected */
   selected?: Option["value"][]
   name?: string
@@ -32,6 +30,8 @@ export interface MultiSelectProps extends BoxProps {
   onBlur?: () => void
   onFocus?: () => void
   onSelect?: (selection: Option[]) => void
+  /** Whether the options dropdown opens immediately when rendered (default: false) */
+  open?: boolean
   visible?: boolean
 }
 
@@ -53,12 +53,12 @@ export const MultiSelect: React.FC<
   onBlur,
   onFocus,
   onSelect,
-  isVisible = false,
+  open = false,
   ...rest
 }) => {
   const selectedOptions = valuesToOptions(selected, options)
 
-  const [visible, setVisible] = useState(isVisible)
+  const [visible, setVisible] = useState(open)
   const [selection, setSelection] = useState<Option[]>(selectedOptions || [])
 
   // Yields focus back and forth between popover and anchor

--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -15,6 +15,8 @@ import { Tooltip } from "../Tooltip"
 import { MULTISELECT_STATES } from "./tokens"
 
 export interface MultiSelectProps extends BoxProps {
+  /** Whether to open the dropdown automatically on mount or render (default: false) */
+  autoOpen?: boolean
   complete?: boolean
   description?: string
   disabled?: boolean
@@ -30,8 +32,7 @@ export interface MultiSelectProps extends BoxProps {
   onBlur?: () => void
   onFocus?: () => void
   onSelect?: (selection: Option[]) => void
-  /** Whether the options dropdown opens immediately when rendered (default: false) */
-  open?: boolean
+
   visible?: boolean
 }
 
@@ -39,6 +40,7 @@ export interface MultiSelectProps extends BoxProps {
 export const MultiSelect: React.FC<
   React.PropsWithChildren<MultiSelectProps>
 > = ({
+  autoOpen = false,
   complete,
   description,
   disabled,
@@ -53,12 +55,11 @@ export const MultiSelect: React.FC<
   onBlur,
   onFocus,
   onSelect,
-  open = false,
   ...rest
 }) => {
   const selectedOptions = valuesToOptions(selected, options)
 
-  const [visible, setVisible] = useState(open)
+  const [visible, setVisible] = useState(autoOpen)
   const [selection, setSelection] = useState<Option[]>(selectedOptions || [])
 
   // Yields focus back and forth between popover and anchor

--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -21,6 +21,8 @@ export interface MultiSelectProps extends BoxProps {
   error?: string | boolean
   focus?: boolean
   hover?: boolean
+  /** Whether the option dropdown is visible immediately (default: false) */
+  isVisible?: boolean
   /** Initial values to be selected */
   selected?: Option["value"][]
   name?: string
@@ -51,11 +53,12 @@ export const MultiSelect: React.FC<
   onBlur,
   onFocus,
   onSelect,
+  isVisible = false,
   ...rest
 }) => {
   const selectedOptions = valuesToOptions(selected, options)
 
-  const [visible, setVisible] = useState(false)
+  const [visible, setVisible] = useState(isVisible)
   const [selection, setSelection] = useState<Option[]>(selectedOptions || [])
 
   // Yields focus back and forth between popover and anchor
@@ -91,7 +94,6 @@ export const MultiSelect: React.FC<
       document.removeEventListener("keydown", handleKeydown)
     }
   }, [])
-
   const { anchorRef, tooltipRef } = usePosition({
     position: "bottom",
     offset: 10,


### PR DESCRIPTION

## Description

This adds an `isVisible` prop to `MultiSelect` to open the options dropdown immediately upon rendering.