### PR TITLE
feat(MultiSelect): Add controlled selection behavior

### DIFF
--- a/packages/palette/src/elements/MultiSelect/MultiSelect.story.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.story.tsx
@@ -34,11 +34,7 @@ export const Default = () => {
         },
       ]}
     >
-      <MultiSelect
-        name="Medium"
-        options={OPTIONS}
-        onSelect={fn()}
-      />
+      <MultiSelect name="Medium" options={OPTIONS} onSelect={fn()} />
     </States>
   )
 }
@@ -59,6 +55,38 @@ export const Example = () => {
         onSelect={(sizes) => {
           setFilter({ sizes: sizes.map((size) => size.value) })
         }}
+      />
+    </>
+  )
+}
+
+export const CustomSelectionLogic = () => {
+  const [selectedValue, setSelectedValue] = React.useState<string[]>([])
+
+  const handleSelect = (selection) => {
+    // If a new option is selected, only keep the most recently selected one
+    if (selection.length > selectedValue.length) {
+      const newlySelected = selection[selection.length - 1]
+      setSelectedValue([newlySelected.value])
+    } else {
+      // If an option was deselected, clear the selection
+      setSelectedValue([])
+    }
+  }
+
+  return (
+    <>
+      <p>
+        This MultiSelect behaves like a single select - selecting a new option
+        deselects all others.
+      </p>
+      <pre>Selected: {JSON.stringify(selectedValue)}</pre>
+
+      <MultiSelect
+        options={OPTIONS}
+        name="Select one medium"
+        selected={selectedValue}
+        onSelect={handleSelect}
       />
     </>
   )

--- a/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
+++ b/packages/palette/src/elements/MultiSelect/MultiSelect.tsx
@@ -23,7 +23,7 @@ export interface MultiSelectProps extends BoxProps {
   error?: string | boolean
   focus?: boolean
   hover?: boolean
-  /** Initial values to be selected */
+  /** Selected values (updating the list will refresh the internal selection and re-render the component) */
   selected?: Option["value"][]
   name?: string
   options: Option[]
@@ -61,6 +61,11 @@ export const MultiSelect: React.FC<
 
   const [visible, setVisible] = useState(autoOpen)
   const [selection, setSelection] = useState<Option[]>(selectedOptions || [])
+
+  useEffect(() => {
+    const newSelectedOptions = valuesToOptions(selected, options)
+    setSelection(newSelectedOptions)
+  }, [selected.toString()])
 
   // Yields focus back and forth between popover and anchor
   useUpdateEffect(() => {


### PR DESCRIPTION
## Description

This change makes the `MultiSelect` component controlled by synchronizing its internal state with the `selected` prop changes.

The motivation is to enable custom selection behavior for the Signature multi-select dropdown in the CMS. We want to deselect all other options whenever "Not Signed" is selected.

Palette's MultiSelect is only used for Batch Edits & Batch Imports in CMS and https://www.artsy.net/price-database ([GitHub search](https://github.com/search?q=org%3Aartsy+%3CMultiSelect&type=code)). I've tested these places and everything works as expected.


**Signature Multi-Select Dropdown:**

<img width="345" height="417" alt="Bildschirmfoto 2025-08-25 um 10 54 42" src="https://github.com/user-attachments/assets/729a306e-7266-44a3-89ef-b65e3c1665be" />
