### PR TITLE
fix: Set Drawer `transform` to `none` when opened for fixed children

### DIFF
--- a/packages/palette/src/elements/Drawer/Drawer.tsx
+++ b/packages/palette/src/elements/Drawer/Drawer.tsx
@@ -1,11 +1,11 @@
+import { themeGet } from "@styled-system/theme-get"
 import React, { FC } from "react"
-import { Box } from "../Box"
-import { Flex } from "../Flex"
+import { FocusOn } from "react-focus-on"
 import styled, { css } from "styled-components"
 import { zIndex } from "styled-system"
-import { FocusOn } from "react-focus-on"
 import { usePortal } from "../../utils/usePortal"
-import { themeGet } from "@styled-system/theme-get"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
 
 export interface DrawerProps {
   open: boolean
@@ -48,7 +48,7 @@ export const Drawer: FC<React.PropsWithChildren<DrawerProps>> = ({
           }
           style={{
             transform: open
-              ? "translateX(0)"
+              ? "none"
               : `translateX(${anchor === "left" ? "-110%" : "110%"})`,
           }}
         >


### PR DESCRIPTION

## Description

Set Drawer `transform` to `none` when it's opened to make fixed elements work inside (e.g. AutocompleteInput).

[The uncanny relationship between position fixed and transform property](https://dev.to/salilnaik/the-uncanny-relationship-between-position-fixed-and-transform-property-32f6)

