### PR TITLE
chore(select-input): Address feedback

### DIFF
--- a/packages/palette/src/elements/SelectInput/SelectInput.story.tsx
+++ b/packages/palette/src/elements/SelectInput/SelectInput.story.tsx
@@ -215,7 +215,7 @@ export const Default = () => {
         { placeholder: "(000) 000 0000", label: undefined },
         { placeholder: "(000) 000 0000", required: true },
         { placeholder: "(000) 000 0000", disabled: true },
-        { placeholder: "(000) 000 0000", selectWidth: 100 },
+        { placeholder: "(000) 000 0000", selectProps: { width: 100 } },
         { placeholder: "(000) 000 0000", optionTextMinWidth: "20ch" },
         { placeholder: "(000) 000 0000", error: "Something is wrong" },
       ]}
@@ -275,7 +275,7 @@ export const CurrencySelect = () => {
         options={currencyOptions}
         onSelect={(option) => console.log(option)}
         label="Currency"
-        selectWidth={70}
+        selectProps={{ width: 70 }}
         optionTextMinWidth="5ch"
       />
     </States>

--- a/packages/palette/src/elements/SelectInput/SelectInput.tsx
+++ b/packages/palette/src/elements/SelectInput/SelectInput.tsx
@@ -26,8 +26,8 @@ export interface SelectInputProps extends Omit<InputProps, "onSelect"> {
   onSelect: (option: Option) => void
   options: Option[]
   required?: boolean
-  /** Controls the width of the left hand select dropdown UI */
-  selectWidth?: ClickableProps["width"]
+  /** Props passed to the left hand select dropdown UI */
+  selectProps?: ClickableProps
   /** Controls the gap between the text and name labels in select options */
   optionTextMinWidth?: TextProps["minWidth"]
 }
@@ -47,8 +47,9 @@ export const SelectInput = React.forwardRef<HTMLInputElement, SelectInputProps>(
       onSelect,
       options,
       required,
-      selectWidth,
       optionTextMinWidth,
+      selectProps,
+
       ...rest
     },
     forwardedRef
@@ -129,12 +130,12 @@ export const SelectInput = React.forwardRef<HTMLInputElement, SelectInputProps>(
           placeholder={inputProps.placeholder}
         >
           <SelectInputSelect
-            data-testid="country-picker"
+            data-testid="select-picker"
             disabled={disabled}
             onClick={() => {
               setOpen(!disabled && !open)
             }}
-            width={selectWidth}
+            {...selectProps}
           >
             {selectedOption.text}
           </SelectInputSelect>

--- a/packages/palette/src/elements/SelectInput/__tests__/SelectInput.test.tsx
+++ b/packages/palette/src/elements/SelectInput/__tests__/SelectInput.test.tsx
@@ -106,7 +106,7 @@ describe("SelectInput", () => {
       />
     )
 
-    wrapper.find('[data-testid="country-picker"]').first().simulate("click")
+    wrapper.find('[data-testid="select-picker"]').first().simulate("click")
 
     expect(wrapper.html().match(/role="option"/g)?.length).toEqual(
       countriesExample.length
@@ -123,7 +123,7 @@ describe("SelectInput", () => {
       />
     )
 
-    wrapper.find('[data-testid="country-picker"]').first().simulate("click")
+    wrapper.find('[data-testid="select-picker"]').first().simulate("click")
 
     wrapper
       .find("input[placeholder='Search']")
@@ -154,7 +154,7 @@ describe("SelectInput", () => {
     // pre-selected country (first on the list)
     expect(wrapper.text()).toContain("🇦🇱 +355")
 
-    wrapper.find('[data-testid="country-picker"]').first().simulate("click")
+    wrapper.find('[data-testid="select-picker"]').first().simulate("click")
 
     wrapper
       .find("input[placeholder='Search']")
@@ -183,7 +183,7 @@ describe("SelectInput", () => {
       />
     )
 
-    wrapper.find('[data-testid="country-picker"]').first().simulate("click")
+    wrapper.find('[data-testid="select-picker"]').first().simulate("click")
 
     expect(wrapper.find("input[placeholder='Search']").length).toEqual(1)
   })
@@ -198,7 +198,7 @@ describe("SelectInput", () => {
       />
     )
 
-    wrapper.find('[data-testid="country-picker"]').first().simulate("click")
+    wrapper.find('[data-testid="select-picker"]').first().simulate("click")
 
     expect(wrapper.find("input[placeholder='Search']").length).toEqual(0)
   })
@@ -213,7 +213,7 @@ describe("SelectInput", () => {
       />
     )
 
-    wrapper.find('[data-testid="country-picker"]').first().simulate("click")
+    wrapper.find('[data-testid="select-picker"]').first().simulate("click")
 
     expect(wrapper.find("input[placeholder='Search']").length).toEqual(1)
   })


### PR DESCRIPTION
Addresses feedback from https://github.com/artsy/palette/pull/1466. TLDR: 
- selectWidth -> selectProps, where we can pass props to underlying select component 