### PR TITLE
fix: MultiSelect selected items check

### DIFF
--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -168,7 +168,7 @@ export const MultiSelect: React.FC<
                 key={option.value}
                 height={50}
                 px={1}
-                selected={selection.includes(option)}
+                selected={selection.map((o) => o.value).includes(option.value)}
                 onSelect={handleSelect(option)}
               >
                 {option.text}


### PR DESCRIPTION
## Description

This PR fixes the issue of checking whether `MultiSelect` items are selected by comparing their values instead of object references.

When comparing object references to determine if an item is selected, any changes to the items in `options` (which are objects) will cause the check to fail, making all items appear unselected.