### PR TITLE
fix(dia-1351): update palettes themed effects to match the lighter dark mode foreground color

### DIFF
--- a/packages/palette-tokens/src/themes/v3Dark.tsx
+++ b/packages/palette-tokens/src/themes/v3Dark.tsx
@@ -90,7 +90,7 @@ const EFFECTS: Effects = {
 `,
   /** Fade right edge */
   fadeRight:
-    "linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%)",
+    "linear-gradient(to right, rgba(18, 18, 18, 0) 0%, rgba(18, 18, 18, 1) 100%)",
   /** Translucent gray for dialog backdrops */
   backdrop: "rgba(26, 26, 26, 0.5)",
 };

--- a/packages/palette/.storybook/preview.js
+++ b/packages/palette/.storybook/preview.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useState } from "react"
-import { Theme } from "../src/Theme"
+import { THEMES, Theme } from "../src/Theme"
 import { injectGlobalStyles } from "../src/helpers/injectGlobalStyles"
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
 import { breakpoints } from "../src/Theme"
@@ -42,9 +42,9 @@ export const decorators = [
 
     const toggleTheme = useCallback(() => {
       setTheme((prevTheme) => {
-        const newTheme = prevTheme === "light" ? "dark" : "light"
-        setStoredTheme(newTheme)
-        return newTheme
+        const nextTheme = prevTheme === "light" ? "dark" : "light"
+        setStoredTheme(nextTheme)
+        return nextTheme
       })
     }, [])
 
@@ -60,10 +60,31 @@ export const decorators = [
       return () => document.removeEventListener("keydown", handleKeyDown)
     }, [toggleTheme])
 
+    const { colors, space } = THEMES[theme]
+
     return (
       <Theme theme={theme}>
         <StylesProvider
-          styles={{ statePropsActive: { color: "currentColor" } }}
+          styles={{
+            state: {
+              border: `1px dotted ${colors.mono15}`,
+              padding: space[1],
+              marginBottom: space[2],
+            },
+            stateProps: {
+              display: "block",
+              marginTop: space[0.5],
+              paddingTop: space[0.5],
+              fontFamily:
+                "source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace",
+              fontSize: "0.8125rem",
+              color: colors.mono60,
+              borderTop: `1px dotted ${colors.mono15}`,
+            },
+            statePropsActive: {
+              color: "currentColor",
+            },
+          }}
         >
           <GlobalStyles />
 

--- a/packages/palette/.storybook/preview.js
+++ b/packages/palette/.storybook/preview.js
@@ -1,20 +1,74 @@
-import React from "react"
+import React, { useEffect, useCallback, useState } from "react"
 import { Theme } from "../src/Theme"
 import { injectGlobalStyles } from "../src/helpers/injectGlobalStyles"
 import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
 import { breakpoints } from "../src/Theme"
 import { StylesProvider } from "storybook-states"
+import { Clickable } from "@artsy/palette"
 
 const { GlobalStyles } = injectGlobalStyles()
 
+const THEME_STORAGE_KEY = "storybook-theme"
+
+const getStoredTheme = () => {
+  if (typeof window === "undefined") return "light"
+  return localStorage.getItem(THEME_STORAGE_KEY) || "light"
+}
+
+const setStoredTheme = (theme) => {
+  if (typeof window !== "undefined") {
+    localStorage.setItem(THEME_STORAGE_KEY, theme)
+  }
+}
+
+// TODO: Replace with https://storybook.js.org/addons/storybook-dark-mode
+// once we upgrade Storybook
+const ThemeToggle = ({ theme, onToggle }) => (
+  <Clickable
+    onClick={onToggle}
+    position="fixed"
+    bottom={0}
+    right={0}
+    zIndex={1}
+    p={2}
+  >
+    {theme === "light" ? "🌑" : "☀️"}
+  </Clickable>
+)
+
 export const decorators = [
   (Story) => {
+    const [theme, setTheme] = useState(getStoredTheme)
+
+    const toggleTheme = useCallback(() => {
+      setTheme((prevTheme) => {
+        const newTheme = prevTheme === "light" ? "dark" : "light"
+        setStoredTheme(newTheme)
+        return newTheme
+      })
+    }, [])
+
+    useEffect(() => {
+      const handleKeyDown = (event) => {
+        if (event.metaKey && event.key === "i") {
+          event.preventDefault()
+          toggleTheme()
+        }
+      }
+
+      document.addEventListener("keydown", handleKeyDown)
+      return () => document.removeEventListener("keydown", handleKeyDown)
+    }, [toggleTheme])
+
     return (
-      <Theme theme="light">
+      <Theme theme={theme}>
         <StylesProvider
           styles={{ statePropsActive: { color: "currentColor" } }}
         >
           <GlobalStyles />
+
+          <ThemeToggle theme={theme} onToggle={toggleTheme} />
+
           <Story />
         </StylesProvider>
       </Theme>

--- a/packages/palette/src/Theme.tsx
+++ b/packages/palette/src/Theme.tsx
@@ -6,7 +6,7 @@ export * from "@artsy/palette-tokens/dist/themes/v3"
 import { THEME_DARK } from "@artsy/palette-tokens/dist/themes/v3Dark"
 export { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 
-const THEMES = {
+export const THEMES = {
   light: THEME,
   dark: THEME_DARK,
 }
@@ -21,7 +21,10 @@ interface ThemeProps {
 /**
  * A wrapper component for passing down the Artsy theme context
  */
-export const Theme: React.FC<React.PropsWithChildren<ThemeProps>> = ({ children, theme = "light" }) => {
+export const Theme: React.FC<React.PropsWithChildren<ThemeProps>> = ({
+  children,
+  theme = "light",
+}) => {
   const selectedTheme = THEMES[theme]
   return <ThemeProvider theme={selectedTheme}>{children}</ThemeProvider>
 }


### PR DESCRIPTION
Currently noticeable on [the shows page](https://www.artsy.net/shows). Updates the effect to match the background color.

Added a theme toggle to the global Storybook so this sort of thing is easier to debug.