### PR TITLE
feat(tokens): alias for half value

### DIFF
--- a/packages/palette-tokens/src/themes/v3.tsx
+++ b/packages/palette-tokens/src/themes/v3.tsx
@@ -164,6 +164,7 @@ export const THEME = {
     // unit: px value
     /** Equivalent to 5px  */
     0.5: "5px",
+    half: "5px", // alias for 0.5 that makes it easier to access
     /** Equivalent to 10px  */
     1: "10px",
     /** Equivalent to 20px  */


### PR DESCRIPTION
`themeGet` doesn't work for this key. So, rather than having to do:

```
${({ theme }) => theme.space["0.5"]};
```

Let's just alias the value here.

cc @artsy/diamond-devs 