### PR TITLE
feat(DIAM-105): add screen reader only text to ReadMore

### DIFF
--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -240,3 +240,31 @@ export const WithBottomReadMore = {
     },
   },
 }
+
+export const SimpleLineClamp = {
+  args: {
+    maxLines: 3,
+    content: `<p>
+      Donald Judd, widely regarded as one of the most significant American
+      artists of <a href="#">the post-war period</a>, is perhaps best-known
+      for the large-scale outdoor installations and long, spacious interiors
+      he designed in Marfa. Donald Judd, widely regarded as one of the most
+      significant American artists of the post-war period, is perhaps
+      best-known for the large-scale outdoor installations and long,
+      spacious interiors he designed in Marfa.
+    </p>
+    <p>
+      <strong>Lorem ipsum dolor</strong> sit amet consectetur adipisicing
+      elit. Ducimus eligendi obcaecati voluptate
+      <em>molestias vero nobis voluptatum</em>, tenetur dolorum assumenda.
+    </p>`,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Simple CSS line-clamp that shows ellipses (...) after specified lines. Full content remains in DOM for SEO/accessibility.",
+      },
+    },
+  },
+}
+

--- a/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.story.tsx
@@ -16,8 +16,8 @@ export default {
       },
     },
     controls: {
-        exclude: STORYBOOK_PROPS_BLOCKLIST,
-      },
+      exclude: STORYBOOK_PROPS_BLOCKLIST,
+    },
   },
 }
 

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -30,10 +30,8 @@ export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
   if (typeof expandedHTML !== "string") return null
 
   const charCount = expandedHTML.replace(HTML_TAG_REGEX, "").length
-
   const truncatedHTML = truncate(expandedHTML, maxChars).html
-
-  const visible = charCount > maxChars
+  const shouldShowToggle = charCount > maxChars
 
   const handleClick = () => {
     if (disabled) return
@@ -44,7 +42,8 @@ export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
       : onReadMoreClicked && onReadMoreClicked()
   }
 
