### PR TITLE
fix(autocomplete): better handles focusing when using a pointer device

### DIFF
--- a/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx
@@ -244,8 +244,23 @@ export const AutocompleteInput = <T extends AutocompleteInputOptionType>({
 
   // Moves focus to different options when keyboard navigating using up/down
   useEffect(() => {
-    const option = optionsWithRefs[index]
-    option?.ref?.current?.focus()
+    const el = optionsWithRefs[index]?.ref?.current
+    if (!el) return
+
+    const isPointerInteraction =
+      performance.now() - lastMouseMoveTimestamp.current < 50
+
+    if (isPointerInteraction) {
+      // Pointer interactions should not cause scroll
+      el.focus({ preventScroll: true })
+      return
+    }
+
+    // Keyboard navigation: focus and ensure visibility
+    el.focus({ preventScroll: true })
+    try {
+      el.scrollIntoView({ block: "nearest" })
+    } catch {}
   }, [index, optionsWithRefs])
 
   const handleFocusChange = useCallback(


### PR DESCRIPTION
Here we make the distinction that pointer interactions should not automatically scroll the results, whereas keyboard innteractions do.

https://github.com/user-attachments/assets/0a44baa1-a16f-4feb-914b-389103f7a852

