### PR TITLE
fix(EMI-2698): Update Radio focus styling

### DIFF
--- a/packages/palette/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/palette/src/elements/Dropdown/Dropdown.tsx
@@ -346,7 +346,6 @@ export const Dropdown = ({
               }
             >
               <FocusOn
-                autoFocus={false}
                 noIsolation
                 enabled={focusEnabled}
                 onClickOutside={onHide}

--- a/packages/palette/src/elements/Radio/Radio.tsx
+++ b/packages/palette/src/elements/Radio/Radio.tsx
@@ -148,7 +148,7 @@ const Container = styled(Flex)<{
         `}
       }
 
-      &:focus {
+      &:focus-visible {
         ${RADIO_STATES.focus}
 
         // Radio


### PR DESCRIPTION
This PR resolves [EMI-2698]

### Description
This PR updates the radio focus style to be on `:focus-visible` instead of `:focus`
This comes as a fix for the first item being focused (aka underlined) when opening the analytics peroid dropdown 

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/ab265cd1-9ed6-4baf-9c24-e90061d68ad8" /> | <video src="https://github.com/user-attachments/assets/b64884d0-9374-48e9-b7f4-21a31517b073" /> |



[EMI-2698]: https://artsyproduct.atlassian.net/browse/EMI-2698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