### PR TITLE
feat(filter-select): Add moveSelectedToTop prop

### DIFF
--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
@@ -30,6 +30,7 @@ interface FilterSelectContextProps {
   initialItemsToShow: number
   isFiltered: boolean
   items: Items
+  moveSelectedToTop: boolean
   multiselect: boolean
   onChange: (state: FilterSelectChangeState) => void
   onSelectAll?: (state: FilterSelectChangeState) => void
@@ -51,6 +52,7 @@ export type FilterSelectState = Pick<
   | "initialItemsToShow"
   | "isFiltered"
   | "items"
+  | "moveSelectedToTop"
   | "multiselect"
   | "onChange"
   | "onSelectAll"
@@ -133,6 +135,7 @@ const initialState: FilterSelectState = {
   initialItemsToShow: INITIAL_ITEMS_TO_SHOW,
   isFiltered: false,
   items: [],
+  moveSelectedToTop: true,
   multiselect: true,
   onChange: (x) => x,
   order: [["label"], ["asc"]],

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.story.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.story.tsx
@@ -29,6 +29,13 @@ export const Default = () => {
             return `${item.label}; ${item.country}; ${extraSearchTerms}`
           },
         },
+
+        // checkboxes with move selected to top disabled
+        {
+          multiselect: true,
+          moveSelectedToTop: false,
+          enableSelectAll: true,
+        },
       ]}
     >
       <FilterSelect

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.test.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.test.tsx
@@ -51,6 +51,19 @@ describe("FilterSelect", () => {
     expect(text).toContain("Item 1")
   })
 
+  it("selects items but keeps original order when moveSelectedToTop is false", () => {
+    const wrapper = getWrapper({ moveSelectedToTop: false })
+    wrapper.find("Checkbox").at(1).simulate("click")
+    wrapper.find("Checkbox").at(2).simulate("click")
+    wrapper.update()
+
+    const text = wrapper.text()
+    // Items should remain in original order
+    expect(text).toContain("Item 1")
+    expect(text).toContain("Item 2")
+    expect(text).toContain("Item 3")
+  })
+
   it("resorts items when deselected", () => {
     const wrapper = getWrapper()
     wrapper.find("Checkbox").at(1).simulate("click")
@@ -72,7 +85,7 @@ describe("FilterSelect", () => {
     expect(text).toContain("Item 3")
   })
 
-  it("only selects one item if multiselect=false, and doesnt resort", () => {
+  it("only selects one item if multiselect=false, and doesn't resort", () => {
     const wrapper = getWrapper({ multiselect: false })
     wrapper.find("Radio").at(1).simulate("click")
     wrapper.update()

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -37,6 +37,7 @@ const _FilterSelect: React.FC<React.PropsWithChildren<unknown>> = () => {
     initialItemsToShow,
     isFiltered,
     items,
+    moveSelectedToTop,
     multiselect,
     onChange,
     order,
@@ -70,10 +71,11 @@ const _FilterSelect: React.FC<React.PropsWithChildren<unknown>> = () => {
   const orderItems = (items: Items) => orderBy([...items], order[0], order[1])
   const itemsOrdered = orderItems(items)
   const filteredItemsOrdered = orderItems(filteredItems)
-  const itemsSorted = multiselect
-    ? // Move selected items to the top
-      uniqBy(selectedItems.concat(itemsOrdered), (x) => x.value)
-    : itemsOrdered
+  const itemsSorted =
+    multiselect && moveSelectedToTop
+      ? // Move selected items to the top
+        uniqBy(selectedItems.concat(itemsOrdered), (x) => x.value)
+      : itemsOrdered
   const expanded = isBelowTheFoldSelected(selectedItems, itemsSorted)
   const showNoResults = filteredItems.length === 0 && query !== ""
   const showSelectAll = multiselect && enableSelectAll && !showNoResults


### PR DESCRIPTION
There's a use case in CMS where this auto move behavior is confusing (within long scrolling content where top is out of window), so adding a prop to disable.