-  if (!visible) {
+  // If content doesn't need truncation, render normally
+  if (!shouldShowToggle) {
     return (
       <span
         dangerouslySetInnerHTML={{
@@ -56,6 +55,11 @@ export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
 
   return (
     <Container aria-expanded={expanded}>
+      {/* Add sr-only full content only when collapsed for SEO/accessibility */}
+      {!expanded && shouldShowToggle && (
+        <span className="sr-only" dangerouslySetInnerHTML={{ __html: expandedHTML }} />
+      )}
+      
       {expanded ? (
         <>
           <Box dangerouslySetInnerHTML={{ __html: expandedHTML }} />
@@ -97,6 +101,19 @@ export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
 const Container = styled.div`
   > * > span > *:last-child {
     display: inherit;
+  }
+  
+  /* Screen reader only content - accessible to screen readers and crawlers */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 `
 

--- a/packages/palette/src/elements/ReadMore/ReadMore.tsx
+++ b/packages/palette/src/elements/ReadMore/ReadMore.tsx
@@ -4,6 +4,7 @@ import truncate from "trunc-html"
 import { Clickable } from "../Clickable"
 import { Text } from "../Text"
 import { Box } from "../Box"
+import { VisuallyHidden } from "../VisuallyHidden"
 
 export interface ReadMoreProps {
   content: string
@@ -55,11 +56,10 @@ export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
 
   return (
     <Container aria-expanded={expanded}>
-      {/* Add sr-only full content only when collapsed for SEO/accessibility */}
       {!expanded && shouldShowToggle && (
-        <span className="sr-only" dangerouslySetInnerHTML={{ __html: expandedHTML }} />
+        <VisuallyHidden dangerouslySetInnerHTML={{ __html: expandedHTML }} />
       )}
-      
+
       {expanded ? (
         <>
           <Box dangerouslySetInnerHTML={{ __html: expandedHTML }} />
@@ -101,19 +101,6 @@ export const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
 const Container = styled.div`
   > * > span > *:last-child {
     display: inherit;
-  }
-  
-  /* Screen reader only content - accessible to screen readers and crawlers */
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
   }
 `
 

--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -34,6 +34,7 @@ describe("ReadMore", () => {
   it("Auto expands text that is less than max char count", () => {
     const wrapper = mount(<ReadMore maxChars={100} content={htmlCopy} />)
     expect(wrapper.find("button").length).toEqual(0)
+    expect(wrapper.find(".sr-only")).toHaveLength(0)
   })
 
   it("changes the button text on click", () => {
@@ -60,5 +61,29 @@ describe("ReadMore", () => {
     expect(callback).not.toBeCalled()
     wrapper.find("button").simulate("click")
     expect(callback).toBeCalled()
+  })
+
+  it("includes full content for screen readers when collapsed", () => {
+    const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
+    expect(wrapper.find(".sr-only")).toHaveLength(1)
+    const srOnlyContent = wrapper.find(".sr-only").html()
+    expect(srOnlyContent).toContain(copy)
+  })
+
+  it("removes sr-only content when expanded", () => {
+    const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
+    expect(wrapper.find(".sr-only")).toHaveLength(1)
+    wrapper.find("button").simulate("click")
+    expect(wrapper.find(".sr-only")).toHaveLength(0)
+  })
+
+  it("has proper ARIA attributes on container", () => {
+    const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
+    const container = wrapper.find("[aria-expanded]").first()
+    expect(container.prop("aria-expanded")).toBe(false)
+    wrapper.find("button").simulate("click")
+    expect(wrapper.find("[aria-expanded]").first().prop("aria-expanded")).toBe(
+      true
+    )
   })
 })

--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -63,19 +63,6 @@ describe("ReadMore", () => {
     expect(callback).toBeCalled()
   })
 
-  it("includes full content for screen readers when collapsed", () => {
-    const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
-    expect(wrapper.find("VisuallyHidden")).toHaveLength(1)
-    const hiddenContent = wrapper.find("VisuallyHidden").html()
-    expect(hiddenContent).toContain(copy)
-  })
-
-  it("removes visually hidden content when expanded", () => {
-    const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
-    expect(wrapper.find("VisuallyHidden")).toHaveLength(1)
-    wrapper.find("button").simulate("click")
-    expect(wrapper.find("VisuallyHidden")).toHaveLength(0)
-  })
 
   it("has proper ARIA attributes on container", () => {
     const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
@@ -86,4 +73,5 @@ describe("ReadMore", () => {
       true
     )
   })
+
 })

--- a/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
+++ b/packages/palette/src/elements/ReadMore/__tests__/ReadMore.test.tsx
@@ -34,7 +34,7 @@ describe("ReadMore", () => {
   it("Auto expands text that is less than max char count", () => {
     const wrapper = mount(<ReadMore maxChars={100} content={htmlCopy} />)
     expect(wrapper.find("button").length).toEqual(0)
-    expect(wrapper.find(".sr-only")).toHaveLength(0)
+    expect(wrapper.find("VisuallyHidden")).toHaveLength(0)
   })
 
   it("changes the button text on click", () => {
@@ -65,16 +65,16 @@ describe("ReadMore", () => {
 
   it("includes full content for screen readers when collapsed", () => {
     const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
-    expect(wrapper.find(".sr-only")).toHaveLength(1)
-    const srOnlyContent = wrapper.find(".sr-only").html()
-    expect(srOnlyContent).toContain(copy)
+    expect(wrapper.find("VisuallyHidden")).toHaveLength(1)
+    const hiddenContent = wrapper.find("VisuallyHidden").html()
+    expect(hiddenContent).toContain(copy)
   })
 
-  it("removes sr-only content when expanded", () => {
+  it("removes visually hidden content when expanded", () => {
     const wrapper = mount(<ReadMore maxChars={20} content={copy} />)
-    expect(wrapper.find(".sr-only")).toHaveLength(1)
+    expect(wrapper.find("VisuallyHidden")).toHaveLength(1)
     wrapper.find("button").simulate("click")
-    expect(wrapper.find(".sr-only")).toHaveLength(0)
+    expect(wrapper.find("VisuallyHidden")).toHaveLength(0)
   })
 
   it("has proper ARIA attributes on container", () => {


### PR DESCRIPTION
This PR uses the `line-clamp` CSS property to visually hide content in the `ReadMore` component while keeping the full content in the DOM for crawlers and screen readers.

| Description | Screenshot |
|-|-|
| max 3 lines collapsed | <img width="783" height="157" alt="Screenshot 2025-09-23 at 12 01 43 PM" src="https://github.com/user-attachments/assets/79a42695-dd51-4826-8372-d3b9750e4d87" /> |
| max 3 lines expanded | <img width="778" height="318" alt="Screenshot 2025-09-23 at 12 01 52 PM" src="https://github.com/user-attachments/assets/09d5648f-7d83-4a4b-bd1b-399644cd686f" /> |
| max line is doesn't fill | <img width="781" height="214" alt="Screenshot 2025-09-23 at 12 02 17 PM" src="https://github.com/user-attachments/assets/fd83eb2d-a3aa-4948-afb0-178df73858a1" /> |
| max line is greater | <img width="782" height="265" alt="Screenshot 2025-09-23 at 12 02 36 PM" src="https://github.com/user-attachments/assets/e0bcc548-8066-414b-9bc0-3d9e8f260fa1" /> |

- Notice the `...` when the **max line doesn't fill** the width of the screen.
- Notice the "Read more" link is visible when the **max line is greater** than (or equal to) the total number of lines.

cc: @artsy/diamond-devs 