### PR TITLE
fix: multiple PhoneInput instances now work together on the same page

### DIFF
--- a/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
@@ -44,7 +44,6 @@ export interface PhoneInputProps extends Omit<InputProps, "onSelect"> {
   required?: boolean
   dropdownValue?: string
   inputValue?: string
-  instanceId?: string
 }
 
 export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
@@ -60,7 +59,6 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
       onSelect,
       dropdownValue,
       inputValue,
-      instanceId,
       ...rest
     },
     forwardedRef
@@ -108,7 +106,7 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
     })
 
     const { anchorRef, tooltipRef } = usePosition({
-      key: `${instanceId || "default"}-${filteredOptions.length}`,
+      key: `default-${filteredOptions.length}`,
       position: "bottom",
       offset: 10,
       active: isDropdownVisible,

--- a/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
@@ -106,7 +106,6 @@ export const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
     })
 
     const { anchorRef, tooltipRef } = usePosition({
-      key: `default-${filteredOptions.length}`,
       position: "bottom",
       offset: 10,
       active: isDropdownVisible,

--- a/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
+++ b/packages/palette/src/elements/PhoneInput/PhoneInput.tsx
@@ -446,7 +446,7 @@ const SelectOption = styled(Box)<{ selected?: boolean; highlighted?: boolean }>`
   align-items: center;
   text-decoration: none;
   color: ${themeGet("colors.mono60")};
-  transition: color 0.25s, text-decoration 0.25s, background-color 0.25s;
+  transition: color 0.25s, text-decoration 0.25s;
 
   &:hover {
     color: ${themeGet("colors.blue100")};


### PR DESCRIPTION
This PR fixes: [EMI-2570](https://artsyproduct.atlassian.net/browse/EMI-2570).

### Description
- Refactors the PhoneInput component to fix multiple instances working together on the same page:
    - Removed `key` prop from usePosition that was causing issues with multiple instances.
    - Replaced useWidthOf hook with direct DOM measurement, which fixed incorrect dropdown sizing and positioning conflicts between multiple instances
- Removed the use-keyboard-list-navigation library usage. The arrow selection was not working and the library was not maintained in years. Implemented instead  custom keyboard navigation.

@artsy/emerald-devs 

[EMI-2570]: https://artsyproduct.atlassian.net/browse/EMI-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