### PR TITLE
fix(shelf): prevents content shift on ssr shelf instances

### DIFF
--- a/packages/palette/src/elements/FullBleed/FullBleed.test.tsx
+++ b/packages/palette/src/elements/FullBleed/FullBleed.test.tsx
@@ -1,0 +1,30 @@
+import { mount } from "enzyme"
+import "jest-styled-components"
+import React from "react"
+import { FullBleed } from "./FullBleed"
+
+describe("FullBleed", () => {
+  it("breaks out of its parent container by default", () => {
+    const wrapper = mount(<FullBleed>content</FullBleed>)
+    const node = wrapper.find("div").last()
+
+    expect(node).toHaveStyleRule("width", "100vw")
+    expect(node).toHaveStyleRule("margin-left", "-50vw")
+    expect(node).toHaveStyleRule("left", "50%")
+  })
+
+  it("does not bleed when `enabled` is false", () => {
+    const wrapper = mount(<FullBleed enabled={false}>content</FullBleed>)
+    const node = wrapper.find("div").last()
+
+    expect(node).not.toHaveStyleRule("width", "100vw")
+    expect(node).not.toHaveStyleRule("margin-left", "-50vw")
+    expect(node).not.toHaveStyleRule("left", "50%")
+  })
+
+  it("does not forward `enabled` to the DOM", () => {
+    const wrapper = mount(<FullBleed enabled={false}>content</FullBleed>)
+
+    expect(wrapper.find("div").last().prop("enabled")).toBeUndefined()
+  })
+})

--- a/packages/palette/src/elements/FullBleed/FullBleed.tsx
+++ b/packages/palette/src/elements/FullBleed/FullBleed.tsx
@@ -2,17 +2,34 @@ import styled from "styled-components"
 import { Box, BoxProps } from "../Box"
 
 /** FullBleedProps */
-export type FullBleedProps = BoxProps
+export type FullBleedProps = BoxProps & {
+  /**
+   * Whether to break out of the parent container. Defaults to `true`.
+   *
+   * Set to `false` for SSR / pre-measurement renders where the bleed offset
+   * isn't known yet — keeping content aligned to the parent container avoids a
+   * content shift once the client mounts and the bleed is enabled.
+   */
+  enabled?: boolean
+}
 
 /**
  * Utility to break out of parent containers
  */
-export const FullBleed = styled(Box).attrs<FullBleedProps>((props) => ({
-  position: props.position ?? "relative",
-  left: props.left ?? "50%",
-  right: props.right ?? "50%",
-  width: props.width ?? "100vw",
-  maxWidth: props.maxWidth ?? "100vw",
-  marginLeft: props.marginLeft ?? "-50vw",
-  marginRight: props.marginRight ?? "-50vw",
-}))<FullBleedProps>``
+export const FullBleed = styled(Box).attrs<FullBleedProps>((props) =>
+  props.enabled === false
+    ? {}
+    : {
+        position: props.position ?? "relative",
+        left: props.left ?? "50%",
+        right: props.right ?? "50%",
+        width: props.width ?? "100vw",
+        maxWidth: props.maxWidth ?? "100vw",
+        marginLeft: props.marginLeft ?? "-50vw",
+        marginRight: props.marginRight ?? "-50vw",
+      }
+).withConfig({
+  // `enabled` is a config prop, not a style/DOM attribute — keep it off the
+  // rendered element.
+  shouldForwardProp: (prop) => prop !== "enabled",
+})``

--- a/packages/palette/src/elements/Shelf/Shelf.story.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.story.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react"
+import { renderToString } from "react-dom/server"
+import { ServerStyleSheet } from "styled-components"
 import { Box } from "../Box"
 import { Text } from "../Text"
 import { Shelf } from "./Shelf"
@@ -216,6 +218,58 @@ export const NavigationHoverFocus = {
     docs: {
       description: {
         story: "Navigation button with both hover and focus states.",
+      },
+    },
+  },
+}
+
+export const ServerSideRender = {
+  render: () => {
+    // Render the Shelf to a static HTML string exactly as a server would,
+    // collecting the styled-components CSS alongside it. Because effects never
+    // run during `renderToString`, `mounted` stays `false` — so this captures
+    // the real pre-hydration first paint. We inject it via `dangerouslySetInnerHTML`
+    // and never hydrate it, freezing the SSR layout so it can be inspected.
+    //
+    // After the FullBleed fix, the cells line up with the page margin (matching
+    // the hydrated client render). Before the fix, the un-bled markup leaked to
+    // the screen edge and the content visibly shifted once the client mounted.
+    const sheet = new ServerStyleSheet()
+
+    let html = ""
+
+    try {
+      const markup = renderToString(
+        sheet.collectStyles(
+          <Box maxWidth={1920} mx="auto">
+            <Box mx={[2, 4]}>
+              <Demo amount={10} />
+            </Box>
+          </Box>
+        )
+      )
+
+      html = sheet.getStyleTags() + markup
+    } finally {
+      sheet.seal()
+    }
+
+    return (
+      <Box>
+        <Text variant="sm-display" mb={2}>
+          Frozen server-rendered markup (never hydrated). Cells should align with
+          the page margin, not the screen edge.
+        </Text>
+
+        <Box dangerouslySetInnerHTML={{ __html: html }} />
+      </Box>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Simulates the server-side render by rendering the Shelf to a static HTML string (with collected styles) and injecting it without hydrating. This exposes the pre-mount layout a real SSR consumer sees on first paint, guarding against content-shift regressions.",
       },
     },
   },

