### PR TITLE
chore: Reproduce the Autocomplete bug within Drawer

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.story.tsx
@@ -12,6 +12,7 @@ import { Clickable } from "../Clickable"
 import { Flex } from "../Flex"
 import { Button } from "../Button"
 import { Stack } from "../Stack"
+import { Drawer } from "../Drawer"
 
 export default {
   title: "Components/AutocompleteInput",
@@ -315,5 +316,17 @@ export const OpenOnClick = () => {
         />
       )}
     </Stack>
+  )
+}
+
+export const InDrawer = () => {
+  return (
+    <Drawer open={true} anchor="right">
+      <AutocompleteInput
+        autoFocus
+        placeholder="Begin typing..."
+        options={CITIES}
+      />
+    </Drawer>
   )
 }


### PR DESCRIPTION
[Slack thread](https://artsy.slack.com/archives/C05F8TNKGAV/p1748537455230889)

Putting up this PR just to illustrate the current issue we have and we can close it once we do not need it.
Just thought it'd be easier for everyone to understand the changes added on https://github.com/artsy/palette/pull/1446

When using the autocomplete input within a drawer positioned to the right, we're bumping into issues with the position of the options. It doesn't always display right below the component (sometimes it doesn't even display on any visible spot).


https://github.com/user-attachments/assets/361d0fd2-1904-4ea7-9308-207d21a8acd6



As pointed out by @olerichter00, this seems to be a conflict between the Autocomplete options relying on `position: fixed` and the drawer relying on the `transform` property, leading to an uncanny relationship (more about this
[here](https://dev.to/salilnaik/the-uncanny-relationship-between-position-fixed-and-transform-property-32f6)).