### PR TITLE
fix(dia-1404): dropdown fixes

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.story.tsx
@@ -105,7 +105,7 @@ export const ChangeDimensions = () => {
   }, [])
 
   return (
-    <Dropdown placement="top" dropdown={<Box height={height} width={300} />}>
+    <Dropdown placement="bottom" dropdown={<Box height={height} width={300} />}>
       {({ anchorRef, anchorProps }) => {
         return (
           <Button
@@ -139,7 +139,7 @@ export const FocusOrder = () => {
 
   return (
     <Flex>
-      <Dropdown dropdown={dropdown}>
+      <Dropdown dropdown={dropdown} placement="bottom">
         {({ anchorRef, anchorProps }) => {
           return (
             <Button
@@ -155,7 +155,7 @@ export const FocusOrder = () => {
         }}
       </Dropdown>
 
-      <Dropdown dropdown={dropdown}>
+      <Dropdown dropdown={dropdown} placement="bottom">
         {({ anchorRef, anchorProps }) => {
           return (
             <Button
@@ -315,7 +315,12 @@ export const DisabledTransition = () => {
         )
 
         return (
-          <Dropdown key={num} dropdown={dropdown} transition={false}>
+          <Dropdown
+            key={num}
+            dropdown={dropdown}
+            transition={false}
+            placement="bottom"
+          >
             {({ anchorRef, anchorProps }) => {
               return (
                 <Button

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -57,7 +57,7 @@ export interface DropdownProps extends Omit<BoxProps, "children"> {
  * positioned relative to, another element and designed to be transitioned in on hover or on click.
  */
 export const Dropdown = ({
-  placement = "top",
+  placement = "bottom",
   visible: _visible = false,
   keepInDOM,
   children,

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -194,9 +194,9 @@ export const Dropdown = ({
 
   // Wait for next tick so that animation runs
   useEffect(() => {
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       setTransition(visible)
-    }, 0)
+    })
   }, [visible])
 
   const translation = useMemo(() => {

--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -350,14 +350,16 @@ export const Dropdown = ({
                 enabled={focusEnabled}
                 onClickOutside={onHide}
               >
-                {typeof dropdown === "function"
-                  ? (dropdown as any)({
-                      onVisible,
-                      onHide,
-                      setVisible,
-                      visible,
-                    })
-                  : dropdown}
+                <Pane maxHeight={maxHeight}>
+                  {typeof dropdown === "function"
+                    ? (dropdown as any)({
+                        onVisible,
+                        onHide,
+                        setVisible,
+                        visible,
+                      })
+                    : dropdown}
+                </Pane>
               </FocusOn>
             </Panel>
           </Container>
@@ -375,6 +377,9 @@ const Container = styled(Box)<{ placement: Position } & BoxProps>`
 const Panel = styled(Box)<{ transition: boolean; maxHeight: number }>`
   transition: ${({ transition }) =>
     transition ? "opacity 250ms ease-out, transform 250ms ease-out" : "none"};
+`
+
+const Pane = styled(Box)`
   > div {
     max-height: ${({ maxHeight }) => (maxHeight ? `${maxHeight}px` : "100vh")};
     box-shadow: ${themeGet("effects.flatShadow")};


### PR DESCRIPTION
* sets the default placement to `bottom` — it is a drop*down* after all
* ensures the transition works in all cases
* prevents the `FocusOn` div from getting styled which was causing a small grey box in the top left corner of all dropdowns

cc @artsy/diamond-devs 