--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -187,26 +187,15 @@ export const Shelf: React.FC<React.PropsWithChildren<ShelfProps>> = ({
       </Nav>
 
       <FullBleed
-        // To prevent any page jank we initially partially disable this component
-        // so that content is left aligned with the parent container and then once
-        // we have the offset and page values; we reset it to actually full-bleed.
-        // The `offset` will push the content up to the parent margin.
+        // To prevent any page jank we initially disable the bleed so that content
+        // is left aligned with the parent container, and then once we have the
+        // offset and page values we enable it to actually full-bleed. The `offset`
+        // will push the content up to the parent margin.
         //
-        // Note: we pass explicit reset values (not `null`) because FullBleed's
-        // `attrs` coalesce nullish props back to their full-bleed defaults
-        // (`props.left ?? "50%"` etc.), so `null` would be a no-op and the
-        // server-rendered markup would bleed to the screen edge — causing a
-        // content shift once the client mounts.
-        {...(!mounted
-          ? {
-              left: 0,
-              right: 0,
-              width: "100%",
-              maxWidth: "100%",
-              marginLeft: 0,
-              marginRight: 0,
-            }
-          : {})}
+        // This matters most on SSR: the server renders the un-mounted state, so
+        // disabling the bleed here keeps content aligned to the parent margin and
+        // avoids a content shift once the client mounts.
+        enabled={mounted}
       >
         <Viewport ref={viewportRef as any}>
           <Rail as="ul" position="relative" alignItems={alignItems} mb={[2, 6]}>

--- a/packages/palette/src/elements/Shelf/Shelf.tsx
+++ b/packages/palette/src/elements/Shelf/Shelf.tsx
@@ -191,7 +191,22 @@ export const Shelf: React.FC<React.PropsWithChildren<ShelfProps>> = ({
         // so that content is left aligned with the parent container and then once
         // we have the offset and page values; we reset it to actually full-bleed.
         // The `offset` will push the content up to the parent margin.
-        {...(!mounted ? { left: null, right: null, marginLeft: null } : {})}
+        //
+        // Note: we pass explicit reset values (not `null`) because FullBleed's
+        // `attrs` coalesce nullish props back to their full-bleed defaults
+        // (`props.left ?? "50%"` etc.), so `null` would be a no-op and the
+        // server-rendered markup would bleed to the screen edge — causing a
+        // content shift once the client mounts.
+        {...(!mounted
+          ? {
+              left: 0,
+              right: 0,
+              width: "100%",
+              maxWidth: "100%",
+              marginLeft: 0,
+              marginRight: 0,
+            }
+          : {})}
       >
         <Viewport ref={viewportRef as any}>
           <Rail as="ul" position="relative" alignItems={alignItems} mb={[2, 6]}>


### PR DESCRIPTION
I noticed on /artists that, on server-side render, the `Shelf` renders the cells flush with the left edge of the screen, then, on mount, shifts them over to the page margin where they belong.

https://github.com/user-attachments/assets/25f16ac7-29dd-4231-a9ee-e87951a19b85

This actually is happening on *all* instances of `Shelf`.

Previously, there was a piece of code in place to prevent this:

```tsx
// To prevent any page jank we initially partially disable this component
// so that content is left aligned with the parent container and then once
// we have the offset and page values; we reset it to actually full-bleed.
// The `offset` will push the content up to the parent margin.
{...(!mounted ? { left: null, right: null, marginLeft: null } : {})}
```

This just neutralized the behavior of `FullBleed` then re-enabled it once we mount and have the positions for everything.

[#1503](https://github.com/artsy/palette/issues/1503) migrated `FullBleed` from `defaultProps` to styled-components attrs with nullish coalescing. Unlike `defaultProps` (which only defaults on `undefined`), `??` coalesces null back to the full-bleed default.

So, this PR adds a way to disable the `FullBleed` component correctly, rather than having to just re-style it from the outside.

cc @artsy/diamond-devs 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-charts@45.9.3-canary.1518.33548.0
  npm install @artsy/palette@46.9.3-canary.1518.33548.0
  # or 
  yarn add @artsy/palette-charts@45.9.3-canary.1518.33548.0
  yarn add @artsy/palette@46.9.3-canary.1518.33548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
