### PR TITLE
fix: Disable autofocus in Dropdown

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -346,6 +346,7 @@ export const Dropdown = ({
               }
             >
               <FocusOn
+                autoFocus={false}
                 noIsolation
                 enabled={focusEnabled}
                 onClickOutside={onHide}


### PR DESCRIPTION
This PR resolves [EMI-2698]

### Description
This PR disables auto focus from the `react-focus-on`'s FocusOn component inside Dropdown element in Palette
This comes as a fix for the first item being focused (aka underlined) when opening the analytics peroid dropdown 

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/ab265cd1-9ed6-4baf-9c24-e90061d68ad8" /> | <video src="https://github.com/user-attachments/assets/b64884d0-9374-48e9-b7f4-21a31517b073" /> |

