### PR TITLE
fix(filterselect): handle nullish entries in selecteditems

### DIFF
--- a/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
+++ b/packages/palette/src/elements/FilterSelect/Components/FilterSelectContext.tsx
@@ -157,6 +157,7 @@ export const FilterSelectContextProvider: React.FC<
 
   const contextValue = {
     ...state,
+    selectedItems: state.selectedItems.filter(Boolean),
 
     toggleSelectedItem: (item) => {
       dispatch({

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.test.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.test.tsx
@@ -240,7 +240,10 @@ describe("FilterSelect", () => {
     expect(text).not.toContain("Item 2")
     expect(text).not.toContain("Item 3")
 
-    wrapper.findWhere(n => n.text() === "Show more" && n.type() === "button").first().simulate("click")
+    wrapper
+      .findWhere((n) => n.text() === "Show more" && n.type() === "button")
+      .first()
+      .simulate("click")
     wrapper.update()
 
     text = wrapper.text()
@@ -259,6 +262,18 @@ describe("FilterSelect", () => {
     })
 
     expect(wrapper.text()).toContain("NameHello1")
+  })
+
+  it("handles nullish entries in selectedItems without crashing", () => {
+    const wrapper = getWrapper({
+      selectedItems: [
+        { label: "Item 1", value: "item-1" },
+        undefined,
+        null,
+      ] as any,
+    })
+
+    expect(wrapper.find("Checkbox").length).toBeGreaterThan(0)
   })
 
   it("dispatches state on change", () => {

--- a/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
+++ b/packages/palette/src/elements/FilterSelect/FilterSelect.tsx
@@ -120,7 +120,7 @@ const _FilterSelect: React.FC<React.PropsWithChildren<unknown>> = () => {
 }
 
 export const isBelowTheFoldSelected = (selectedItems, resultsSorted) => {
-  const selected = selectedItems.map(({ value }) => value)
+  const selected = selectedItems.filter(Boolean).map(({ value }) => value)
   const results = resultsSorted
     .slice(INITIAL_ITEMS_TO_SHOW)
     .map(({ value }) => value)


### PR DESCRIPTION
We can see this in production in some instances. I'm not sure how you can into this state naturally; as the filter aggregations should just not show up. But URLs accessed directly can reproduce it. (Currently: https://www.artsy.net/collect?location_cities%5B0%5D=Tel%20Aviv-Yafo%2C%20Israel&acquireable=true&offerable=true)

cc @artsy/diamond-devs 